### PR TITLE
refactor(docker-compose.yml): update service to use pre-built image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
 services:
   twitch-relay:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ghcr.io/wandabastyle/twitch_relay:latest
+    pull_policy: always
     container_name: twitch-relay
     restart: unless-stopped
     ports:


### PR DESCRIPTION
- Updated \`docker-compose.yml\` to use a pre-built image from \`ghcr.io/wandabastyle/twitch_relay:latest\`.
- Removed the build context and Dockerfile path as the image is now pulled directly.
- Added \`pull_policy: always\` to ensure the latest image version is used in all environments.