### PR TITLE
refactor(theme): apply Tokyo Night Moon styling across web UI

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -531,10 +531,19 @@ fn render_error_page(channel: &str, message: &str) -> Response {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Watch {channel}</title>
 <style>
+  /* Tokyo Night Moon theme tokens */
+  :root {{
+    --bg: #1e2030;
+    --bg-soft: #222436;
+    --surface: #2f334d;
+    --fg: #c8d3f5;
+    --muted: #a9b8e8;
+    --border: #444a73;
+  }}
   * {{ margin: 0; padding: 0; box-sizing: border-box; }}
   body {{
-    background: #0b0f14;
-    color: #f3f6fa;
+    background: var(--bg);
+    color: var(--fg);
     font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
     min-height: 100vh;
     display: flex;
@@ -542,7 +551,7 @@ fn render_error_page(channel: &str, message: &str) -> Response {
   }}
   header {{
     padding: 0.75rem 1rem;
-    border-bottom: 1px solid #2a3442;
+    border-bottom: 1px solid var(--border);
     display: flex;
     align-items: center;
     gap: 0.75rem;
@@ -558,13 +567,13 @@ fn render_error_page(channel: &str, message: &str) -> Response {
   .error-box {{
     text-align: center;
     max-width: 28rem;
-    background: rgba(20, 28, 43, 0.95);
-    border: 1px solid rgba(164, 182, 216, 0.25);
+    background: rgba(47, 51, 77, 0.95);
+    border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
     border-radius: 1rem;
     padding: 1.5rem;
   }}
   .error-box p {{
-    color: #9eb3d6;
+    color: var(--muted);
     line-height: 1.6;
   }}
 </style>

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -464,11 +464,25 @@
 {/if}
 
 <style>
+  /* Tokyo Night Moon theme tokens */
   :global(body) {
+    --bg: #1e2030;
+    --bg-soft: #222436;
+    --surface: #2f334d;
+    --surface-2: #3b4261;
+    --fg: #c8d3f5;
+    --muted: #a9b8e8;
+    --accent: #82aaff;
+    --accent-2: #c099ff;
+    --success: #c3e88d;
+    --warn: #ffc777;
+    --danger: #ff757f;
+    --border: #444a73;
+    --ring: rgba(130, 170, 255, 0.45);
     margin: 0;
     min-height: 100vh;
-    background: radial-gradient(circle at 20% -10%, #29324a 0%, #111722 45%, #090d14 100%);
-    color: #edf2fb;
+    background: radial-gradient(circle at 20% -10%, #3b4261 0%, #222436 45%, #1e2030 100%);
+    color: var(--fg);
     font-family: 'Space Grotesk', 'IBM Plex Sans', 'Noto Sans', sans-serif;
   }
 
@@ -494,8 +508,8 @@
 
   .panel {
     width: min(46rem, 100%);
-    background: linear-gradient(160deg, rgba(20, 28, 43, 0.95), rgba(13, 18, 28, 0.95));
-    border: 1px solid rgba(164, 182, 216, 0.25);
+    background: linear-gradient(160deg, rgba(47, 51, 77, 0.95), rgba(34, 36, 54, 0.95));
+    border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
     border-radius: 1rem;
     padding: 1.2rem;
     box-shadow: 0 1rem 2.5rem rgba(3, 8, 16, 0.45);
@@ -515,12 +529,12 @@
 
   .header-subtle {
     margin: 0.35rem 0 0;
-    color: #b6c4de;
+    color: var(--muted);
     font-size: 0.86rem;
   }
 
   .header-subtle strong {
-    color: #dce7fa;
+    color: var(--fg);
     font-weight: 700;
   }
 
@@ -548,7 +562,7 @@
     text-transform: uppercase;
     letter-spacing: 0.16em;
     font-size: 0.68rem;
-    color: #9cb2d7;
+    color: var(--muted);
   }
 
   .error {
@@ -557,12 +571,12 @@
     background: rgba(194, 67, 89, 0.18);
     border: 1px solid rgba(246, 135, 154, 0.45);
     border-radius: 0.6rem;
-    color: #ffd9e2;
+    color: color-mix(in srgb, var(--danger) 72%, white);
   }
 
   .muted {
     margin: 0;
-    color: #b6c4de;
+    color: var(--muted);
   }
 
   .login-form {
@@ -572,13 +586,13 @@
 
   .login-form label {
     font-weight: 600;
-    color: #d7e2f7;
+    color: var(--fg);
   }
 
   input {
     border: 1px solid rgba(160, 181, 216, 0.35);
     background: rgba(8, 12, 19, 0.9);
-    color: #f1f5ff;
+    color: var(--fg);
     border-radius: 0.6rem;
     padding: 0.7rem 0.8rem;
     font: inherit;
@@ -588,8 +602,8 @@
     border: 0;
     border-radius: 0.6rem;
     padding: 0.62rem 0.95rem;
-    background: linear-gradient(130deg, #ff6f61, #cf4f50);
-    color: #fff6f0;
+    background: var(--accent);
+    color: #1e2030;
     font: inherit;
     font-weight: 600;
     cursor: pointer;
@@ -603,7 +617,7 @@
   .ghost {
     background: transparent;
     border: 1px solid rgba(162, 182, 217, 0.35);
-    color: #d5e0f7;
+    color: var(--fg);
   }
 
   .channels-header {
@@ -621,14 +635,14 @@
 
   .channels-label {
     font-weight: 600;
-    color: #d7e2f7;
+    color: var(--fg);
   }
 
   .live-only-switch {
     display: inline-flex;
     align-items: center;
     gap: 0.45rem;
-    color: #bfd0ee;
+    color: var(--muted);
     font-size: 0.82rem;
     cursor: pointer;
     user-select: none;
@@ -636,7 +650,7 @@
   }
 
   .switch-text {
-    color: #c9d7ef;
+    color: var(--muted);
     letter-spacing: 0.01em;
   }
 
@@ -664,15 +678,15 @@
     width: 1.12rem;
     height: 1.12rem;
     border-radius: 50%;
-    background: #f7fbff;
+    background: var(--fg);
     box-shadow: 0 1px 5px rgba(0, 0, 0, 0.28);
     transform: translateX(0);
     transition: transform 0.18s ease;
   }
 
   .switch-input:checked + .switch-track {
-    background: linear-gradient(130deg, rgba(255, 111, 97, 0.95), rgba(207, 79, 80, 0.95));
-    border-color: rgba(255, 174, 164, 0.7);
+    background: color-mix(in srgb, var(--accent) 80%, var(--accent-2));
+    border-color: color-mix(in srgb, var(--accent) 68%, white);
   }
 
   .switch-input:checked + .switch-track .switch-knob {
@@ -694,21 +708,21 @@
 
   .live-status-warning {
     margin: 0 0 0.65rem;
-    color: #f3c78a;
+    color: var(--warn);
     font-size: 0.8rem;
   }
 
   .add-btn {
     background: transparent;
     border: 1px dashed rgba(162, 182, 217, 0.4);
-    color: #9cb2d7;
+    color: var(--muted);
     padding: 0.4rem 0.8rem;
     font-size: 0.85rem;
   }
 
   .add-btn:hover {
     border-color: rgba(162, 182, 217, 0.7);
-    color: #d5e0f7;
+    color: var(--fg);
   }
 
   .add-form {
@@ -761,7 +775,7 @@
     font-size: 0.9rem;
     font-weight: 600;
     text-transform: lowercase;
-    color: #f2f7ff;
+    color: var(--fg);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -778,7 +792,7 @@
 
   .channel-meta {
     margin: 0.2rem 0 0;
-    color: #99afcf;
+    color: var(--muted);
     font-size: 0.74rem;
     text-transform: uppercase;
     letter-spacing: 0.07em;
@@ -788,8 +802,8 @@
     display: inline-flex;
     align-items: center;
     gap: 0.3rem;
-    background: rgba(239, 68, 68, 0.9);
-    color: white;
+    background: color-mix(in srgb, var(--success) 86%, transparent);
+    color: #1e2030;
     font-size: 0.65rem;
     line-height: 1;
     font-weight: 700;
@@ -803,7 +817,7 @@
   .live-dot {
     width: 6px;
     height: 6px;
-    background: white;
+    background: #1e2030;
     border-radius: 50%;
     animation: pulse 1.5s ease-in-out infinite;
   }
@@ -817,7 +831,7 @@
     display: block;
     width: 100%;
     margin: 0.2rem 0 0;
-    color: #c5d0e8;
+    color: color-mix(in srgb, var(--fg) 85%, var(--muted));
     font-size: 0.82rem;
     white-space: nowrap;
     overflow: hidden;
@@ -827,7 +841,7 @@
 
   .channel-subtitle {
     margin: 0.15rem 0 0;
-    color: #9eb3d6;
+    color: var(--muted);
     font-size: 0.87rem;
   }
 
@@ -842,14 +856,14 @@
   .remove-btn {
     background: transparent;
     border: none;
-    color: #9eb3d6;
+    color: var(--muted);
     font-size: 1.4rem;
     padding: 0.2rem 0.5rem;
     line-height: 1;
   }
 
   .remove-btn:hover {
-    color: #ff6f61;
+    color: var(--danger);
   }
 
   .modal-overlay {
@@ -873,13 +887,13 @@
 
   .modal-text {
     margin: 0 0 1.25rem;
-    color: #edf2fb;
+    color: var(--fg);
     line-height: 1.5;
   }
 
   .modal-text strong {
     text-transform: lowercase;
-    color: #ff6f61;
+    color: var(--danger);
   }
 
   .modal-actions {
@@ -889,7 +903,7 @@
   }
 
   .danger {
-    background: linear-gradient(130deg, #c43f55, #a33545);
+    background: color-mix(in srgb, var(--danger) 92%, #1e2030);
   }
 
   @media (max-width: 600px) {

--- a/web/static/watch.css
+++ b/web/static/watch.css
@@ -1,7 +1,22 @@
+  /* Tokyo Night Moon theme tokens */
+  :root {
+    --bg: #1e2030;
+    --bg-soft: #222436;
+    --surface: #2f334d;
+    --surface-2: #3b4261;
+    --fg: #c8d3f5;
+    --muted: #a9b8e8;
+    --accent: #82aaff;
+    --accent-2: #c099ff;
+    --success: #c3e88d;
+    --warn: #ffc777;
+    --border: #444a73;
+    --ring: rgba(130, 170, 255, 0.45);
+  }
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body {
-    background: #0b0f14;
-    color: #f3f6fa;
+    background: var(--bg);
+    color: var(--fg);
     font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
     min-height: 100vh;
     display: flex;
@@ -19,7 +34,7 @@
   }
   header {
     padding: 0.75rem 1rem;
-    border-bottom: 1px solid #2a3442;
+    border-bottom: 1px solid var(--border);
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -35,20 +50,20 @@
     font-size: 1rem;
     font-weight: 700;
     text-transform: lowercase;
-    color: #f2f7ff;
+    color: var(--fg);
   }
   header span {
     font-size: 0.82rem;
-    color: #9cb2d7;
+    color: var(--muted);
   }
   .connect-twitch-btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border: 1px solid #456083;
+    border: 1px solid var(--border);
     border-radius: 6px;
-    background: #152338;
-    color: #d7e7ff;
+    background: var(--surface);
+    color: var(--fg);
     padding: 0.4rem 0.62rem;
     text-decoration: none;
     font-size: 0.82rem;
@@ -56,8 +71,8 @@
     white-space: nowrap;
   }
   .connect-twitch-btn:hover {
-    border-color: #6186b8;
-    background: #1d314d;
+    border-color: var(--accent);
+    background: var(--surface-2);
   }
   .connect-twitch-btn.hidden {
     display: none;
@@ -68,7 +83,7 @@
     background: #000;
     width: min(1280px, 100%);
     aspect-ratio: 16 / 9;
-    border: 1px solid #2a3442;
+    border: 1px solid var(--border);
     cursor: none;
   }
   .video-container.controls-visible {
@@ -77,8 +92,8 @@
   .chat-panel {
     width: min(360px, 38vw);
     min-width: 280px;
-    border: 1px solid #2a3442;
-    background: #0f141c;
+    border: 1px solid var(--border);
+    background: var(--bg-soft);
     display: flex;
     flex-direction: column;
     min-height: 200px;
@@ -89,8 +104,8 @@
   }
   .chat-header {
     padding: 0.65rem 0.75rem;
-    border-bottom: 1px solid #2a3442;
-    color: #b7c6df;
+    border-bottom: 1px solid var(--border);
+    color: var(--muted);
     font-size: 0.82rem;
   }
   .chat-messages {
@@ -118,21 +133,21 @@
     margin: 0 0.05em;
   }
   .chat-message .who {
-    color: #8eb6ff;
+    color: var(--accent);
     font-weight: 600;
     margin-right: 0.35rem;
   }
   .chat-message.notice .who {
-    color: #f3ba70;
+    color: var(--warn);
   }
   .chat-new-messages-pill {
     position: absolute;
     left: 50%;
     bottom: 3.6rem;
     transform: translateX(-50%);
-    border: 1px solid rgba(190, 209, 241, 0.22);
-    background: rgba(22, 27, 37, 0.96);
-    color: #eef4ff;
+    border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+    background: rgba(47, 51, 77, 0.96);
+    color: var(--fg);
     border-radius: 999px;
     padding: 0.34rem 0.78rem;
     font-size: 0.95rem;
@@ -146,15 +161,15 @@
     white-space: nowrap;
   }
   .chat-new-messages-pill:hover {
-    background: rgba(33, 41, 56, 0.98);
-    border-color: rgba(190, 209, 241, 0.38);
+    background: rgba(59, 66, 97, 0.98);
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
   }
   .chat-form {
     display: flex;
     flex-wrap: nowrap;
     align-items: center;
     gap: 0.45rem;
-    border-top: 1px solid #2a3442;
+    border-top: 1px solid var(--border);
     padding: 0.65rem;
     position: relative;
   }
@@ -162,23 +177,23 @@
     width: 2.15rem;
     height: 2.15rem;
     min-width: 2.15rem;
-    border: 1px solid #2f3f55;
-    background: #101824;
-    color: #d7e7ff;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--fg);
     border-radius: 6px;
     cursor: pointer;
     font-size: 1rem;
     line-height: 1;
   }
   .chat-emote-btn:hover {
-    border-color: #4d6487;
-    background: #172233;
+    border-color: var(--accent);
+    background: var(--surface-2);
   }
   .chat-input {
     flex: 1 1 0%;
-    background: #0b1017;
-    border: 1px solid #29374b;
-    color: #ecf4ff;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    color: var(--fg);
     border-radius: 6px;
     padding: 0.45rem 0.55rem;
     height: 2.15rem;
@@ -192,11 +207,12 @@
   }
   .chat-input:focus {
     outline: none;
-    border-color: #4b668d;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--ring);
   }
   .chat-input:empty::before {
     content: attr(data-placeholder);
-    color: #8ea3c5;
+    color: var(--muted);
     pointer-events: none;
   }
   .chat-input .composer-emote {
@@ -206,21 +222,24 @@
     margin: 0 0.06em;
   }
   .chat-send {
-    background: #2c65f5;
+    background: var(--accent);
     border: 0;
-    color: #f8fbff;
+    color: #1e2030;
     border-radius: 6px;
     padding: 0.45rem 0.75rem;
     font-weight: 600;
     cursor: pointer;
+  }
+  .chat-send:hover {
+    background: color-mix(in srgb, var(--accent) 85%, white);
   }
   .emote-popup {
     position: absolute;
     left: 0.65rem;
     right: 0.65rem;
     bottom: calc(100% + 0.5rem);
-    background: #0f141c;
-    border: 1px solid #2a3442;
+    background: var(--bg-soft);
+    border: 1px solid var(--border);
     border-radius: 8px;
     box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
     display: none;
@@ -234,9 +253,9 @@
   }
   .emote-search {
     margin: 0.6rem;
-    border: 1px solid #2f3f55;
-    background: #0b1017;
-    color: #ecf4ff;
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--fg);
     border-radius: 6px;
     padding: 0.45rem 0.55rem;
   }
@@ -250,7 +269,7 @@
     display: none;
   }
   .emote-group-title {
-    color: #97afcf;
+    color: var(--muted);
     font-size: 0.8rem;
     font-weight: 700;
     letter-spacing: 0.02em;
@@ -262,10 +281,10 @@
     gap: 0.35rem;
   }
   .emote-item {
-    border: 1px solid #2a3442;
+    border: 0;
     border-radius: 6px;
-    background: #101824;
-    color: #d7e7ff;
+    background: transparent;
+    color: var(--fg);
     min-height: 44px;
     height: 44px;
     display: flex;
@@ -276,15 +295,14 @@
   }
   .emote-item:hover,
   .emote-item.active {
-    border-color: #4b668d;
-    background: #182436;
+    background: color-mix(in srgb, var(--surface-2) 62%, transparent);
   }
   .emote-item img {
     max-height: 30px;
     max-width: 30px;
   }
   .emote-empty {
-    color: #9eb3d6;
+    color: var(--muted);
     font-size: 0.85rem;
     padding: 0.75rem 0.2rem;
   }
@@ -293,8 +311,8 @@
     left: 2.85rem;
     right: 0.65rem;
     bottom: calc(100% + 0.42rem);
-    border: 1px solid #2f3f55;
-    background: #0f141c;
+    border: 1px solid var(--border);
+    background: var(--bg-soft);
     border-radius: 6px;
     box-shadow: 0 8px 20px rgba(0,0,0,0.42);
     display: none;
@@ -308,11 +326,11 @@
     width: 10px;
   }
   .emote-suggestions::-webkit-scrollbar-thumb {
-    background: #3a4a61;
+    background: var(--surface-2);
     border-radius: 8px;
   }
   .emote-suggestions::-webkit-scrollbar-track {
-    background: #101722;
+    background: var(--bg);
   }
   .emote-suggestions.open {
     display: block;
@@ -323,12 +341,12 @@
     gap: 0.45rem;
     padding: 0.35rem 0.5rem;
     cursor: pointer;
-    color: #deebff;
+    color: var(--fg);
     font-size: 0.86rem;
   }
   .emote-suggestion:hover,
   .emote-suggestion.active {
-    background: #1a2537;
+    background: var(--surface);
   }
   .emote-suggestion img {
     height: 22px;
@@ -348,7 +366,7 @@
     bottom: 0;
     left: 0;
     right: 0;
-    background: linear-gradient(transparent, rgba(0,0,0,0.9));
+    background: linear-gradient(transparent, rgba(30, 32, 48, 0.92));
     padding: 20px 10px 8px;
     display: flex;
     align-items: center;
@@ -368,9 +386,9 @@
     gap: 8px;
   }
   .ctrl-btn {
-    background: transparent;
-    border: none;
-    color: white;
+    background: color-mix(in srgb, var(--surface) 45%, transparent);
+    border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+    color: var(--fg);
     cursor: pointer;
     padding: 6px;
     display: flex;
@@ -380,7 +398,8 @@
     transition: background 0.15s;
   }
   .ctrl-btn:hover {
-    background: rgba(255,255,255,0.2);
+    background: var(--surface);
+    border-color: var(--accent);
   }
   .ctrl-btn svg {
     width: 20px;
@@ -397,7 +416,7 @@
     transition: width 0.2s, opacity 0.2s;
     height: 4px;
     -webkit-appearance: none;
-    background: rgba(255,255,255,0.3);
+    background: color-mix(in srgb, var(--fg) 25%, transparent);
     border-radius: 2px;
     cursor: pointer;
   }
@@ -409,21 +428,21 @@
     -webkit-appearance: none;
     width: 12px;
     height: 12px;
-    background: white;
+    background: var(--fg);
     border-radius: 50%;
     cursor: pointer;
   }
   .time-display {
-    color: white;
+    color: var(--fg);
     font-size: 12px;
     font-variant-numeric: tabular-nums;
     min-width: 90px;
     text-align: center;
   }
   .quality-btn {
-    background: rgba(255,255,255,0.1);
-    border: none;
-    color: white;
+    background: color-mix(in srgb, var(--surface) 45%, transparent);
+    border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+    color: var(--fg);
     padding: 4px 10px;
     border-radius: 4px;
     cursor: pointer;
@@ -431,16 +450,18 @@
     transition: background 0.15s;
   }
   .quality-btn:hover {
-    background: rgba(255,255,255,0.2);
+    background: var(--surface);
+    border-color: var(--accent);
   }
   .go-live-btn {
     display: inline-flex;
-    background: rgba(239, 68, 68, 0.25);
-    border: 1px solid rgba(239, 68, 68, 0.55);
+    background: color-mix(in srgb, var(--success) 24%, transparent);
+    border: 1px solid color-mix(in srgb, var(--success) 56%, transparent);
   }
   .go-live-btn.live {
-    background: rgba(239, 68, 68, 0.4);
-    border-color: rgba(248, 113, 113, 0.75);
+    background: color-mix(in srgb, var(--success) 40%, transparent);
+    border-color: color-mix(in srgb, var(--success) 74%, transparent);
+    color: #1e2030;
   }
   .go-live-btn:disabled {
     opacity: 0.65;
@@ -450,7 +471,8 @@
     position: absolute;
     bottom: 50px;
     right: 8px;
-    background: rgba(20, 24, 32, 0.95);
+    background: rgba(34, 36, 54, 0.96);
+    border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
     border-radius: 6px;
     padding: 6px 0;
     min-width: 140px;
@@ -469,14 +491,14 @@
     justify-content: space-between;
   }
   .quality-menu-item:hover {
-    background: rgba(255, 255, 255, 0.1);
+    background: color-mix(in srgb, var(--surface) 75%, transparent);
   }
   .quality-menu-item.active {
-    color: #9147ff;
+    color: var(--accent-2);
     font-weight: 600;
   }
   .quality-menu-item .bitrate {
-    color: #9cb2d7;
+    color: var(--muted);
     font-size: 11px;
   }
   .progress-bar {
@@ -485,7 +507,7 @@
     left: 0;
     right: 0;
     height: 5px;
-    background: rgba(255,255,255,0.2);
+    background: color-mix(in srgb, var(--fg) 20%, transparent);
     cursor: pointer;
     z-index: 15;
     opacity: 0;
@@ -501,7 +523,7 @@
   }
   .progress-bar.disabled {
     cursor: not-allowed;
-    background: rgba(255,255,255,0.12);
+    background: color-mix(in srgb, var(--fg) 12%, transparent);
   }
   .progress-bar.disabled:hover {
     height: 5px;
@@ -515,118 +537,14 @@
     top: 0;
     left: 0;
     height: 100%;
-    background: rgba(255,255,255,0.3);
+    background: color-mix(in srgb, var(--fg) 32%, transparent);
   }
   .progress-played {
     position: absolute;
     top: 0;
     left: 0;
     height: 100%;
-    background: #9147ff;
-  }
-  .controls-left, .controls-right {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-  .ctrl-btn {
-    background: transparent;
-    border: none;
-    color: white;
-    cursor: pointer;
-    padding: 6px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 4px;
-    transition: background 0.15s;
-  }
-  .ctrl-btn:hover {
-    background: rgba(255,255,255,0.2);
-  }
-  .ctrl-btn svg {
-    width: 20px;
-    height: 20px;
-  }
-  .volume-control {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-  }
-  .volume-slider {
-    width: 0;
-    opacity: 0;
-    transition: width 0.2s, opacity 0.2s;
-    height: 4px;
-    -webkit-appearance: none;
-    background: rgba(255,255,255,0.3);
-    border-radius: 2px;
-    cursor: pointer;
-  }
-  .volume-control:hover .volume-slider {
-    width: 60px;
-    opacity: 1;
-  }
-  .volume-slider::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    width: 12px;
-    height: 12px;
-    background: white;
-    border-radius: 50%;
-    cursor: pointer;
-  }
-  .time-display {
-    color: white;
-    font-size: 12px;
-    font-variant-numeric: tabular-nums;
-    min-width: 90px;
-    text-align: center;
-  }
-  .quality-btn {
-    background: rgba(255,255,255,0.1);
-    border: none;
-    color: white;
-    padding: 4px 10px;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 12px;
-    transition: background 0.15s;
-  }
-  .quality-btn:hover {
-    background: rgba(255,255,255,0.2);
-  }
-  .quality-menu {
-    position: absolute;
-    bottom: 50px;
-    right: 8px;
-    background: rgba(20, 24, 32, 0.95);
-    border-radius: 6px;
-    padding: 6px 0;
-    min-width: 140px;
-    display: none;
-    z-index: 20;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.5);
-  }
-  .quality-menu.open {
-    display: block;
-  }
-  .quality-menu-item {
-    padding: 8px 14px;
-    cursor: pointer;
-    font-size: 13px;
-    display: flex;
-    justify-content: space-between;
-  }
-  .quality-menu-item:hover {
-    background: rgba(255, 255, 255, 0.1);
-  }
-  .quality-menu-item.active {
-    color: #9147ff;
-    font-weight: 600;
-  }
-  .quality-menu-item .bitrate {
-    color: #9cb2d7;
-    font-size: 11px;
+    background: var(--accent);
   }
   @media (max-width: 700px) {
     .watch-shell {
@@ -658,7 +576,7 @@
     max-width: 28rem;
   }
   .error-box p {
-    color: #9eb3d6;
+    color: var(--muted);
     line-height: 1.6;
     margin-top: 0.5rem;
   }


### PR DESCRIPTION
## Summary
- apply a Tokyo Night Moon token palette across the dashboard and watch UI for a consistent visual language
- retheme watch controls/chat/pickers and the Rust-rendered watch error page to match the same colors and contrast model
- simplify button treatments and chat/emote picker chrome (flat send/watch accents, cleaner emote tiles) while keeping existing behavior

## Verification
- cargo check
- cargo clippy --all-targets --all-features
- cargo test
- pnpm run verify