### PR TITLE
feat(recording): add recording file deletion and overview functionality

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -313,6 +313,8 @@ struct UpsertRecordingRuleRequest {
     stop_when_offline: Option<bool>,
     #[serde(default)]
     max_duration_minutes: Option<u64>,
+    #[serde(default)]
+    keep_last_videos: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -500,12 +502,17 @@ async fn upsert_recording_rule(
         Err(_) => return error_response(StatusCode::BAD_REQUEST, "invalid quality"),
     };
 
+    if payload.keep_last_videos == Some(0) {
+        return error_response(StatusCode::BAD_REQUEST, "keep_last_videos must be >= 1");
+    }
+
     let rule = RecordingRule {
         channel_login,
         enabled: payload.enabled,
         quality,
         stop_when_offline: payload.stop_when_offline.unwrap_or(true),
         max_duration_minutes: payload.max_duration_minutes,
+        keep_last_videos: payload.keep_last_videos,
     };
 
     match recording_rules::upsert_rule(rule) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,7 +21,7 @@ use crate::{
     live_status::{LiveStatusResponse, LiveStatusService},
     playback::{PlaybackTicketError, PlaybackTicketService},
     prewarm::PrewarmCoordinator,
-    recording::{ActiveRecording, RecordingMode, RecordingService},
+    recording::{ActiveRecording, RecordingBucket, RecordingMode, RecordingService},
     recording_rules::{self, RecordingRule},
     recording_scheduler::RecordingScheduler,
     stream_proxy, twitch_auth,
@@ -134,6 +134,7 @@ pub fn build_router(config: &AppConfig, access_code_hash: String) -> Result<Rout
     let recording_routes = Router::new()
         .route("/api/recordings/start", post(start_recording))
         .route("/api/recordings/stop", post(stop_recording))
+        .route("/api/recordings/delete", post(delete_recording_file))
         .route("/api/recordings", get(get_recordings))
         .route("/api/recording-rules", get(get_recording_rules))
         .route("/api/recording-rules", post(upsert_recording_rule))
@@ -314,6 +315,13 @@ struct UpsertRecordingRuleRequest {
     max_duration_minutes: Option<u64>,
 }
 
+#[derive(Debug, Deserialize)]
+struct DeleteRecordingFileRequest {
+    bucket: String,
+    channel_login: String,
+    filename: String,
+}
+
 #[derive(Debug, Serialize)]
 struct RecordingRulesResponse {
     rules: Vec<RecordingRule>,
@@ -437,6 +445,31 @@ async fn get_recordings(State(state): State<RecordingState>) -> Json<RecordingsR
     })
 }
 
+async fn delete_recording_file(
+    State(state): State<RecordingState>,
+    Json(payload): Json<DeleteRecordingFileRequest>,
+) -> Response {
+    let bucket = match payload.bucket.as_str() {
+        "completed" => RecordingBucket::Completed,
+        "incomplete" => RecordingBucket::Incomplete,
+        _ => return error_response(StatusCode::BAD_REQUEST, "invalid recording bucket"),
+    };
+
+    match state
+        .service
+        .delete_recording_file(bucket, &payload.channel_login, &payload.filename)
+    {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(error) => {
+            let (status, message) = classify_recording_error(&error);
+            if status == StatusCode::INTERNAL_SERVER_ERROR {
+                tracing::error!(error = %error, "recording file delete failed");
+            }
+            error_response(status, message)
+        }
+    }
+}
+
 async fn get_recording_rules() -> Response {
     match recording_rules::load_rules() {
         Ok(rules) => (StatusCode::OK, Json(RecordingRulesResponse { rules })).into_response(),
@@ -518,6 +551,18 @@ fn classify_recording_error(error: &str) -> (StatusCode, &str) {
     }
     if error.contains("not active") {
         return (StatusCode::NOT_FOUND, "recording not active");
+    }
+    if error.contains("file not found") {
+        return (StatusCode::NOT_FOUND, "recording file not found");
+    }
+    if error.contains("filename cannot be empty") {
+        return (StatusCode::BAD_REQUEST, "filename cannot be empty");
+    }
+    if error.contains("invalid filename") {
+        return (StatusCode::BAD_REQUEST, "invalid filename");
+    }
+    if error.contains("delete failed") {
+        return (StatusCode::INTERNAL_SERVER_ERROR, "recording delete failed");
     }
     if error.contains("spawn failed") {
         return (StatusCode::BAD_GATEWAY, "streamlink spawn failed");

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,7 +41,6 @@ pub struct RecordingConfig {
     pub poll_interval_secs: u64,
     pub start_live_confirmations: u64,
     pub stop_offline_confirmations: u64,
-    pub max_duration_minutes: Option<u64>,
 }
 
 impl AppConfig {
@@ -100,7 +99,6 @@ impl AppConfig {
             start_live_confirmations: parse_u64("RECORDING_START_LIVE_CONFIRMATIONS")?.unwrap_or(2),
             stop_offline_confirmations: parse_u64("RECORDING_STOP_OFFLINE_CONFIRMATIONS")?
                 .unwrap_or(3),
-            max_duration_minutes: parse_u64("RECORDING_MAX_DURATION_MINUTES")?,
         };
 
         if recording.poll_interval_secs == 0 {

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -36,9 +36,25 @@ pub struct ActiveRecording {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RecordingFileEntry {
+    pub channel_login: String,
     pub filename: String,
     pub path_display: String,
     pub status: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum RecordingBucket {
+    Completed,
+    Incomplete,
+}
+
+impl RecordingBucket {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::Incomplete => "incomplete",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -231,6 +247,25 @@ impl RecordingService {
                 limit_per_bucket,
             ),
         }
+    }
+
+    pub fn delete_recording_file(
+        &self,
+        bucket: RecordingBucket,
+        channel_login: &str,
+        filename: &str,
+    ) -> Result<(), String> {
+        let channel_login = Self::normalize_channel_login(channel_login)?;
+        let filename = validate_recording_filename(filename)?;
+        let target_path = self
+            .channel_bucket_dir(bucket.as_str(), &channel_login)
+            .join(&filename);
+
+        if !target_path.exists() {
+            return Err("recording file not found".to_string());
+        }
+
+        fs::remove_file(&target_path).map_err(|error| format!("recording delete failed: {error}"))
     }
 
     async fn reconcile_exited_recordings(&self) {
@@ -451,29 +486,30 @@ fn sanitize_filename(value: &str) -> String {
 }
 
 fn list_recording_files(dir: &Path, status: &str, limit: usize) -> Vec<RecordingFileEntry> {
-    let mut entries = Vec::new();
+    let mut entries: Vec<(String, PathBuf)> = Vec::new();
     if let Ok(read) = fs::read_dir(dir) {
         for entry in read.flatten() {
             let path = entry.path();
             if path.is_file() {
-                entries.push(path);
+                entries.push(("unknown".to_string(), path));
                 continue;
             }
 
             if path.is_dir()
-                && let Ok(nested) = fs::read_dir(path)
+                && let Some(channel_login) = path.file_name().and_then(|f| f.to_str())
+                && let Ok(nested) = fs::read_dir(&path)
             {
                 for nested_entry in nested.flatten() {
                     let nested_path = nested_entry.path();
                     if nested_path.is_file() {
-                        entries.push(nested_path);
+                        entries.push((channel_login.to_string(), nested_path));
                     }
                 }
             }
         }
     }
 
-    entries.sort_by_key(|path| {
+    entries.sort_by_key(|(_, path)| {
         std::cmp::Reverse(
             fs::metadata(path)
                 .ok()
@@ -485,7 +521,8 @@ fn list_recording_files(dir: &Path, status: &str, limit: usize) -> Vec<Recording
     entries
         .into_iter()
         .take(limit)
-        .map(|path| RecordingFileEntry {
+        .map(|(channel_login, path)| RecordingFileEntry {
+            channel_login,
             filename: path
                 .file_name()
                 .and_then(|f| f.to_str())
@@ -495,6 +532,21 @@ fn list_recording_files(dir: &Path, status: &str, limit: usize) -> Vec<Recording
             status: status.to_string(),
         })
         .collect()
+}
+
+fn validate_recording_filename(filename: &str) -> Result<String, String> {
+    let trimmed = filename.trim();
+    if trimmed.is_empty() {
+        return Err("filename cannot be empty".to_string());
+    }
+    if trimmed.contains('/') || trimmed.contains('\\') {
+        return Err("invalid filename".to_string());
+    }
+    if trimmed == "." || trimmed == ".." {
+        return Err("invalid filename".to_string());
+    }
+
+    Ok(trimmed.to_string())
 }
 
 fn now_unix() -> u64 {

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -11,6 +11,8 @@ use serde::Serialize;
 use time::{OffsetDateTime, format_description};
 use tokio::{process::Command, sync::RwLock};
 
+use crate::recording_rules;
+
 const QUALITY_OPTIONS: [&str; 9] = [
     "best", "source", "1080p60", "1080p", "720p60", "720p", "480p", "360p", "160p",
 ];
@@ -211,6 +213,7 @@ impl RecordingService {
             );
             move_file_if_exists(&output_path, &final_path);
             tracing::info!(from = %output_path.display(), to = %final_path.display(), "recording moved to completed");
+            self.prune_completed_for_channel(&channel_login);
         }
 
         tracing::info!(channel = %channel_login, "recording stopped");
@@ -321,6 +324,7 @@ impl RecordingService {
                 .channel_bucket_dir("completed", channel_login)
                 .join(filename);
             move_file_if_exists(&output_path, &final_path);
+            self.prune_completed_for_channel(channel_login);
             tracing::info!(
                 channel = %channel_login,
                 status = ?exit,
@@ -417,6 +421,36 @@ impl RecordingService {
         self.recordings_dir
             .join(bucket)
             .join(sanitize_filename(channel_login))
+    }
+
+    fn prune_completed_for_channel(&self, channel_login: &str) {
+        let keep_last = match recording_rules::load_rules() {
+            Ok(rules) => rules
+                .into_iter()
+                .find(|rule| rule.channel_login == channel_login)
+                .and_then(|rule| rule.keep_last_videos),
+            Err(error) => {
+                tracing::warn!(
+                    channel = %channel_login,
+                    error = %error,
+                    "failed to load recording rules for pruning"
+                );
+                None
+            }
+        };
+
+        let Some(keep_last) = keep_last else {
+            return;
+        };
+
+        if keep_last == 0 {
+            return;
+        }
+
+        prune_completed_channel_dir(
+            &self.channel_bucket_dir("completed", channel_login),
+            keep_last as usize,
+        );
     }
 }
 
@@ -564,4 +598,35 @@ fn move_file_if_exists(from: &Path, to: &Path) -> bool {
         let _ = fs::create_dir_all(parent);
     }
     fs::rename(from, to).is_ok()
+}
+
+fn prune_completed_channel_dir(dir: &Path, keep_last: usize) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+
+    let mut files: Vec<PathBuf> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.is_file())
+        .collect();
+
+    files.sort_by_key(|path| {
+        std::cmp::Reverse(
+            fs::metadata(path)
+                .ok()
+                .and_then(|meta| meta.modified().ok())
+                .unwrap_or(SystemTime::UNIX_EPOCH),
+        )
+    });
+
+    for old_path in files.into_iter().skip(keep_last) {
+        if let Err(error) = fs::remove_file(&old_path) {
+            tracing::warn!(
+                path = %old_path.display(),
+                error = %error,
+                "failed to prune old completed recording"
+            );
+        }
+    }
 }

--- a/src/recording_rules.rs
+++ b/src/recording_rules.rs
@@ -10,6 +10,7 @@ pub struct RecordingRule {
     pub quality: String,
     pub stop_when_offline: bool,
     pub max_duration_minutes: Option<u64>,
+    pub keep_last_videos: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -63,6 +64,7 @@ pub fn upsert_rule(rule: RecordingRule) -> Result<RecordingRule, String> {
         existing.quality = updated.quality.clone();
         existing.stop_when_offline = updated.stop_when_offline;
         existing.max_duration_minutes = updated.max_duration_minutes;
+        existing.keep_last_videos = updated.keep_last_videos;
         updated = existing.clone();
     } else {
         rules.push(updated.clone());

--- a/src/recording_scheduler.rs
+++ b/src/recording_scheduler.rs
@@ -102,7 +102,7 @@ impl RecordingScheduler {
                             continue;
                         }
 
-                        let max_minutes = rule.max_duration_minutes.or(config.max_duration_minutes);
+                        let max_minutes = rule.max_duration_minutes;
                         if let Some(limit) = max_minutes {
                             let elapsed_secs =
                                 now_unix().saturating_sub(active_recording.started_at_unix);

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -37,6 +37,7 @@ export interface RecordingRule {
   quality: string;
   stop_when_offline: boolean;
   max_duration_minutes: number | null;
+  keep_last_videos: number | null;
 }
 
 export interface ActiveRecording {
@@ -374,6 +375,7 @@ export async function upsertRecordingRule(rule: {
   quality?: string;
   stop_when_offline?: boolean;
   max_duration_minutes?: number | null;
+  keep_last_videos?: number | null;
 }): Promise<RecordingRule> {
   const response = await request('/api/recording-rules', {
     method: 'POST',

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -50,6 +50,7 @@ export interface ActiveRecording {
 }
 
 export interface RecordingFileEntry {
+  channel_login: string;
   filename: string;
   path_display: string;
   status: string;
@@ -439,5 +440,22 @@ export async function stopRecording(channel_login: string): Promise<void> {
   if (!response.ok) {
     const payload = await safeJson(response);
     throw new Error(readError(payload));
+  }
+}
+
+export async function deleteRecordingFile(payload: {
+  bucket: 'completed' | 'incomplete';
+  channel_login: string;
+  filename: string;
+}): Promise<void> {
+  const response = await request('/api/recordings/delete', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    const body = await safeJson(response);
+    throw new Error(readError(body));
   }
 }

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -712,9 +712,24 @@
                         class="recording-delete-btn"
                         onclick={() => removeRecordingFile('completed', file)}
                         title="Delete recording"
+                        aria-label="Delete recording"
+                        aria-busy={deletingRecordingKey === deleteKey}
                         disabled={deletingRecordingKey === deleteKey}
                       >
-                        {deletingRecordingKey === deleteKey ? '...' : 'Del'}
+                        {#if deletingRecordingKey === deleteKey}
+                          <svg class="recording-delete-spinner" viewBox="0 0 24 24" aria-hidden="true">
+                            <circle cx="12" cy="12" r="8" class="spinner-track"></circle>
+                            <path d="M12 4a8 8 0 0 1 8 8" class="spinner-head"></path>
+                          </svg>
+                        {:else}
+                          <svg class="recording-delete-icon" viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="M9 4h6"></path>
+                            <path d="M5 7h14"></path>
+                            <path d="M7 7l1 12h8l1-12"></path>
+                            <path d="M10 10v6"></path>
+                            <path d="M14 10v6"></path>
+                          </svg>
+                        {/if}
                       </button>
                     </li>
                   {/each}
@@ -740,9 +755,24 @@
                         class="recording-delete-btn"
                         onclick={() => removeRecordingFile('incomplete', file)}
                         title="Delete recording"
+                        aria-label="Delete recording"
+                        aria-busy={deletingRecordingKey === deleteKey}
                         disabled={deletingRecordingKey === deleteKey}
                       >
-                        {deletingRecordingKey === deleteKey ? '...' : 'Del'}
+                        {#if deletingRecordingKey === deleteKey}
+                          <svg class="recording-delete-spinner" viewBox="0 0 24 24" aria-hidden="true">
+                            <circle cx="12" cy="12" r="8" class="spinner-track"></circle>
+                            <path d="M12 4a8 8 0 0 1 8 8" class="spinner-head"></path>
+                          </svg>
+                        {:else}
+                          <svg class="recording-delete-icon" viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="M9 4h6"></path>
+                            <path d="M5 7h14"></path>
+                            <path d="M7 7l1 12h8l1-12"></path>
+                            <path d="M10 10v6"></path>
+                            <path d="M14 10v6"></path>
+                          </svg>
+                        {/if}
                       </button>
                     </li>
                   {/each}
@@ -1179,6 +1209,34 @@
     border-color: color-mix(in srgb, var(--danger) 68%, white);
     color: var(--danger);
     background: rgba(35, 14, 22, 0.9);
+  }
+
+  .recording-delete-icon,
+  .recording-delete-spinner {
+    width: 0.95rem;
+    height: 0.95rem;
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 1.8;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .spinner-track {
+    opacity: 0.28;
+  }
+
+  .spinner-head {
+    opacity: 0.95;
+  }
+
+  .recording-delete-spinner {
+    animation: spin 0.8s linear infinite;
+  }
+
+  @keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
   }
 
   .add-form {

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -4,6 +4,7 @@
   import {
     addChannel,
     createWatchTicket,
+    deleteRecordingFile,
     disconnectTwitch,
     getChannels,
     getLiveStatus,
@@ -49,6 +50,8 @@
   let completedRecordings = $state<Array<RecordingFileEntry>>([]);
   let incompleteRecordings = $state<Array<RecordingFileEntry>>([]);
   let currentView = $state<'channels' | 'recordings'>('channels');
+  let recordingsChannelFilter = $state('all');
+  let deletingRecordingKey = $state<string | null>(null);
 
   let showAddForm = $state(false);
   let newChannelLogin = $state('');
@@ -222,6 +225,62 @@
 
   function latestThree<T>(entries: Array<T>): Array<T> {
     return entries.slice(0, 3);
+  }
+
+  function recordingsChannelOptions(): Array<string> {
+    const known: Record<string, true> = {};
+    for (const channel of channels) {
+      known[channel.login] = true;
+    }
+    for (const item of completedRecordings) {
+      known[item.channel_login] = true;
+    }
+    for (const item of incompleteRecordings) {
+      known[item.channel_login] = true;
+    }
+    for (const item of Object.values(activeRecordings)) {
+      known[item.channel_login] = true;
+    }
+    return Object.keys(known).sort((a, b) => a.localeCompare(b));
+  }
+
+  function withFilter<T extends { channel_login: string }>(entries: Array<T>): Array<T> {
+    if (recordingsChannelFilter === 'all') {
+      return entries;
+    }
+    return entries.filter((entry) => entry.channel_login === recordingsChannelFilter);
+  }
+
+  function shownEntries<T extends { channel_login: string }>(entries: Array<T>): Array<T> {
+    const filtered = withFilter(entries);
+    return recordingsChannelFilter === 'all' ? latestThree(filtered) : filtered;
+  }
+
+  function recordingDeleteKey(bucket: 'completed' | 'incomplete', file: RecordingFileEntry): string {
+    return `${bucket}:${file.channel_login}:${file.filename}`;
+  }
+
+  async function removeRecordingFile(bucket: 'completed' | 'incomplete', file: RecordingFileEntry): Promise<void> {
+    const shouldDelete = window.confirm(`Delete ${file.filename}?`);
+    if (!shouldDelete) {
+      return;
+    }
+
+    const key = recordingDeleteKey(bucket, file);
+    deletingRecordingKey = key;
+    errorMessage = null;
+    try {
+      await deleteRecordingFile({
+        bucket,
+        channel_login: file.channel_login,
+        filename: file.filename
+      });
+      await loadRecordingState();
+    } catch (err) {
+      errorMessage = readMessage(err, 'failed to delete recording');
+    } finally {
+      deletingRecordingKey = null;
+    }
   }
 
   function selectedQuality(channelLogin: string): string {
@@ -595,7 +654,12 @@
           {/if}
         </div>
       {:else}
-        {@const activeList = Object.values(activeRecordings)}
+        {@const activeList = withFilter(Object.values(activeRecordings))}
+        {@const completedList = withFilter(completedRecordings)}
+        {@const incompleteList = withFilter(incompleteRecordings)}
+        {@const shownActive = shownEntries(Object.values(activeRecordings))}
+        {@const shownCompleted = shownEntries(completedRecordings)}
+        {@const shownIncomplete = shownEntries(incompleteRecordings)}
         <div class="recordings-view">
           <div class="recordings-header">
             <div>
@@ -605,6 +669,17 @@
             <button type="button" class="ghost" onclick={backToChannels}>Back to channels</button>
           </div>
 
+          <div class="recordings-filter-row">
+            <label class="recordings-filter-label" for="recordings-filter">Filter by channel</label>
+            <select id="recordings-filter" class="recordings-filter-select" bind:value={recordingsChannelFilter}>
+              <option value="all">All channels</option>
+              {#each recordingsChannelOptions() as channelLogin (channelLogin)}
+                <option value={channelLogin}>{channelLogin}</option>
+              {/each}
+            </select>
+            <p class="recordings-filter-hint">All channels shows latest 3 per section.</p>
+          </div>
+
           <div class="recordings-grid">
             <section class="recordings-section">
               <h2>Active ({activeList.length})</h2>
@@ -612,7 +687,7 @@
                 <p class="muted">No active recordings right now.</p>
               {:else}
                 <ul class="recordings-list">
-                  {#each latestThree(activeList) as recording (recording.channel_login)}
+                  {#each shownActive as recording (recording.channel_login)}
                     <li>
                       <span class="entry-main">{recording.channel_login}</span>
                       <span class="entry-meta">{recording.mode} · {recording.quality}</span>
@@ -623,15 +698,27 @@
             </section>
 
             <section class="recordings-section">
-              <h2>Completed ({completedRecordings.length})</h2>
-              {#if completedRecordings.length === 0}
+              <h2>Completed ({completedList.length})</h2>
+              {#if completedList.length === 0}
                 <p class="muted">No completed files yet.</p>
               {:else}
                 <ul class="recordings-list">
-                  {#each latestThree(completedRecordings) as file (file.path_display)}
-                    <li>
-                      <span class="entry-main" title={file.filename}>{file.filename}</span>
-                      <span class="entry-meta" title={file.path_display}>{file.path_display}</span>
+                  {#each shownCompleted as file (file.path_display)}
+                    {@const deleteKey = recordingDeleteKey('completed', file)}
+                    <li class="recordings-item-with-action">
+                      <div>
+                        <span class="entry-main" title={file.filename}>{file.filename}</span>
+                        <span class="entry-meta" title={file.path_display}>{file.path_display}</span>
+                      </div>
+                      <button
+                        type="button"
+                        class="recording-delete-btn"
+                        onclick={() => removeRecordingFile('completed', file)}
+                        title="Delete recording"
+                        disabled={deletingRecordingKey === deleteKey}
+                      >
+                        {deletingRecordingKey === deleteKey ? '...' : 'Del'}
+                      </button>
                     </li>
                   {/each}
                 </ul>
@@ -639,15 +726,27 @@
             </section>
 
             <section class="recordings-section">
-              <h2>Incomplete ({incompleteRecordings.length})</h2>
-              {#if incompleteRecordings.length === 0}
+              <h2>Incomplete ({incompleteList.length})</h2>
+              {#if incompleteList.length === 0}
                 <p class="muted">No incomplete files.</p>
               {:else}
                 <ul class="recordings-list">
-                  {#each latestThree(incompleteRecordings) as file (file.path_display)}
-                    <li>
-                      <span class="entry-main" title={file.filename}>{file.filename}</span>
-                      <span class="entry-meta" title={file.path_display}>{file.path_display}</span>
+                  {#each shownIncomplete as file (file.path_display)}
+                    {@const deleteKey = recordingDeleteKey('incomplete', file)}
+                    <li class="recordings-item-with-action">
+                      <div>
+                        <span class="entry-main" title={file.filename}>{file.filename}</span>
+                        <span class="entry-meta" title={file.path_display}>{file.path_display}</span>
+                      </div>
+                      <button
+                        type="button"
+                        class="recording-delete-btn"
+                        onclick={() => removeRecordingFile('incomplete', file)}
+                        title="Delete recording"
+                        disabled={deletingRecordingKey === deleteKey}
+                      >
+                        {deletingRecordingKey === deleteKey ? '...' : 'Del'}
+                      </button>
                     </li>
                   {/each}
                 </ul>
@@ -988,6 +1087,35 @@
     gap: 0.75rem;
   }
 
+  .recordings-filter-row {
+    display: grid;
+    gap: 0.35rem;
+    margin-top: -0.1rem;
+  }
+
+  .recordings-filter-label {
+    color: var(--muted);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .recordings-filter-select {
+    width: min(22rem, 100%);
+    border: 1px solid rgba(160, 181, 216, 0.35);
+    background: rgba(8, 12, 19, 0.9);
+    color: var(--fg);
+    border-radius: 0.6rem;
+    padding: 0.6rem 0.7rem;
+    font: inherit;
+  }
+
+  .recordings-filter-hint {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.78rem;
+  }
+
   .recordings-section {
     border: 1px solid rgba(156, 178, 215, 0.22);
     background: rgba(10, 16, 27, 0.78);
@@ -1014,6 +1142,12 @@
     gap: 0.1rem;
   }
 
+  .recordings-item-with-action {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
   .entry-main {
     font-size: 0.88rem;
     color: var(--fg);
@@ -1028,6 +1162,26 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .recording-delete-btn {
+    width: 2rem;
+    height: 2rem;
+    border: 1px solid rgba(160, 181, 216, 0.3);
+    border-radius: 0.55rem;
+    background: rgba(14, 22, 36, 0.92);
+    color: var(--muted);
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.9rem;
+  }
+
+  .recording-delete-btn:hover {
+    border-color: color-mix(in srgb, var(--danger) 68%, white);
+    color: var(--danger);
+    background: rgba(35, 14, 22, 0.9);
   }
 
   .add-form {

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -43,10 +43,8 @@
   let twitchStatus = $state<TwitchStatusResponse>({ connected: false, scopes: [] });
   let isTwitchBusy = $state(false);
   let appVersion = $state('?');
-  const QUALITY_OPTIONS = ['best', 'source', '1080p60', '1080p', '720p60', '720p', '480p', '360p', '160p'];
   let recordingRules = $state<Record<string, RecordingRule>>({});
   let activeRecordings = $state<Record<string, ActiveRecording>>({});
-  let selectedQualityByChannel = $state<Record<string, string>>({});
   let completedRecordings = $state<Array<RecordingFileEntry>>([]);
   let incompleteRecordings = $state<Array<RecordingFileEntry>>([]);
   let currentView = $state<'channels' | 'recordings'>('channels');
@@ -281,7 +279,7 @@
   }
 
   function selectedQuality(channelLogin: string): string {
-    return selectedQualityByChannel[channelLogin] || recordingRules[channelLogin]?.quality || 'best';
+    return recordingRules[channelLogin]?.quality || 'best';
   }
 
   async function toggleAutoRecord(channelLogin: string): Promise<void> {
@@ -293,7 +291,8 @@
         enabled,
         quality: selectedQuality(channelLogin),
         stop_when_offline: current?.stop_when_offline ?? true,
-        max_duration_minutes: current?.max_duration_minutes ?? null
+        max_duration_minutes: current?.max_duration_minutes ?? null,
+        keep_last_videos: current?.keep_last_videos ?? null
       });
       await loadRecordingRules();
     } catch (err) {
@@ -315,11 +314,8 @@
     }
   }
 
-  function onQualityChange(channelLogin: string, quality: string): void {
-    selectedQualityByChannel = {
-      ...selectedQualityByChannel,
-      [channelLogin]: quality
-    };
+  function openChannelSetup(channelLogin: string): void {
+    window.location.assign(`/channels/${channelLogin}`);
   }
 
   async function loadTwitchStatus(): Promise<void> {
@@ -562,7 +558,9 @@
 
               <div class="channel-main">
                 <div class="channel-main-top">
-                  <p class="channel-name">{status?.display_name || channel.display_name || channel.login}</p>
+                  <button type="button" class="channel-name" onclick={() => openChannelSetup(channel.login)}>
+                    {status?.display_name || channel.display_name || channel.login}
+                  </button>
                 </div>
                 <p class="channel-meta">{channel.source === 'manual' ? 'Manual' : channel.source === 'followed' ? 'Followed' : 'Manual + Followed'}</p>
                 <div class="channel-main-bottom">
@@ -623,16 +621,6 @@
                   >
                     ⬤
                   </button>
-                  <select
-                    class="quality-select"
-                    value={selectedQuality(channel.login)}
-                    onchange={(event) => onQualityChange(channel.login, (event.currentTarget as HTMLSelectElement).value)}
-                    aria-label={`Recording quality for ${channel.login}`}
-                  >
-                    {#each QUALITY_OPTIONS as quality (quality)}
-                      <option value={quality}>{quality}</option>
-                    {/each}
-                  </select>
                   </div>
                   {#if channel.removable}
                     <button
@@ -1321,6 +1309,9 @@
 
   .channel-name {
     margin: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
     font-size: 0.9rem;
     font-weight: 600;
     text-transform: lowercase;
@@ -1330,6 +1321,12 @@
     text-overflow: ellipsis;
     min-width: 0;
     flex: 1;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .channel-name:hover {
+    text-decoration: underline;
   }
 
   .channel-name-row {
@@ -1481,27 +1478,12 @@
     color: #fff;
   }
 
-  .quality-select {
-    width: 6.4rem;
-    height: var(--ctrl-h);
-    border: 1px solid var(--ctrl-border);
-    background: var(--ctrl-bg);
-    color: var(--ctrl-fg);
-    border-radius: var(--ctrl-r);
-    padding: 0 0.6rem;
-    font: inherit;
-    font-size: 0.86rem;
-    font-weight: 500;
-  }
-
-  .icon-btn:hover,
-  .quality-select:hover {
+  .icon-btn:hover {
     border-color: rgba(190, 206, 234, 0.52);
     background: color-mix(in srgb, var(--ctrl-bg) 82%, #101b30);
   }
 
   .icon-btn:focus-visible,
-  .quality-select:focus-visible,
   .watch-btn:focus-visible {
     outline: none;
     box-shadow: 0 0 0 3px rgba(130, 170, 255, 0.24);
@@ -1645,11 +1627,6 @@
       --ctrl-h: 2.15rem;
       --ctrl-r: 0.56rem;
       gap: 0.4rem;
-    }
-
-    .quality-select {
-      width: 5.8rem;
-      font-size: 0.82rem;
     }
 
     .watch-btn {

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -229,9 +229,6 @@
 
   function recordingsChannelOptions(): Array<string> {
     const known: Record<string, true> = {};
-    for (const channel of channels) {
-      known[channel.login] = true;
-    }
     for (const item of completedRecordings) {
       known[item.channel_login] = true;
     }

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1175,20 +1175,24 @@
     gap: 0.5rem;
   }
 
+  .recordings-item-with-action > div {
+    min-width: 0;
+  }
+
   .entry-main {
     font-size: 0.88rem;
     color: var(--fg);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 
   .entry-meta {
     font-size: 0.8rem;
     color: var(--muted);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 
   .recording-delete-btn {

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -22,6 +22,7 @@
     type ActiveRecording,
     type ChannelEntry,
     type ChannelStatus,
+    type RecordingFileEntry,
     type RecordingRule,
     type TwitchStatusResponse
   } from '$lib/api';
@@ -45,6 +46,9 @@
   let recordingRules = $state<Record<string, RecordingRule>>({});
   let activeRecordings = $state<Record<string, ActiveRecording>>({});
   let selectedQualityByChannel = $state<Record<string, string>>({});
+  let completedRecordings = $state<Array<RecordingFileEntry>>([]);
+  let incompleteRecordings = $state<Array<RecordingFileEntry>>([]);
+  let currentView = $state<'channels' | 'recordings'>('channels');
 
   let showAddForm = $state(false);
   let newChannelLogin = $state('');
@@ -200,9 +204,24 @@
         next[recording.channel_login] = recording;
       }
       activeRecordings = next;
+      completedRecordings = recordings.completed;
+      incompleteRecordings = recordings.incomplete;
     } catch {
       // ignore transient recording state failures
     }
+  }
+
+  function openRecordingsOverview(): void {
+    currentView = 'recordings';
+    showAddForm = false;
+  }
+
+  function backToChannels(): void {
+    currentView = 'channels';
+  }
+
+  function latestThree<T>(entries: Array<T>): Array<T> {
+    return entries.slice(0, 3);
   }
 
   function selectedQuality(channelLogin: string): string {
@@ -424,53 +443,59 @@
         <button type="submit" disabled={isBusy}>{isBusy ? 'Signing in...' : 'Sign in'}</button>
       </form>
     {:else}
-      <div class="channels-header">
-        <div class="channels-title-row">
-          <span class="channels-label">Channels</span>
-          <label class="live-only-switch" aria-label="Show only live channels">
-            <span class="switch-text">Live only</span>
-            <input class="switch-input" type="checkbox" bind:checked={liveOnly} onchange={onLiveOnlyChange} />
-            <span class="switch-track" aria-hidden="true">
-              <span class="switch-knob"></span>
-            </span>
-          </label>
+      {#if currentView === 'channels'}
+        <div class="channels-header">
+          <div class="channels-title-row">
+            <span class="channels-label">Channels</span>
+            <label class="live-only-switch" aria-label="Show only live channels">
+              <span class="switch-text">Live only</span>
+              <input class="switch-input" type="checkbox" bind:checked={liveOnly} onchange={onLiveOnlyChange} />
+              <span class="switch-track" aria-hidden="true">
+                <span class="switch-knob"></span>
+              </span>
+            </label>
+          </div>
+          <div class="channels-actions">
+            <button type="button" class="overview-btn" onclick={openRecordingsOverview}>
+              Recordings overview
+            </button>
+            {#if !showAddForm}
+              <button type="button" class="add-btn" onclick={() => showAddForm = true}>
+                + Add channel
+              </button>
+            {/if}
+          </div>
         </div>
-        {#if !showAddForm}
-          <button type="button" class="add-btn" onclick={() => showAddForm = true}>
-            + Add channel
-          </button>
+
+        {#if liveStatusError}
+          <p class="live-status-warning">{liveStatusError}</p>
         {/if}
-      </div>
 
-      {#if liveStatusError}
-        <p class="live-status-warning">{liveStatusError}</p>
-      {/if}
+        {#if showAddForm}
+          <form class="add-form" onsubmit={submitAddChannel}>
+            <input
+              type="text"
+              bind:value={newChannelLogin}
+              placeholder="channel_login"
+              autocomplete="off"
+              spellcheck="false"
+            />
+            <button type="submit" disabled={isAddingChannel}>
+              {isAddingChannel ? 'Adding...' : 'Add'}
+            </button>
+            <button type="button" class="ghost" onclick={cancelAddChannel}>
+              Cancel
+            </button>
+          </form>
+        {/if}
 
-      {#if showAddForm}
-        <form class="add-form" onsubmit={submitAddChannel}>
-          <input
-            type="text"
-            bind:value={newChannelLogin}
-            placeholder="channel_login"
-            autocomplete="off"
-            spellcheck="false"
-          />
-          <button type="submit" disabled={isAddingChannel}>
-            {isAddingChannel ? 'Adding...' : 'Add'}
-          </button>
-          <button type="button" class="ghost" onclick={cancelAddChannel}>
-            Cancel
-          </button>
-        </form>
-      {/if}
-
-      <div class="channels">
-        {#if visibleChannels().length === 0}
-          <p class="muted">{liveOnly ? 'No channels are live right now.' : 'No channels configured yet.'}</p>
-        {:else}
-          {#each visibleChannels() as channel (channel.login)}
-            {@const status = liveStatus[channel.login]}
-            <article class="channel-card">
+        <div class="channels">
+          {#if visibleChannels().length === 0}
+            <p class="muted">{liveOnly ? 'No channels are live right now.' : 'No channels configured yet.'}</p>
+          {:else}
+            {#each visibleChannels() as channel (channel.login)}
+              {@const status = liveStatus[channel.login]}
+              <article class="channel-card">
               <div class="channel-avatar-wrap">
                 {#if channel.image_url}
                   <img class="channel-avatar" src={channel.image_url} alt={channel.login} />
@@ -565,10 +590,72 @@
                   {/if}
                 </div>
               </div>
-            </article>
-          {/each}
-        {/if}
-      </div>
+              </article>
+            {/each}
+          {/if}
+        </div>
+      {:else}
+        {@const activeList = Object.values(activeRecordings)}
+        <div class="recordings-view">
+          <div class="recordings-header">
+            <div>
+              <p class="channels-label">Recordings overview</p>
+              <p class="recordings-subtle">Recent recording activity and files</p>
+            </div>
+            <button type="button" class="ghost" onclick={backToChannels}>Back to channels</button>
+          </div>
+
+          <div class="recordings-grid">
+            <section class="recordings-section">
+              <h2>Active ({activeList.length})</h2>
+              {#if activeList.length === 0}
+                <p class="muted">No active recordings right now.</p>
+              {:else}
+                <ul class="recordings-list">
+                  {#each latestThree(activeList) as recording (recording.channel_login)}
+                    <li>
+                      <span class="entry-main">{recording.channel_login}</span>
+                      <span class="entry-meta">{recording.mode} · {recording.quality}</span>
+                    </li>
+                  {/each}
+                </ul>
+              {/if}
+            </section>
+
+            <section class="recordings-section">
+              <h2>Completed ({completedRecordings.length})</h2>
+              {#if completedRecordings.length === 0}
+                <p class="muted">No completed files yet.</p>
+              {:else}
+                <ul class="recordings-list">
+                  {#each latestThree(completedRecordings) as file (file.path_display)}
+                    <li>
+                      <span class="entry-main" title={file.filename}>{file.filename}</span>
+                      <span class="entry-meta" title={file.path_display}>{file.path_display}</span>
+                    </li>
+                  {/each}
+                </ul>
+              {/if}
+            </section>
+
+            <section class="recordings-section">
+              <h2>Incomplete ({incompleteRecordings.length})</h2>
+              {#if incompleteRecordings.length === 0}
+                <p class="muted">No incomplete files.</p>
+              {:else}
+                <ul class="recordings-list">
+                  {#each latestThree(incompleteRecordings) as file (file.path_display)}
+                    <li>
+                      <span class="entry-main" title={file.filename}>{file.filename}</span>
+                      <span class="entry-meta" title={file.path_display}>{file.path_display}</span>
+                    </li>
+                  {/each}
+                </ul>
+              {/if}
+            </section>
+          </div>
+        </div>
+      {/if}
     {/if}
   </section>
 </main>
@@ -754,7 +841,16 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 0.6rem;
     margin-bottom: 0.75rem;
+  }
+
+  .channels-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
   }
 
   .channels-title-row {
@@ -850,9 +946,88 @@
     font-size: 0.85rem;
   }
 
+  .overview-btn {
+    background: transparent;
+    border: 1px solid rgba(162, 182, 217, 0.45);
+    color: var(--fg);
+    padding: 0.4rem 0.8rem;
+    font-size: 0.85rem;
+  }
+
   .add-btn:hover {
     border-color: rgba(162, 182, 217, 0.7);
     color: var(--fg);
+  }
+
+  .overview-btn:hover {
+    border-color: rgba(190, 206, 234, 0.72);
+    background: rgba(17, 26, 41, 0.72);
+  }
+
+  .recordings-view {
+    display: grid;
+    gap: 0.85rem;
+  }
+
+  .recordings-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.65rem;
+    flex-wrap: wrap;
+  }
+
+  .recordings-subtle {
+    margin: 0.3rem 0 0;
+    color: var(--muted);
+    font-size: 0.84rem;
+  }
+
+  .recordings-grid {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .recordings-section {
+    border: 1px solid rgba(156, 178, 215, 0.22);
+    background: rgba(10, 16, 27, 0.78);
+    border-radius: 0.75rem;
+    padding: 0.8rem;
+  }
+
+  .recordings-section h2 {
+    margin: 0 0 0.55rem;
+    font-size: 0.95rem;
+    font-weight: 700;
+  }
+
+  .recordings-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.45rem;
+  }
+
+  .recordings-list li {
+    display: grid;
+    gap: 0.1rem;
+  }
+
+  .entry-main {
+    font-size: 0.88rem;
+    color: var(--fg);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .entry-meta {
+    font-size: 0.8rem;
+    color: var(--muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .add-form {
@@ -1228,6 +1403,20 @@
 
     .channels-title-row {
       flex-wrap: wrap;
+    }
+
+    .channels-header {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .channels-actions {
+      width: 100%;
+      justify-content: flex-start;
+    }
+
+    .recordings-header {
+      align-items: flex-start;
     }
 
     .channel-actions {

--- a/web/src/routes/channels/[login]/+page.svelte
+++ b/web/src/routes/channels/[login]/+page.svelte
@@ -1,0 +1,364 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  import {
+    getChannels,
+    getRecordingRules,
+    upsertRecordingRule,
+    type RecordingRule
+  } from '$lib/api';
+
+  let { data } = $props<{ data: { login: string } }>();
+
+  const QUALITY_OPTIONS = ['best', 'source', '1080p60', '1080p', '720p60', '720p', '480p', '360p', '160p'];
+
+  const channelLogin = $derived(data.login.trim().toLowerCase());
+  let channelExists = $state(true);
+  let channelDisplayName = $state('');
+
+  let isLoading = $state(true);
+  let isSaving = $state(false);
+  let errorMessage = $state<string | null>(null);
+  let successMessage = $state<string | null>(null);
+
+  let enabled = $state(false);
+  let quality = $state('best');
+  let stopWhenOffline = $state(true);
+  let maxDurationMinutesInput = $state('');
+  let keepLastVideosInput = $state('');
+
+  onMount(async () => {
+    await loadPageState();
+  });
+
+  async function loadPageState(): Promise<void> {
+    isLoading = true;
+    errorMessage = null;
+    successMessage = null;
+
+    try {
+      const [channels, rules] = await Promise.all([getChannels(), getRecordingRules()]);
+      const channel = channels.find((entry) => entry.login === channelLogin);
+      channelExists = Boolean(channel);
+      channelDisplayName = channel?.display_name || channel?.login || channelLogin;
+
+      const rule = rules.find((entry) => entry.channel_login === channelLogin);
+      applyRule(rule || null);
+    } catch (err) {
+      errorMessage = readMessage(err, 'failed to load channel settings');
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  function applyRule(rule: RecordingRule | null): void {
+    if (!rule) {
+      enabled = false;
+      quality = 'best';
+      stopWhenOffline = true;
+      maxDurationMinutesInput = '';
+      keepLastVideosInput = '';
+      return;
+    }
+
+    enabled = rule.enabled;
+    quality = rule.quality || 'best';
+    stopWhenOffline = rule.stop_when_offline;
+    maxDurationMinutesInput = rule.max_duration_minutes == null ? '' : String(rule.max_duration_minutes);
+    keepLastVideosInput = rule.keep_last_videos == null ? '' : String(rule.keep_last_videos);
+  }
+
+  function parseOptionalPositiveInt(value: string, label: string): number | null {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    if (!/^\d+$/.test(trimmed)) {
+      throw new Error(`${label} must be a whole number`);
+    }
+
+    const parsed = Number(trimmed);
+    if (!Number.isSafeInteger(parsed) || parsed < 1) {
+      throw new Error(`${label} must be at least 1`);
+    }
+
+    return parsed;
+  }
+
+  async function saveSettings(event: SubmitEvent): Promise<void> {
+    event.preventDefault();
+    isSaving = true;
+    errorMessage = null;
+    successMessage = null;
+
+    try {
+      const maxDurationMinutes = parseOptionalPositiveInt(maxDurationMinutesInput, 'Max duration minutes');
+      const keepLastVideos = parseOptionalPositiveInt(keepLastVideosInput, 'Keep last videos');
+
+      const saved = await upsertRecordingRule({
+        channel_login: channelLogin,
+        enabled,
+        quality,
+        stop_when_offline: stopWhenOffline,
+        max_duration_minutes: maxDurationMinutes,
+        keep_last_videos: keepLastVideos
+      });
+
+      applyRule(saved);
+      successMessage = 'Saved';
+    } catch (err) {
+      errorMessage = readMessage(err, 'failed to save settings');
+    } finally {
+      isSaving = false;
+    }
+  }
+
+  function goBack(): void {
+    window.location.assign('/');
+  }
+
+  function readMessage(error: unknown, fallback: string): string {
+    if (error instanceof Error && error.message.trim().length > 0) {
+      return error.message;
+    }
+    return fallback;
+  }
+</script>
+
+<svelte:head>
+  <title>Channel Setup - Twitch Relay</title>
+</svelte:head>
+
+<main class="shell">
+  <section class="panel">
+    <header class="header">
+      <div>
+        <p class="eyebrow">Channel Settings</p>
+        <h1>{channelDisplayName}</h1>
+        <p class="subtle">Configure recording behavior for <strong>{channelLogin}</strong></p>
+      </div>
+      <button type="button" class="ghost" onclick={goBack}>Back to channels</button>
+    </header>
+
+    {#if errorMessage}
+      <p class="error" role="alert">{errorMessage}</p>
+    {/if}
+    {#if successMessage}
+      <p class="success" role="status">{successMessage}</p>
+    {/if}
+
+    {#if isLoading}
+      <p class="muted">Loading settings...</p>
+    {:else if !channelExists}
+      <p class="muted">This channel is not in your list. Add it on the front page first.</p>
+    {:else}
+      <form class="settings-form" onsubmit={saveSettings}>
+        <label class="toggle-row">
+          <input type="checkbox" bind:checked={enabled} />
+          <span>Enable auto-record</span>
+        </label>
+
+        <label>
+          Quality
+          <select bind:value={quality}>
+            {#each QUALITY_OPTIONS as option (option)}
+              <option value={option}>{option}</option>
+            {/each}
+          </select>
+        </label>
+
+        <label class="toggle-row">
+          <input type="checkbox" bind:checked={stopWhenOffline} />
+          <span>Stop when channel goes offline</span>
+        </label>
+
+        <label>
+          Max duration minutes
+          <input
+            type="number"
+            min="1"
+            step="1"
+            bind:value={maxDurationMinutesInput}
+            placeholder="Leave empty for no limit"
+            inputmode="numeric"
+          />
+        </label>
+
+        <label>
+          Keep last videos
+          <input
+            type="number"
+            min="1"
+            step="1"
+            bind:value={keepLastVideosInput}
+            placeholder="Leave empty for no limit"
+            inputmode="numeric"
+          />
+        </label>
+        <p class="hint">Applies to completed recordings only. Older completed files are deleted automatically.</p>
+
+        <div class="actions">
+          <button type="submit" disabled={isSaving}>{isSaving ? 'Saving...' : 'Save settings'}</button>
+        </div>
+      </form>
+    {/if}
+  </section>
+</main>
+
+<style>
+  :global(body) {
+    --bg: #1e2030;
+    --fg: #c8d3f5;
+    --muted: #a9b8e8;
+    --accent: #82aaff;
+    --danger: #ff757f;
+    --success: #c3e88d;
+    margin: 0;
+    min-height: 100vh;
+    background: radial-gradient(circle at 20% -10%, #3b4261 0%, #222436 45%, #1e2030 100%);
+    color: var(--fg);
+    font-family: 'Space Grotesk', 'IBM Plex Sans', 'Noto Sans', sans-serif;
+  }
+
+  .shell {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    padding: 2rem 1rem;
+  }
+
+  .panel {
+    width: min(42rem, 100%);
+    background: linear-gradient(160deg, rgba(47, 51, 77, 0.95), rgba(34, 36, 54, 0.95));
+    border: 1px solid rgba(68, 74, 115, 0.65);
+    border-radius: 1rem;
+    padding: 1.2rem;
+    box-shadow: 0 1rem 2.5rem rgba(3, 8, 16, 0.45);
+  }
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+  }
+
+  .eyebrow {
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    font-size: 0.68rem;
+    color: var(--muted);
+  }
+
+  h1 {
+    margin: 0.18rem 0 0;
+    font-size: clamp(1.45rem, 4vw, 1.9rem);
+    line-height: 1.1;
+    text-transform: lowercase;
+  }
+
+  .subtle {
+    margin: 0.35rem 0 0;
+    color: var(--muted);
+    font-size: 0.86rem;
+  }
+
+  .subtle strong {
+    color: var(--fg);
+  }
+
+  .settings-form {
+    display: grid;
+    gap: 0.8rem;
+  }
+
+  label {
+    display: grid;
+    gap: 0.35rem;
+    font-weight: 600;
+  }
+
+  .toggle-row {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    font-weight: 500;
+  }
+
+  input,
+  select {
+    border: 1px solid rgba(160, 181, 216, 0.35);
+    background: rgba(8, 12, 19, 0.9);
+    color: var(--fg);
+    border-radius: 0.6rem;
+    padding: 0.68rem 0.76rem;
+    font: inherit;
+  }
+
+  button {
+    border: 0;
+    border-radius: 0.6rem;
+    padding: 0.62rem 0.95rem;
+    background: var(--accent);
+    color: #1e2030;
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .ghost {
+    background: transparent;
+    border: 1px solid rgba(162, 182, 217, 0.35);
+    color: var(--fg);
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 0.2rem;
+  }
+
+  .hint,
+  .muted {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.84rem;
+  }
+
+  .error,
+  .success {
+    margin: 0 0 0.9rem;
+    border-radius: 0.6rem;
+    padding: 0.65rem 0.72rem;
+  }
+
+  .error {
+    background: rgba(194, 67, 89, 0.18);
+    border: 1px solid rgba(246, 135, 154, 0.45);
+    color: color-mix(in srgb, var(--danger) 72%, white);
+  }
+
+  .success {
+    background: rgba(129, 199, 132, 0.18);
+    border: 1px solid rgba(195, 232, 141, 0.45);
+    color: color-mix(in srgb, var(--success) 72%, white);
+  }
+
+  @media (max-width: 640px) {
+    .panel {
+      padding: 1rem;
+    }
+
+    .header {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .actions {
+      justify-content: flex-start;
+    }
+  }
+</style>

--- a/web/src/routes/channels/[login]/+page.ts
+++ b/web/src/routes/channels/[login]/+page.ts
@@ -1,0 +1,7 @@
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = ({ params }) => {
+  return {
+    login: params.login
+  };
+};


### PR DESCRIPTION
- Added a new endpoint \`/api/recordings/delete\` to handle the deletion of recording files.
- Updated \`recording.rs\` with a new enum \`RecordingBucket\` and methods to manage completed and incomplete recordings.
- Refactored \`list_recording_files\` to return a vector of tuples containing channel login and file paths.
- Added validation for recording filenames and updated error handling in file deletion.
- Implemented a function to prune old completed recordings based on the number of videos to keep.
- Updated the web API to include methods for deleting recording files and navigating between channels and recordings views.