### PR TITLE
Add explicit container user to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     image: ghcr.io/wandabastyle/twitch_relay:latest
     pull_policy: always
     container_name: twitch-relay
+    user: "1000:1000"
     restart: unless-stopped
     ports:
       - "18081:8080"


### PR DESCRIPTION
### Motivation
- Ensure the `twitch-relay` container runs as UID/GID 1000 instead of root when deployed via Docker Compose.

### Description
- Add `user: "1000:1000"` to the `twitch-relay` service in `docker-compose.yml` to enforce the UID/GID mapping.

### Testing
- Attempted to validate the compose file with `docker compose config >/tmp/compose.out` but it failed because `docker` is not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24dc202dc832893a6d9bc48f0d896)