### PR TITLE
Improve live stream latency and chat emote UX

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1208,6 +1208,14 @@ fn render_stream_page(
   let controlsTimeout = null;
   let liveStatusRefreshTimer = null;
   const CONTROLS_HIDE_DELAY_MS = 2000;
+  const AUTO_LIVE_SEEK_LAG_SECS = 6;
+  const AUTO_LIVE_TARGET_OFFSET_SECS = 2;
+  const AUTO_LIVE_SEEK_CONSECUTIVE_CHECKS = 2;
+  const AUTO_LIVE_SEEK_COOLDOWN_MS = 12000;
+  const AUTO_LIVE_CHECK_INTERVAL_MS = 2000;
+  const MANUAL_SEEK_SUPPRESS_MS = 30000;
+  const LIVE_BUTTON_ENTER_LIVE_SECS = 4.2;
+  const LIVE_BUTTON_EXIT_LIVE_SECS = 5.2;
   let currentPlayingLevelIdx = -1;
   let userSelectedAuto = true;
   let attemptedRelayFallback = new URLSearchParams(window.location.search).get('relay') === '1';
@@ -1218,6 +1226,11 @@ fn render_stream_page(
   let emoteSuggestionsOpen = false;
   let emoteSuggestionIndex = 0;
   let emoteSuggestionItems = [];
+  let liveLagHighStreak = 0;
+  let lastAutoLiveCheckAtMs = 0;
+  let lastAutoLiveSeekAtMs = 0;
+  let manualSeekSuppressUntilMs = 0;
+  let liveButtonIsLive = true;
   
   const debugOverlay = document.createElement('div');
   debugOverlay.style.cssText = 'position:fixed;top:50px;left:10px;background:rgba(0,0,0,0.9);color:#0f0;padding:10px;font-family:monospace;font-size:11px;z-index:99999;display:none;max-width:350px;border-radius:4px;';
@@ -1364,6 +1377,7 @@ fn render_stream_page(
     var timeline = getTimelineModel();
     updateTimelineInteractivity(timeline);
     updateGoLiveButton(timeline);
+    maybeAutoCatchUpLive(timeline);
     currentTimeEl.textContent = formatTime(video.currentTime);
     if (timeline.mode === 'vod') {{
       durationEl.textContent = formatTime(timeline.end);
@@ -1432,6 +1446,8 @@ fn render_stream_page(
       video.currentTime = percent * timeline.length;
     }} else {{
       video.currentTime = timeline.start + (percent * timeline.length);
+      manualSeekSuppressUntilMs = Date.now() + MANUAL_SEEK_SUPPRESS_MS;
+      liveLagHighStreak = 0;
     }}
   }}
 
@@ -1445,22 +1461,71 @@ fn render_stream_page(
 
   function updateGoLiveButton(timeline) {{
     if (!timeline.seekable) {{
+      liveButtonIsLive = true;
       goLiveBtn.textContent = 'Live';
       goLiveBtn.classList.add('live');
       goLiveBtn.disabled = true;
       return;
     }}
+
     var lag = Math.max(0, timeline.end - video.currentTime);
-    var atLiveEdge = lag < 3;
-    goLiveBtn.textContent = atLiveEdge ? 'Live' : 'Go Live';
-    goLiveBtn.classList.toggle('live', atLiveEdge);
-    goLiveBtn.disabled = atLiveEdge;
+    if (liveButtonIsLive) {{
+      if (lag > LIVE_BUTTON_EXIT_LIVE_SECS) {{
+        liveButtonIsLive = false;
+      }}
+    }} else if (lag < LIVE_BUTTON_ENTER_LIVE_SECS) {{
+      liveButtonIsLive = true;
+    }}
+
+    goLiveBtn.textContent = liveButtonIsLive ? 'Live' : 'Go Live';
+    goLiveBtn.classList.toggle('live', liveButtonIsLive);
+    goLiveBtn.disabled = liveButtonIsLive;
+  }}
+
+  function maybeAutoCatchUpLive(timeline) {{
+    if (!timeline || !timeline.seekable || timeline.mode === 'vod' || document.visibilityState !== 'visible') {{
+      liveLagHighStreak = 0;
+      return;
+    }}
+
+    const now = Date.now();
+    if (now < manualSeekSuppressUntilMs) {{
+      liveLagHighStreak = 0;
+      return;
+    }}
+
+    if (now - lastAutoLiveCheckAtMs < AUTO_LIVE_CHECK_INTERVAL_MS) {{
+      return;
+    }}
+    lastAutoLiveCheckAtMs = now;
+
+    const lag = Math.max(0, timeline.end - video.currentTime);
+    if (lag > AUTO_LIVE_SEEK_LAG_SECS) {{
+      liveLagHighStreak += 1;
+    }} else {{
+      liveLagHighStreak = 0;
+      return;
+    }}
+
+    if (liveLagHighStreak < AUTO_LIVE_SEEK_CONSECUTIVE_CHECKS) {{
+      return;
+    }}
+
+    if (now - lastAutoLiveSeekAtMs < AUTO_LIVE_SEEK_COOLDOWN_MS) {{
+      return;
+    }}
+
+    video.currentTime = Math.max(timeline.start, timeline.end - AUTO_LIVE_TARGET_OFFSET_SECS);
+    lastAutoLiveSeekAtMs = now;
+    liveLagHighStreak = 0;
   }}
 
   function goLive() {{
     var timeline = getTimelineModel();
     if (!timeline.seekable || timeline.length <= 0) return;
     video.currentTime = timeline.end;
+    manualSeekSuppressUntilMs = 0;
+    liveLagHighStreak = 0;
     showControls();
   }}
 
@@ -1719,12 +1784,30 @@ fn render_stream_page(
   }});
 
   if (Hls.isSupported()) {{
-    hlsInstance = new Hls({{ startPosition: -10, maxBufferLength: 30, maxMaxBufferLength: 60 }});
+    hlsInstance = new Hls({{
+      startPosition: -4,
+      lowLatencyMode: true,
+      liveSyncDurationCount: 1,
+      liveMaxLatencyDurationCount: 3,
+      maxLiveSyncPlaybackRate: 1.3,
+      maxBufferLength: 30,
+      maxMaxBufferLength: 60
+    }});
     hlsInstance.currentLevel = -1;
     hlsInstance.on(Hls.Events.MANIFEST_PARSED, function(e, data) {{
       console.log('[HLS] ' + data.levels.length + ' quality levels loaded');
       qualityBtn.textContent = 'Auto';
       buildQualityMenu(data.levels, hlsInstance.currentLevel);
+      setTimeout(function() {{
+        var timeline = getTimelineModel();
+        if (!timeline.seekable || timeline.mode === 'vod') return;
+        if (Date.now() < manualSeekSuppressUntilMs) return;
+        var lag = Math.max(0, timeline.end - video.currentTime);
+        if (lag <= AUTO_LIVE_SEEK_LAG_SECS) return;
+        video.currentTime = Math.max(timeline.start, timeline.end - AUTO_LIVE_TARGET_OFFSET_SECS);
+        lastAutoLiveSeekAtMs = Date.now();
+        liveLagHighStreak = 0;
+      }}, 1800);
     }});
     hlsInstance.on(Hls.Events.LEVEL_SWITCHED, function(e, data) {{
       currentPlayingLevelIdx = data.level;

--- a/src/app.rs
+++ b/src/app.rs
@@ -606,8 +606,9 @@ fn render_stream_page(
     position: relative;
   }}
   .chat-emote-btn {{
-    width: 2rem;
-    min-width: 2rem;
+    width: 2.15rem;
+    height: 2.15rem;
+    min-width: 2.15rem;
     border: 1px solid #2f3f55;
     background: #101824;
     color: #d7e7ff;
@@ -2237,6 +2238,7 @@ fn render_stream_page(
 
   chatForm.addEventListener('submit', async function(e) {{
     e.preventDefault();
+    closeEmotePicker();
     closeEmoteSuggestions();
     const text = getComposerPlainText().trim();
     if (!text) return;

--- a/src/app.rs
+++ b/src/app.rs
@@ -598,6 +598,7 @@ fn render_stream_page(
   }}
   .chat-form {{
     display: flex;
+    flex-wrap: wrap;
     gap: 0.45rem;
     border-top: 1px solid #2a3442;
     padding: 0.65rem;
@@ -619,7 +620,7 @@ fn render_stream_page(
     background: #172233;
   }}
   .chat-input {{
-    flex: 1;
+    flex: 1 1 0%;
     background: #0b1017;
     border: 1px solid #29374b;
     color: #ecf4ff;
@@ -634,6 +635,27 @@ fn render_stream_page(
     padding: 0.45rem 0.75rem;
     font-weight: 600;
     cursor: pointer;
+  }}
+  .chat-preview {{
+    width: 100%;
+    min-height: 0;
+    display: none;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.2rem;
+    padding: 0.38rem 0.5rem;
+    border: 1px solid #2a3442;
+    border-radius: 6px;
+    background: #0b1017;
+    color: #c8d7f2;
+    line-height: 1.3;
+    font-size: 0.86rem;
+  }}
+  .chat-preview.open {{
+    display: flex;
+  }}
+  .chat-preview .chat-emote {{
+    height: 1.3em;
   }}
   .emote-popup {{
     position: absolute;
@@ -1129,6 +1151,7 @@ fn render_stream_page(
       <button class="chat-emote-btn" type="button" id="chatEmoteBtn" title="Open emote picker">☺</button>
       <input class="chat-input" id="chatInput" type="text" maxlength="500" placeholder="Send a message" autocomplete="off" />
       <button class="chat-send" type="submit" id="chatSendBtn">Send</button>
+      <div class="chat-preview" id="chatPreview"></div>
       <div class="emote-suggestions" id="emoteSuggestions"></div>
       <div class="emote-popup" id="emotePopup" role="dialog" aria-label="Emote picker">
         <input class="emote-search" id="emoteSearch" type="text" placeholder="Search emotes" autocomplete="off" />
@@ -1164,6 +1187,7 @@ fn render_stream_page(
   const chatForm = document.getElementById('chatForm');
   const chatInput = document.getElementById('chatInput');
   const chatSendBtn = document.getElementById('chatSendBtn');
+  const chatPreview = document.getElementById('chatPreview');
   const chatEmoteBtn = document.getElementById('chatEmoteBtn');
   const emotePopup = document.getElementById('emotePopup');
   const emoteSearch = document.getElementById('emoteSearch');
@@ -1192,6 +1216,7 @@ fn render_stream_page(
   let emoteSuggestionsOpen = false;
   let emoteSuggestionIndex = 0;
   let emoteSuggestionItems = [];
+  let emotePreviewLoading = false;
   
   const debugOverlay = document.createElement('div');
   debugOverlay.style.cssText = 'position:fixed;top:50px;left:10px;background:rgba(0,0,0,0.9);color:#0f0;padding:10px;font-family:monospace;font-size:11px;z-index:99999;display:none;max-width:350px;border-radius:4px;';
@@ -1572,6 +1597,7 @@ fn render_stream_page(
   videoContainer.addEventListener('mousemove', showControls);
   videoContainer.addEventListener('mouseleave', function() {{ if (!video.paused) hideControls(); }});
   chatInput.addEventListener('input', function() {{
+    refreshComposerPreview();
     refreshEmoteSuggestions();
   }});
   chatInput.addEventListener('click', function() {{
@@ -1789,6 +1815,108 @@ fn render_stream_page(
     insertTextAtCursor(chatInput, safeCode + ' ');
   }}
 
+  function splitMessageSegments(input) {{
+    const out = [];
+    let current = '';
+    let currentWhitespace = null;
+
+    for (const ch of input) {{
+      const isWhitespace = /\s/.test(ch);
+      if (currentWhitespace === null || currentWhitespace === isWhitespace) {{
+        current += ch;
+        currentWhitespace = isWhitespace;
+      }} else {{
+        out.push({{ text: current, whitespace: currentWhitespace }});
+        current = ch;
+        currentWhitespace = isWhitespace;
+      }}
+    }}
+
+    if (current.length > 0) {{
+      out.push({{ text: current, whitespace: currentWhitespace }});
+    }}
+
+    return out;
+  }}
+
+  function renderComposerPreview() {{
+    const value = chatInput.value || '';
+    if (!value.trim().length || !availableEmotes.length) {{
+      chatPreview.innerHTML = '';
+      chatPreview.classList.remove('open');
+      return;
+    }}
+
+    const emotesByCode = new Map();
+    for (const item of availableEmotes) {{
+      if (typeof item.code === 'string' && typeof item.image_url === 'string' && typeof item.id === 'string') {{
+        emotesByCode.set(item.code, item);
+      }}
+    }}
+
+    let hasEmote = false;
+    const fragment = document.createDocumentFragment();
+    for (const segment of splitMessageSegments(value)) {{
+      if (segment.whitespace) {{
+        fragment.appendChild(document.createTextNode(segment.text));
+        continue;
+      }}
+
+      const match = emotesByCode.get(segment.text);
+      if (!match) {{
+        fragment.appendChild(document.createTextNode(segment.text));
+        continue;
+      }}
+
+      hasEmote = true;
+      const img = document.createElement('img');
+      img.className = 'chat-emote';
+      img.src = match.image_url;
+      img.alt = match.code;
+      img.title = match.code;
+      img.loading = 'lazy';
+      img.decoding = 'async';
+      fragment.appendChild(img);
+    }}
+
+    chatPreview.innerHTML = '';
+    if (!hasEmote) {{
+      chatPreview.classList.remove('open');
+      return;
+    }}
+
+    chatPreview.appendChild(fragment);
+    chatPreview.classList.add('open');
+  }}
+
+  function refreshComposerPreview() {{
+    const value = chatInput.value || '';
+    if (!value.trim()) {{
+      chatPreview.innerHTML = '';
+      chatPreview.classList.remove('open');
+      return;
+    }}
+
+    if (availableEmotes.length > 0) {{
+      renderComposerPreview();
+      return;
+    }}
+
+    if (emotePreviewLoading) {{
+      return;
+    }}
+
+    emotePreviewLoading = true;
+    ensureEmotesLoaded()
+      .catch(function() {{
+        // Ignore preview failures; chat send still works.
+      }})
+      .finally(function() {{
+        emotePreviewLoading = false;
+        renderComposerPreview();
+      }});
+  }}
+
   function filteredPickerEmotes() {{
     const term = emoteSearchTerm.trim().toLowerCase();
     if (!term) return availableEmotes;
@@ -1979,6 +2107,7 @@ fn render_stream_page(
 
     emotePickerLoaded = true;
     renderEmotePicker();
+    renderComposerPreview();
   }}
 
   async function openEmotePicker() {{
@@ -2085,6 +2214,8 @@ fn render_stream_page(
         body: JSON.stringify({{ channel_login: chatChannel, message: text }})
       }});
       chatInput.value = '';
+      chatPreview.innerHTML = '';
+      chatPreview.classList.remove('open');
       chatStatus.textContent = 'Connected to #' + chatChannel;
     }} catch (error) {{
       chatStatus.textContent = error && error.message ? error.message : 'Failed to send message';

--- a/src/app.rs
+++ b/src/app.rs
@@ -598,7 +598,8 @@ fn render_stream_page(
   }}
   .chat-form {{
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    align-items: center;
     gap: 0.45rem;
     border-top: 1px solid #2a3442;
     padding: 0.65rem;
@@ -626,10 +627,14 @@ fn render_stream_page(
     color: #ecf4ff;
     border-radius: 6px;
     padding: 0.45rem 0.55rem;
+    height: 2.15rem;
     min-height: 2.15rem;
-    line-height: 1.3;
-    white-space: pre-wrap;
-    word-break: break-word;
+    max-height: 2.15rem;
+    line-height: 1.2;
+    white-space: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    word-break: normal;
   }}
   .chat-input:focus {{
     outline: none;
@@ -641,7 +646,7 @@ fn render_stream_page(
     pointer-events: none;
   }}
   .chat-input .composer-emote {{
-    height: 1.4em;
+    height: 1em;
     width: auto;
     vertical-align: middle;
     margin: 0 0.06em;
@@ -1601,7 +1606,7 @@ fn render_stream_page(
   }});
   chatComposer.addEventListener('paste', function(e) {{
     e.preventDefault();
-    const text = (e.clipboardData && e.clipboardData.getData('text/plain')) || '';
+    const text = ((e.clipboardData && e.clipboardData.getData('text/plain')) || '').replace(/[\r\n]+/g, ' ');
     if (!text) return;
 
     const plain = getComposerPlainText();
@@ -1935,6 +1940,7 @@ fn render_stream_page(
 
   function normalizeComposerInput() {{
     let plain = getComposerPlainText();
+    plain = plain.replace(/[\r\n]+/g, ' ');
     if (plain.length > 500) {{
       plain = plain.slice(0, 500);
     }}

--- a/src/app.rs
+++ b/src/app.rs
@@ -1174,10 +1174,13 @@ fn render_stream_page(
   let chatEvents = null;
   const fullscreenBtn = document.getElementById('fullscreenBtn');
   const MOBILE_LAYOUT_QUERY = window.matchMedia('(max-width: 700px)');
-  
+  const LIVE_STATUS_CACHE_KEY = 'twitchRelay.liveStatus';
+  const LIVE_STATUS_REFRESH_MS = 45000;
+
   let hlsInstance = null;
   let debugVisible = false;
   let controlsTimeout = null;
+  let liveStatusRefreshTimer = null;
   const CONTROLS_HIDE_DELAY_MS = 2000;
   let currentPlayingLevelIdx = -1;
   let userSelectedAuto = true;
@@ -1452,6 +1455,55 @@ fn render_stream_page(
       '<div>currentTime: ' + video.currentTime.toFixed(1) + '</div>' +
       '<div>paused: ' + video.paused + '</div>' +
       '<div>buffered: ' + JSON.stringify(bufferedRanges) + '</div>';
+  }}
+
+  function isObject(value) {{
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+  }}
+
+  async function refreshLiveStatusCache() {{
+    try {{
+      const response = await fetch('/api/live-status', {{ credentials: 'same-origin' }});
+      if (!response.ok) {{
+        return;
+      }}
+
+      const payload = await response.json();
+      if (!isObject(payload) || !isObject(payload.channels)) {{
+        return;
+      }}
+
+      window.sessionStorage.setItem(
+        LIVE_STATUS_CACHE_KEY,
+        JSON.stringify({{
+          timestamp: Date.now(),
+          data: {{
+            channels: payload.channels
+          }}
+        }})
+      );
+    }} catch (_) {{}}
+  }}
+
+  function handleVisibilityChange() {{
+    if (document.visibilityState === 'visible') {{
+      void refreshLiveStatusCache();
+    }}
+  }}
+
+  function startLiveStatusRefreshLoop() {{
+    void refreshLiveStatusCache();
+
+    if (liveStatusRefreshTimer) {{
+      clearInterval(liveStatusRefreshTimer);
+    }}
+
+    liveStatusRefreshTimer = setInterval(function() {{
+      if (document.visibilityState !== 'visible') {{
+        return;
+      }}
+      void refreshLiveStatusCache();
+    }}, LIVE_STATUS_REFRESH_MS);
   }}
 
   document.addEventListener('keydown', function(e) {{
@@ -2053,8 +2105,15 @@ fn render_stream_page(
     if (typeof MOBILE_LAYOUT_QUERY.removeEventListener === 'function') {{
       MOBILE_LAYOUT_QUERY.removeEventListener('change', syncPlayerLayout);
     }}
+    document.removeEventListener('visibilitychange', handleVisibilityChange);
+    if (liveStatusRefreshTimer) {{
+      clearInterval(liveStatusRefreshTimer);
+      liveStatusRefreshTimer = null;
+    }}
   }});
 
+  document.addEventListener('visibilitychange', handleVisibilityChange);
+  startLiveStatusRefreshLoop();
   initChat();
 </script>
 </body>

--- a/src/app.rs
+++ b/src/app.rs
@@ -626,6 +626,25 @@ fn render_stream_page(
     color: #ecf4ff;
     border-radius: 6px;
     padding: 0.45rem 0.55rem;
+    min-height: 2.15rem;
+    line-height: 1.3;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }}
+  .chat-input:focus {{
+    outline: none;
+    border-color: #4b668d;
+  }}
+  .chat-input:empty::before {{
+    content: attr(data-placeholder);
+    color: #8ea3c5;
+    pointer-events: none;
+  }}
+  .chat-input .composer-emote {{
+    height: 1.4em;
+    width: auto;
+    vertical-align: middle;
+    margin: 0 0.06em;
   }}
   .chat-send {{
     background: #2c65f5;
@@ -635,27 +654,6 @@ fn render_stream_page(
     padding: 0.45rem 0.75rem;
     font-weight: 600;
     cursor: pointer;
-  }}
-  .chat-preview {{
-    width: 100%;
-    min-height: 0;
-    display: none;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 0.2rem;
-    padding: 0.38rem 0.5rem;
-    border: 1px solid #2a3442;
-    border-radius: 6px;
-    background: #0b1017;
-    color: #c8d7f2;
-    line-height: 1.3;
-    font-size: 0.86rem;
-  }}
-  .chat-preview.open {{
-    display: flex;
-  }}
-  .chat-preview .chat-emote {{
-    height: 1.3em;
   }}
   .emote-popup {{
     position: absolute;
@@ -1149,9 +1147,8 @@ fn render_stream_page(
     <div class="chat-messages" id="chatMessages"></div>
     <form class="chat-form" id="chatForm">
       <button class="chat-emote-btn" type="button" id="chatEmoteBtn" title="Open emote picker">☺</button>
-      <input class="chat-input" id="chatInput" type="text" maxlength="500" placeholder="Send a message" autocomplete="off" />
+      <div class="chat-input" id="chatComposer" contenteditable="true" role="textbox" aria-label="Send a message" data-placeholder="Send a message"></div>
       <button class="chat-send" type="submit" id="chatSendBtn">Send</button>
-      <div class="chat-preview" id="chatPreview"></div>
       <div class="emote-suggestions" id="emoteSuggestions"></div>
       <div class="emote-popup" id="emotePopup" role="dialog" aria-label="Emote picker">
         <input class="emote-search" id="emoteSearch" type="text" placeholder="Search emotes" autocomplete="off" />
@@ -1185,9 +1182,8 @@ fn render_stream_page(
   const chatStatus = document.getElementById('chatStatus');
   const chatMessages = document.getElementById('chatMessages');
   const chatForm = document.getElementById('chatForm');
-  const chatInput = document.getElementById('chatInput');
+  const chatComposer = document.getElementById('chatComposer');
   const chatSendBtn = document.getElementById('chatSendBtn');
-  const chatPreview = document.getElementById('chatPreview');
   const chatEmoteBtn = document.getElementById('chatEmoteBtn');
   const emotePopup = document.getElementById('emotePopup');
   const emoteSearch = document.getElementById('emoteSearch');
@@ -1216,7 +1212,6 @@ fn render_stream_page(
   let emoteSuggestionsOpen = false;
   let emoteSuggestionIndex = 0;
   let emoteSuggestionItems = [];
-  let emotePreviewLoading = false;
   
   const debugOverlay = document.createElement('div');
   debugOverlay.style.cssText = 'position:fixed;top:50px;left:10px;background:rgba(0,0,0,0.9);color:#0f0;padding:10px;font-family:monospace;font-size:11px;z-index:99999;display:none;max-width:350px;border-radius:4px;';
@@ -1547,7 +1542,7 @@ fn render_stream_page(
   chatEmoteBtn.addEventListener('click', function() {{
     if (emotePickerOpen) {{
       closeEmotePicker();
-      chatInput.focus();
+      placeComposerCaretAtEnd();
     }} else {{
       openEmotePicker();
     }}
@@ -1596,14 +1591,30 @@ fn render_stream_page(
   videoContainer.addEventListener('mouseenter', showControls);
   videoContainer.addEventListener('mousemove', showControls);
   videoContainer.addEventListener('mouseleave', function() {{ if (!video.paused) hideControls(); }});
-  chatInput.addEventListener('input', function() {{
-    refreshComposerPreview();
+  chatComposer.addEventListener('input', function() {{
+    normalizeComposerInput();
     refreshEmoteSuggestions();
   }});
-  chatInput.addEventListener('click', function() {{
+  chatComposer.addEventListener('click', function() {{
+    placeComposerCaretAtEnd();
     refreshEmoteSuggestions();
   }});
-  chatInput.addEventListener('keydown', function(e) {{
+  chatComposer.addEventListener('paste', function(e) {{
+    e.preventDefault();
+    const text = (e.clipboardData && e.clipboardData.getData('text/plain')) || '';
+    if (!text) return;
+
+    const plain = getComposerPlainText();
+    applyPlainTextToComposer((plain + text).slice(0, 500));
+    refreshEmoteSuggestions();
+  }});
+  chatComposer.addEventListener('keydown', function(e) {{
+    if (e.key === 'Enter' && !(emoteSuggestionsOpen && emoteSuggestionItems.length)) {{
+      e.preventDefault();
+      chatForm.requestSubmit();
+      return;
+    }}
+
     if (!emoteSuggestionsOpen || !emoteSuggestionItems.length) {{
       if (e.key === 'Escape') {{
         closeEmotePicker();
@@ -1645,6 +1656,11 @@ fn render_stream_page(
     if (!chatForm.contains(e.target)) {{
       closeEmotePicker();
       closeEmoteSuggestions();
+      return;
+    }}
+
+    if (e.target === chatComposer) {{
+      placeComposerCaretAtEnd();
     }}
   }});
   if (typeof MOBILE_LAYOUT_QUERY.addEventListener === 'function') {{
@@ -1776,43 +1792,121 @@ fn render_stream_page(
     return 99;
   }}
 
-  function insertTextAtCursor(input, insertText) {{
-    const start = input.selectionStart || 0;
-    const end = input.selectionEnd || 0;
-    const before = input.value.slice(0, start);
-    const after = input.value.slice(end);
-    input.value = before + insertText + after;
-    const next = before.length + insertText.length;
-    input.setSelectionRange(next, next);
-    input.dispatchEvent(new Event('input', {{ bubbles: true }}));
+  function placeComposerCaretAtEnd() {{
+    chatComposer.focus();
+    const range = document.createRange();
+    range.selectNodeContents(chatComposer);
+    range.collapse(false);
+    const selection = window.getSelection();
+    if (!selection) return;
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }}
+
+  function composerTextFromNode(node) {{
+    if (!node) return '';
+    if (node.nodeType === Node.TEXT_NODE) {{
+      return node.textContent || '';
+    }}
+
+    if (node.nodeType !== Node.ELEMENT_NODE) {{
+      return '';
+    }}
+
+    const element = node;
+    if (element.tagName === 'IMG') {{
+      return element.dataset.code || '';
+    }}
+    if (element.tagName === 'BR') {{
+      return '\n';
+    }}
+
+    let out = '';
+    for (const child of Array.from(element.childNodes)) {{
+      out += composerTextFromNode(child);
+    }}
+    return out;
+  }}
+
+  function getComposerPlainText() {{
+    let out = '';
+    for (const child of Array.from(chatComposer.childNodes)) {{
+      out += composerTextFromNode(child);
+    }}
+    return out;
+  }}
+
+  function buildEmoteMapByCode() {{
+    const emotesByCode = new Map();
+    for (const item of availableEmotes) {{
+      if (typeof item.code === 'string' && typeof item.image_url === 'string' && typeof item.id === 'string') {{
+        emotesByCode.set(item.code, item);
+      }}
+    }}
+    return emotesByCode;
+  }}
+
+  function renderComposerFromPlainText(text) {{
+    const emotesByCode = buildEmoteMapByCode();
+    chatComposer.innerHTML = '';
+
+    if (!text) {{
+      return;
+    }}
+
+    for (const segment of splitMessageSegments(text)) {{
+      if (segment.whitespace) {{
+        chatComposer.appendChild(document.createTextNode(segment.text));
+        continue;
+      }}
+
+      const match = emotesByCode.get(segment.text);
+      if (!match) {{
+        chatComposer.appendChild(document.createTextNode(segment.text));
+        continue;
+      }}
+
+      const img = document.createElement('img');
+      img.className = 'composer-emote';
+      img.src = match.image_url;
+      img.alt = match.code;
+      img.title = match.code;
+      img.dataset.code = match.code;
+      img.dataset.id = match.id;
+      img.loading = 'lazy';
+      img.decoding = 'async';
+      img.contentEditable = 'false';
+      chatComposer.appendChild(img);
+    }}
+  }}
+
+  function applyPlainTextToComposer(text) {{
+    renderComposerFromPlainText(text);
+    placeComposerCaretAtEnd();
   }}
 
   function findActiveEmoteQuery() {{
-    const caret = chatInput.selectionStart || 0;
-    const left = chatInput.value.slice(0, caret);
-    const match = left.match(/(^|\s):([A-Za-z0-9_]{{2,}})$/);
+    const full = getComposerPlainText();
+    const match = full.match(/(^|\s):([A-Za-z0-9_]{{2,}})$/);
     if (!match) return null;
     const query = match[2];
-    const tokenStart = caret - query.length - 1;
-    return {{ query: query, start: tokenStart, end: caret }};
+    const tokenStart = full.length - query.length - 1;
+    return {{ query: query, start: tokenStart, end: full.length }};
   }}
 
   function applyEmoteCode(code, queryRange) {{
     const safeCode = normalizeEmoteCode(code);
     if (!safeCode) return;
 
+    const full = getComposerPlainText();
     if (queryRange) {{
-      const before = chatInput.value.slice(0, queryRange.start);
-      const after = chatInput.value.slice(queryRange.end);
-      const replacement = safeCode + ' ';
-      chatInput.value = before + replacement + after;
-      const next = before.length + replacement.length;
-      chatInput.setSelectionRange(next, next);
-      chatInput.dispatchEvent(new Event('input', {{ bubbles: true }}));
+      const before = full.slice(0, queryRange.start);
+      const after = full.slice(queryRange.end);
+      applyPlainTextToComposer(before + safeCode + ' ' + after);
       return;
     }}
 
-    insertTextAtCursor(chatInput, safeCode + ' ');
+    applyPlainTextToComposer(full + safeCode + ' ');
   }}
 
   function splitMessageSegments(input) {{
@@ -1839,82 +1933,14 @@ fn render_stream_page(
     return out;
   }}
 
-  function renderComposerPreview() {{
-    const value = chatInput.value || '';
-    if (!value.trim().length || !availableEmotes.length) {{
-      chatPreview.innerHTML = '';
-      chatPreview.classList.remove('open');
-      return;
+  function normalizeComposerInput() {{
+    let plain = getComposerPlainText();
+    if (plain.length > 500) {{
+      plain = plain.slice(0, 500);
     }}
 
-    const emotesByCode = new Map();
-    for (const item of availableEmotes) {{
-      if (typeof item.code === 'string' && typeof item.image_url === 'string' && typeof item.id === 'string') {{
-        emotesByCode.set(item.code, item);
-      }}
-    }}
-
-    let hasEmote = false;
-    const fragment = document.createDocumentFragment();
-    for (const segment of splitMessageSegments(value)) {{
-      if (segment.whitespace) {{
-        fragment.appendChild(document.createTextNode(segment.text));
-        continue;
-      }}
-
-      const match = emotesByCode.get(segment.text);
-      if (!match) {{
-        fragment.appendChild(document.createTextNode(segment.text));
-        continue;
-      }}
-
-      hasEmote = true;
-      const img = document.createElement('img');
-      img.className = 'chat-emote';
-      img.src = match.image_url;
-      img.alt = match.code;
-      img.title = match.code;
-      img.loading = 'lazy';
-      img.decoding = 'async';
-      fragment.appendChild(img);
-    }}
-
-    chatPreview.innerHTML = '';
-    if (!hasEmote) {{
-      chatPreview.classList.remove('open');
-      return;
-    }}
-
-    chatPreview.appendChild(fragment);
-    chatPreview.classList.add('open');
-  }}
-
-  function refreshComposerPreview() {{
-    const value = chatInput.value || '';
-    if (!value.trim()) {{
-      chatPreview.innerHTML = '';
-      chatPreview.classList.remove('open');
-      return;
-    }}
-
-    if (availableEmotes.length > 0) {{
-      renderComposerPreview();
-      return;
-    }}
-
-    if (emotePreviewLoading) {{
-      return;
-    }}
-
-    emotePreviewLoading = true;
-    ensureEmotesLoaded()
-      .catch(function() {{
-        // Ignore preview failures; chat send still works.
-      }})
-      .finally(function() {{
-        emotePreviewLoading = false;
-        renderComposerPreview();
-      }});
+    renderComposerFromPlainText(plain);
+    placeComposerCaretAtEnd();
   }}
 
   function filteredPickerEmotes() {{
@@ -1964,7 +1990,7 @@ fn render_stream_page(
         button.setAttribute('aria-label', item.code);
         button.addEventListener('click', function() {{
           applyEmoteCode(item.code, null);
-          chatInput.focus();
+          placeComposerCaretAtEnd();
         }});
 
         const img = document.createElement('img');
@@ -2107,7 +2133,7 @@ fn render_stream_page(
 
     emotePickerLoaded = true;
     renderEmotePicker();
-    renderComposerPreview();
+    normalizeComposerInput();
   }}
 
   async function openEmotePicker() {{
@@ -2179,6 +2205,9 @@ fn render_stream_page(
       }});
 
       chatStatus.textContent = 'Connected to #' + chatChannel;
+      ensureEmotesLoaded().catch(function() {{
+        // Emote picker can still retry on demand.
+      }});
 
       chatEvents = new EventSource('/api/chat/events/' + encodeURIComponent(chatChannel));
       chatEvents.addEventListener('chat', function(raw) {{
@@ -2195,7 +2224,7 @@ fn render_stream_page(
       }};
     }} catch (error) {{
       chatStatus.textContent = error && error.message ? error.message : 'Chat unavailable';
-      chatInput.disabled = true;
+      chatComposer.contentEditable = 'false';
       chatSendBtn.disabled = true;
     }}
   }}
@@ -2203,7 +2232,7 @@ fn render_stream_page(
   chatForm.addEventListener('submit', async function(e) {{
     e.preventDefault();
     closeEmoteSuggestions();
-    const text = chatInput.value.trim();
+    const text = getComposerPlainText().trim();
     if (!text) return;
 
     chatSendBtn.disabled = true;
@@ -2213,10 +2242,9 @@ fn render_stream_page(
         headers: {{ 'content-type': 'application/json' }},
         body: JSON.stringify({{ channel_login: chatChannel, message: text }})
       }});
-      chatInput.value = '';
-      chatPreview.innerHTML = '';
-      chatPreview.classList.remove('open');
+      chatComposer.innerHTML = '';
       chatStatus.textContent = 'Connected to #' + chatChannel;
+      placeComposerCaretAtEnd();
     }} catch (error) {{
       chatStatus.textContent = error && error.message ? error.message : 'Failed to send message';
     }} finally {{

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -169,7 +169,12 @@ impl ChatService {
         let owner_name_cache = Arc::new(RwLock::new(HashMap::new()));
         let owner_lookup_cooldown_until_unix = Arc::new(AtomicU64::new(0));
 
-        tokio::spawn(run_chat_manager(auth.clone(), command_rx, channels.clone()));
+        tokio::spawn(run_chat_manager(
+            auth.clone(),
+            command_rx,
+            channels.clone(),
+            emote_cache.clone(),
+        ));
 
         Self {
             auth,
@@ -343,6 +348,8 @@ impl ChatService {
             &broadcaster.id,
         )
         .await?;
+        let allowed_user_emote_ids: HashSet<String> =
+            user_emotes.iter().map(|emote| emote.id.clone()).collect();
 
         let mut owner_ids = HashSet::new();
         for emote in &user_emotes {
@@ -373,6 +380,9 @@ impl ChatService {
         let watched_group_key = format!("owner:{}", broadcaster.id);
 
         for emote in channel_emotes {
+            if !allowed_user_emote_ids.contains(&emote.id) {
+                continue;
+            }
             if seen.insert(emote.id.clone()) {
                 let emote_id = emote.id.clone();
                 merged.push(EmotePickerItem {
@@ -546,6 +556,7 @@ async fn run_chat_manager(
     auth: TwitchAuthService,
     mut command_rx: mpsc::UnboundedReceiver<ChatCommand>,
     channels: Arc<RwLock<HashMap<String, broadcast::Sender<ChatEvent>>>>,
+    emote_cache: Arc<RwLock<HashMap<String, CachedEmoteEntry>>>,
 ) {
     let mut subscribed_counts: HashMap<String, usize> = HashMap::new();
     let mut joined_channels: HashSet<String> = HashSet::new();
@@ -657,9 +668,12 @@ async fn run_chat_manager(
                                     sender_login: Some(identity.login.clone()),
                                     sender_display_name: Some(identity.display_name.clone()),
                                     text: message.clone(),
-                                    parts: vec![ChatPart::Text {
-                                        text: message.clone(),
-                                    }],
+                                    parts: local_echo_parts_for_channel(
+                                        &emote_cache,
+                                        &channel,
+                                        &message,
+                                    )
+                                    .await,
                                     sent_at_unix: now_unix_secs(),
                                 };
                                 remember_local_echo(&mut pending_local_echo, &echo_event);
@@ -1295,6 +1309,105 @@ fn parse_message_parts(message: &str, emotes_tag: Option<&str>) -> Vec<ChatPart>
         if !text.is_empty() {
             parts.push(ChatPart::Text { text });
         }
+    }
+
+    if parts.is_empty() {
+        vec![ChatPart::Text {
+            text: message.to_string(),
+        }]
+    } else {
+        parts
+    }
+}
+
+async fn local_echo_parts_for_channel(
+    emote_cache: &Arc<RwLock<HashMap<String, CachedEmoteEntry>>>,
+    channel: &str,
+    message: &str,
+) -> Vec<ChatPart> {
+    let now = now_unix_secs();
+    let key_suffix = format!(":{channel}");
+    let mut emotes_by_code: HashMap<String, String> = HashMap::new();
+
+    {
+        let cache = emote_cache.read().await;
+        for (key, entry) in cache.iter() {
+            if !key.ends_with(&key_suffix) || entry.expires_at_unix <= now {
+                continue;
+            }
+
+            for emote in &entry.items {
+                emotes_by_code
+                    .entry(emote.code.clone())
+                    .or_insert_with(|| emote.id.clone());
+            }
+        }
+    }
+
+    parse_local_message_parts(message, &emotes_by_code)
+}
+
+fn parse_local_message_parts(
+    message: &str,
+    emotes_by_code: &HashMap<String, String>,
+) -> Vec<ChatPart> {
+    if message.is_empty() {
+        return vec![ChatPart::Text {
+            text: message.to_string(),
+        }];
+    }
+
+    let mut parts = Vec::new();
+    let mut segment = String::new();
+    let mut segment_is_whitespace: Option<bool> = None;
+
+    let flush_segment = |value: &mut String, is_whitespace: bool, out: &mut Vec<ChatPart>| {
+        if value.is_empty() {
+            return;
+        }
+
+        if is_whitespace {
+            out.push(ChatPart::Text {
+                text: value.clone(),
+            });
+            value.clear();
+            return;
+        }
+
+        if let Some(id) = emotes_by_code.get(value) {
+            out.push(ChatPart::Emote {
+                id: id.clone(),
+                code: value.clone(),
+            });
+        } else {
+            out.push(ChatPart::Text {
+                text: value.clone(),
+            });
+        }
+
+        value.clear();
+    };
+
+    for ch in message.chars() {
+        let is_whitespace = ch.is_whitespace();
+        match segment_is_whitespace {
+            None => {
+                segment_is_whitespace = Some(is_whitespace);
+                segment.push(ch);
+            }
+            Some(current) if current == is_whitespace => {
+                segment.push(ch);
+            }
+            Some(current) => {
+                flush_segment(&mut segment, current, &mut parts);
+                segment_is_whitespace = Some(is_whitespace);
+                segment.push(ch);
+            }
+        }
+    }
+
+    if let Some(is_whitespace) = segment_is_whitespace {
+        flush_segment(&mut segment, is_whitespace, &mut parts);
     }
 
     if parts.is_empty() {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1,8 +1,11 @@
 use std::{
     collections::{HashMap, HashSet},
     convert::Infallible,
-    sync::Arc,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use axum::{
@@ -25,6 +28,8 @@ pub struct ChatService {
     command_tx: mpsc::UnboundedSender<ChatCommand>,
     channels: Arc<RwLock<HashMap<String, broadcast::Sender<ChatEvent>>>>,
     emote_cache: Arc<RwLock<HashMap<String, CachedEmoteEntry>>>,
+    owner_name_cache: Arc<RwLock<HashMap<String, CachedOwnerName>>>,
+    owner_lookup_cooldown_until_unix: Arc<AtomicU64>,
 }
 
 #[derive(Debug, Clone)]
@@ -105,6 +110,16 @@ struct CachedEmoteEntry {
     items: Vec<EmotePickerItem>,
 }
 
+#[derive(Debug, Clone)]
+struct CachedOwnerName {
+    expires_at_unix: u64,
+    display_name: String,
+}
+
+const EMOTE_CACHE_TTL_SECS: u64 = 900;
+const OWNER_NAME_CACHE_TTL_SECS: u64 = 24 * 60 * 60;
+const OWNER_LOOKUP_429_FALLBACK_COOLDOWN_SECS: u64 = 60;
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ChatPart {
@@ -151,6 +166,8 @@ impl ChatService {
         let (command_tx, command_rx) = mpsc::unbounded_channel();
         let channels = Arc::new(RwLock::new(HashMap::new()));
         let emote_cache = Arc::new(RwLock::new(HashMap::new()));
+        let owner_name_cache = Arc::new(RwLock::new(HashMap::new()));
+        let owner_lookup_cooldown_until_unix = Arc::new(AtomicU64::new(0));
 
         tokio::spawn(run_chat_manager(auth.clone(), command_rx, channels.clone()));
 
@@ -159,6 +176,8 @@ impl ChatService {
             command_tx,
             channels,
             emote_cache,
+            owner_name_cache,
+            owner_lookup_cooldown_until_unix,
         }
     }
 
@@ -275,7 +294,7 @@ impl ChatService {
                     )
                 }
             })
-            .buffer_unordered(6)
+            .buffer_unordered(2)
             .for_each(|(channel, result)| async move {
                 if let Err(error) = result {
                     tracing::debug!(error = %error, channel = %channel, "failed prewarming emotes for channel");
@@ -339,6 +358,8 @@ impl ChatService {
             &client_id,
             &account.access_token,
             owner_ids.into_iter().collect(),
+            &self.owner_name_cache,
+            &self.owner_lookup_cooldown_until_unix,
         )
         .await;
 
@@ -424,7 +445,7 @@ impl ChatService {
         cache.insert(
             cache_key,
             CachedEmoteEntry {
-                expires_at_unix: now.saturating_add(Duration::from_secs(120).as_secs()),
+                expires_at_unix: now.saturating_add(EMOTE_CACHE_TTL_SECS),
                 items: merged.clone(),
             },
         );
@@ -944,13 +965,55 @@ async fn resolve_user_display_names_by_ids(
     client_id: &str,
     access_token: &str,
     user_ids: Vec<String>,
+    owner_name_cache: &Arc<RwLock<HashMap<String, CachedOwnerName>>>,
+    owner_lookup_cooldown_until_unix: &Arc<AtomicU64>,
 ) -> HashMap<String, String> {
     let mut out = HashMap::new();
     if user_ids.is_empty() {
         return out;
     }
 
-    for chunk in user_ids.chunks(100) {
+    let filtered_ids: Vec<String> = user_ids
+        .into_iter()
+        .map(|id| id.trim().to_string())
+        .filter(|id| !id.is_empty())
+        .filter(|id| id.bytes().all(|byte| byte.is_ascii_digit()))
+        .collect();
+
+    if filtered_ids.is_empty() {
+        return out;
+    }
+
+    let now = now_unix_secs();
+    let mut missing_ids = Vec::new();
+    {
+        let cache = owner_name_cache.read().await;
+        for id in filtered_ids {
+            if let Some(entry) = cache.get(&id)
+                && entry.expires_at_unix > now
+            {
+                out.insert(id, entry.display_name.clone());
+            } else {
+                missing_ids.push(id);
+            }
+        }
+    }
+
+    if missing_ids.is_empty() {
+        return out;
+    }
+
+    let cooldown_until = owner_lookup_cooldown_until_unix.load(Ordering::Relaxed);
+    if now < cooldown_until {
+        tracing::debug!(
+            cooldown_until_unix = cooldown_until,
+            pending_owner_ids = missing_ids.len(),
+            "skipping user name lookup while rate-limited"
+        );
+        return out;
+    }
+
+    for chunk in missing_ids.chunks(100) {
         let response = match client
             .get("https://api.twitch.tv/helix/users")
             .header("Client-Id", client_id)
@@ -967,7 +1030,41 @@ async fn resolve_user_display_names_by_ids(
         };
 
         if !response.status().is_success() {
-            tracing::warn!(status = %response.status(), "resolve user names by ids returned non-success status");
+            let status = response.status();
+            if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                let reset_header = response
+                    .headers()
+                    .get("Ratelimit-Reset")
+                    .and_then(|value| value.to_str().ok())
+                    .and_then(|value| value.parse::<u64>().ok());
+                let fallback_cooldown_until =
+                    now_unix_secs().saturating_add(OWNER_LOOKUP_429_FALLBACK_COOLDOWN_SECS);
+                let cooldown_until = match reset_header {
+                    Some(value) if value > now_unix_secs() => value,
+                    _ => fallback_cooldown_until,
+                };
+                owner_lookup_cooldown_until_unix.store(cooldown_until, Ordering::Relaxed);
+
+                let body = response.text().await.unwrap_or_default();
+                let sample_ids: Vec<&str> = chunk.iter().map(String::as_str).take(5).collect();
+                tracing::warn!(
+                    status = %status,
+                    sample_ids = ?sample_ids,
+                    cooldown_until_unix = cooldown_until,
+                    body = %body,
+                    "resolve user names by ids rate-limited"
+                );
+                break;
+            }
+
+            let body = response.text().await.unwrap_or_default();
+            let sample_ids: Vec<&str> = chunk.iter().map(String::as_str).take(5).collect();
+            tracing::warn!(
+                status = %status,
+                sample_ids = ?sample_ids,
+                body = %body,
+                "resolve user names by ids returned non-success status"
+            );
             continue;
         }
 
@@ -979,14 +1076,30 @@ async fn resolve_user_display_names_by_ids(
             }
         };
 
+        let mut fresh_names = Vec::with_capacity(payload.data.len());
         for user in payload.data {
-            out.insert(
-                user.id,
-                user.display_name
-                    .clone()
-                    .filter(|name| !name.trim().is_empty())
-                    .unwrap_or_else(|| "Unknown channel".to_string()),
-            );
+            let display_name = user
+                .display_name
+                .clone()
+                .filter(|name| !name.trim().is_empty())
+                .unwrap_or_else(|| "Unknown channel".to_string());
+
+            out.insert(user.id.clone(), display_name.clone());
+            fresh_names.push((user.id, display_name));
+        }
+
+        if !fresh_names.is_empty() {
+            let expires_at_unix = now_unix_secs().saturating_add(OWNER_NAME_CACHE_TTL_SECS);
+            let mut cache = owner_name_cache.write().await;
+            for (user_id, display_name) in fresh_names {
+                cache.insert(
+                    user_id,
+                    CachedOwnerName {
+                        expires_at_unix,
+                        display_name,
+                    },
+                );
+            }
         }
     }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -176,14 +176,15 @@ export interface LiveStatusResponse {
   channels: Record<string, ChannelStatus>;
 }
 
-export async function getLiveStatus(): Promise<LiveStatusResponse> {
-  const response = await request('/api/live-status');
-  if (!response.ok) {
-    const payload = await safeJson(response);
-    throw new Error(readError(payload));
-  }
+interface LiveStatusCacheEntry {
+  timestamp: number;
+  data: LiveStatusResponse;
+}
 
-  const payload = await safeJson(response);
+const LIVE_STATUS_CACHE_KEY = 'twitchRelay.liveStatus';
+const LIVE_STATUS_CACHE_MAX_AGE_MS = 60000;
+
+function parseLiveStatusPayload(payload: unknown): LiveStatusResponse {
   if (!isObject(payload) || !isObject(payload.channels)) {
     throw new Error('live status payload is invalid');
   }
@@ -191,6 +192,81 @@ export async function getLiveStatus(): Promise<LiveStatusResponse> {
   return {
     channels: payload.channels as Record<string, ChannelStatus>
   };
+}
+
+function getLiveStatusFromCache(): LiveStatusResponse | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const encoded = window.sessionStorage.getItem(LIVE_STATUS_CACHE_KEY);
+    if (!encoded) {
+      return null;
+    }
+
+    const parsed = JSON.parse(encoded) as unknown;
+    if (!isObject(parsed) || typeof parsed.timestamp !== 'number' || !('data' in parsed)) {
+      return null;
+    }
+
+    const ageMs = Date.now() - parsed.timestamp;
+    if (ageMs > LIVE_STATUS_CACHE_MAX_AGE_MS) {
+      return null;
+    }
+
+    return parseLiveStatusPayload(parsed.data);
+  } catch {
+    return null;
+  }
+}
+
+function setLiveStatusCache(data: LiveStatusResponse): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    const payload: LiveStatusCacheEntry = {
+      timestamp: Date.now(),
+      data
+    };
+    window.sessionStorage.setItem(LIVE_STATUS_CACHE_KEY, JSON.stringify(payload));
+  } catch {
+    // Ignore storage failures and continue with in-memory state.
+  }
+}
+
+async function fetchLiveStatusFromApi(): Promise<LiveStatusResponse> {
+  const response = await request('/api/live-status');
+  if (!response.ok) {
+    const payload = await safeJson(response);
+    throw new Error(readError(payload));
+  }
+
+  const payload = await safeJson(response);
+  return parseLiveStatusPayload(payload);
+}
+
+async function refreshLiveStatusCache(): Promise<void> {
+  try {
+    const fresh = await fetchLiveStatusFromApi();
+    setLiveStatusCache(fresh);
+  } catch {
+    // Keep existing cache if refresh fails.
+  }
+}
+
+export async function getLiveStatus(): Promise<LiveStatusResponse> {
+  const cached = getLiveStatusFromCache();
+  if (cached) {
+    void refreshLiveStatusCache();
+    return cached;
+  }
+
+  const fresh = await fetchLiveStatusFromApi();
+  setLiveStatusCache(fresh);
+  return fresh;
 }
 
 export async function getTwitchStatus(): Promise<TwitchStatusResponse> {

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -63,7 +63,6 @@
       if (authenticated) {
         await loadTwitchStatus();
         await loadChannels();
-        await loadLiveStatus();
         startPolling();
       }
     } catch (err) {
@@ -282,15 +281,33 @@
 <main class="shell">
   <section class="panel">
     <header class="panel-header">
-      <div>
+      <div class="panel-title">
         <p class="eyebrow">Private Deck</p>
         <h1>Twitch Relay</h1>
+        {#if authMode === 'authenticated'}
+          <p class="header-subtle">
+            {#if twitchStatus.connected}
+              Linked as <strong>{twitchStatus.display_name || twitchStatus.login}</strong>
+            {:else}
+              Twitch not connected
+            {/if}
+          </p>
+        {/if}
       </div>
 
       {#if authMode === 'authenticated'}
-        <button class="ghost" onclick={signOut} disabled={isBusy}>
-          Sign out
-        </button>
+        <div class="header-actions">
+          {#if twitchStatus.connected}
+            <button type="button" class="ghost compact" onclick={unlinkTwitch} disabled={isTwitchBusy}>
+              {isTwitchBusy ? 'Disconnecting...' : 'Disconnect'}
+            </button>
+          {:else}
+            <button type="button" class="compact" onclick={connectTwitch}>Connect Twitch</button>
+          {/if}
+          <button class="ghost compact" onclick={signOut} disabled={isBusy}>
+            Sign out
+          </button>
+        </div>
       {/if}
     </header>
 
@@ -313,24 +330,6 @@
         <button type="submit" disabled={isBusy}>{isBusy ? 'Signing in...' : 'Sign in'}</button>
       </form>
     {:else}
-      <section class="twitch-box">
-        <div>
-          <p class="twitch-title">Connect Twitch</p>
-          {#if twitchStatus.connected}
-            <p class="muted">Linked as <strong>{twitchStatus.display_name || twitchStatus.login}</strong></p>
-          {:else}
-            <p class="muted">Link your Twitch account to auto-load followed channels and chat.</p>
-          {/if}
-        </div>
-        {#if twitchStatus.connected}
-          <button type="button" class="ghost" onclick={unlinkTwitch} disabled={isTwitchBusy}>
-            {isTwitchBusy ? 'Disconnecting...' : 'Disconnect Twitch'}
-          </button>
-        {:else}
-          <button type="button" onclick={connectTwitch}>Connect Twitch</button>
-        {/if}
-      </section>
-
       <div class="channels-header">
         <div class="channels-title-row">
           <span class="channels-label">Channels</span>
@@ -483,21 +482,32 @@
     margin-bottom: 1rem;
   }
 
-  .twitch-box {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-    margin: 0 0 1rem;
-    padding: 0.85rem;
-    border-radius: 0.8rem;
-    border: 1px solid rgba(121, 169, 255, 0.32);
-    background: linear-gradient(150deg, rgba(26, 42, 72, 0.55), rgba(20, 30, 46, 0.5));
+  .panel-title {
+    min-width: 0;
   }
 
-  .twitch-title {
-    margin: 0 0 0.25rem;
+  .header-subtle {
+    margin: 0.35rem 0 0;
+    color: #b6c4de;
+    font-size: 0.86rem;
+  }
+
+  .header-subtle strong {
+    color: #dce7fa;
     font-weight: 700;
+  }
+
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .compact {
+    padding: 0.52rem 0.8rem;
+    font-size: 0.9rem;
   }
 
   h1 {
@@ -860,9 +870,14 @@
       padding: 1rem;
     }
 
-    .twitch-box {
+    .panel-header {
       flex-direction: column;
       align-items: flex-start;
+    }
+
+    .header-actions {
+      width: 100%;
+      justify-content: flex-start;
     }
 
     .channel-card {


### PR DESCRIPTION
## Summary
- Improves watch-page playback latency behavior by tuning HLS live settings, adding guarded auto-catch-up, and preventing auto-catch-up from overriding manual seek actions.
- Upgrades chat composition UX with a rich inline emote composer, better local emote rendering, and picker behavior updates (including filtering unavailable emotes).
- Adds frontend live-status session caching and watch-page background refresh so returning from streams no longer forces cold live-status reloads.

## Validation
- `cargo fmt -- --check`
- `cargo check`
- `cargo clippy --all-targets --all-features`
- `cargo test`
- `pnpm run verify` (in `web/`)