### PR TITLE
feat: add GHCR publishing workflow and update auth handling

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -12,7 +12,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: wandabanet/twitch_relay
+  IMAGE_NAME: wandabastyle/twitch_relay
 
 jobs:
   publish:

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,38 @@
+name: Publish twitch_relay image to GHCR
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: wandabanet/twitch_relay
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        run: echo "${{ github.token }}" | docker login "$REGISTRY" -u "${{ github.actor }}" --password-stdin
+
+      - name: Build image
+        run: |
+          docker build \
+            -t "$REGISTRY/$IMAGE_NAME:latest" \
+            -t "$REGISTRY/$IMAGE_NAME:${{ github.sha }}" \
+            .
+
+      - name: Push image
+        run: |
+          docker push "$REGISTRY/$IMAGE_NAME:latest"
+          docker push "$REGISTRY/$IMAGE_NAME:${{ github.sha }}"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -525,7 +525,7 @@ mod tests {
         }
 
         fn read_current(&self) -> String {
-            fs::read_to_string(&self.path).expect("read current auth file")
+            fs::read_to_string(&self.path).unwrap_or_default()
         }
     }
 
@@ -569,6 +569,10 @@ mod tests {
 
         if matches!(resolved.state, PasswordState::GeneratedPersisted) {
             let saved = restore.read_current();
+            assert!(
+                !saved.trim().is_empty(),
+                "persisted auth file should not be empty"
+            );
             assert!(saved.contains("access_code_hash"));
         }
     }


### PR DESCRIPTION
- Added a GitHub Actions workflow to publish the \`twitch_relay\` image to GHCR.
- Modified the \`src/auth.rs\` file to handle an empty auth file gracefully by returning an empty string instead of panicking.
- Updated tests in \`src/auth.rs\` to validate that the persisted auth file is not empty.