### PR TITLE
feat(recording): add recording playback and playlist functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,6 +1706,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "toml",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread", "signal",
 tokio-stream = { version = "0.1.17", features = ["sync"] }
 tokio-tungstenite = { version = "0.28.0", features = ["rustls-tls-webpki-roots"] }
 tower-http = { version = "0.6.6", features = ["fs", "timeout", "trace"] }
+tower = "0.5.3"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt"] }
 directories = "5"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,9 +1,13 @@
-use std::path::PathBuf;
+use std::{
+    io::{Read, Seek, SeekFrom},
+    path::PathBuf,
+};
 
 use axum::{
+    body::Body,
     Json, Router,
     extract::{Path, Query, State},
-    http::HeaderMap,
+    http::{HeaderMap, HeaderValue, header},
     http::StatusCode,
     middleware,
     response::{Html, IntoResponse, Response},
@@ -135,6 +139,7 @@ pub fn build_router(config: &AppConfig, access_code_hash: String) -> Result<Rout
         .route("/api/recordings/start", post(start_recording))
         .route("/api/recordings/stop", post(stop_recording))
         .route("/api/recordings/delete", post(delete_recording_file))
+        .route("/api/recordings/play", get(play_recording_file))
         .route("/api/recordings", get(get_recordings))
         .route("/api/recording-rules", get(get_recording_rules))
         .route("/api/recording-rules", post(upsert_recording_rule))
@@ -214,10 +219,7 @@ pub fn build_router(config: &AppConfig, access_code_hash: String) -> Result<Rout
         .merge(stream_routes)
         .nest_service("/static/images", ServeDir::new(&images_path))
         .nest_service("/static", ServeDir::new(&assets_path))
-        .fallback_service(
-            ServeDir::new(&static_path)
-                .not_found_service(ServeFile::new(static_path.join("index.html"))),
-        );
+        .fallback_service(ServeDir::new(&static_path).fallback(ServeFile::new(static_path.join("index.html"))));
 
     Ok(router)
 }
@@ -320,6 +322,12 @@ struct UpsertRecordingRuleRequest {
 #[derive(Debug, Deserialize)]
 struct DeleteRecordingFileRequest {
     bucket: String,
+    channel_login: String,
+    filename: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PlayRecordingFileQuery {
     channel_login: String,
     filename: String,
 }
@@ -470,6 +478,162 @@ async fn delete_recording_file(
             error_response(status, message)
         }
     }
+}
+
+async fn play_recording_file(
+    State(state): State<RecordingState>,
+    Query(query): Query<PlayRecordingFileQuery>,
+    headers: HeaderMap,
+) -> Response {
+    let path = match state
+        .service
+        .resolve_completed_file_path(&query.channel_login, &query.filename)
+    {
+        Ok(path) => path,
+        Err(error) => {
+            let (status, message) = classify_recording_error(&error);
+            return error_response(status, message);
+        }
+    };
+
+    if !path.exists() {
+        return error_response(StatusCode::NOT_FOUND, "recording file not found");
+    }
+
+    let file_size = match std::fs::metadata(&path) {
+        Ok(meta) => meta.len(),
+        Err(error) => {
+            tracing::error!(error = %error, path = %path.display(), "failed to read recording metadata");
+            return error_response(StatusCode::INTERNAL_SERVER_ERROR, "recording playback failed");
+        }
+    };
+
+    let content_type = if path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("ts"))
+    {
+        HeaderValue::from_static("video/mp2t")
+    } else {
+        HeaderValue::from_static("application/octet-stream")
+    };
+
+    let range_header = headers
+        .get(header::RANGE)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+
+    let (start, end, partial) = match range_header {
+        Some(raw) => match parse_byte_range(&raw, file_size) {
+            Ok((start, end)) => (start, end, true),
+            Err(()) => {
+                let mut response = error_response(StatusCode::RANGE_NOT_SATISFIABLE, "invalid range");
+                if let Ok(value) = HeaderValue::from_str(&format!("bytes */{file_size}")) {
+                    response.headers_mut().insert(header::CONTENT_RANGE, value);
+                }
+                return response;
+            }
+        },
+        None => {
+            if file_size == 0 {
+                (0, 0, false)
+            } else {
+                (0, file_size - 1, false)
+            }
+        }
+    };
+
+    let length = if file_size == 0 { 0 } else { end - start + 1 };
+    let length_usize = match usize::try_from(length) {
+        Ok(value) => value,
+        Err(_) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "recording playback failed"),
+    };
+
+    let mut file = match std::fs::File::open(&path) {
+        Ok(file) => file,
+        Err(error) => {
+            tracing::error!(error = %error, path = %path.display(), "failed to open recording file");
+            return error_response(StatusCode::INTERNAL_SERVER_ERROR, "recording playback failed");
+        }
+    };
+
+    if let Err(error) = file.seek(SeekFrom::Start(start)) {
+        tracing::error!(error = %error, path = %path.display(), "failed to seek recording file");
+        return error_response(StatusCode::INTERNAL_SERVER_ERROR, "recording playback failed");
+    }
+
+    let mut chunk = Vec::with_capacity(length_usize);
+    if let Err(error) = file.take(length).read_to_end(&mut chunk) {
+        tracing::error!(error = %error, path = %path.display(), "failed to read recording file bytes");
+        return error_response(StatusCode::INTERNAL_SERVER_ERROR, "recording playback failed");
+    }
+
+    let mut response = if partial {
+        Response::builder().status(StatusCode::PARTIAL_CONTENT)
+    } else {
+        Response::builder().status(StatusCode::OK)
+    }
+    .header(header::ACCEPT_RANGES, "bytes")
+    .header(header::CONTENT_TYPE, content_type)
+    .header(header::CACHE_CONTROL, "no-store, no-cache, must-revalidate")
+    .header(header::PRAGMA, "no-cache")
+    .header(header::EXPIRES, "0")
+    .header(header::CONTENT_LENGTH, chunk.len().to_string());
+
+    if partial
+        && let Ok(value) = HeaderValue::from_str(&format!("bytes {start}-{end}/{file_size}"))
+    {
+        response = response.header(header::CONTENT_RANGE, value);
+    }
+
+    match response.body(Body::from(chunk)) {
+        Ok(response) => response.into_response(),
+        Err(error) => {
+            tracing::error!(error = %error, "failed to build playback response");
+            error_response(StatusCode::INTERNAL_SERVER_ERROR, "recording playback failed")
+        }
+    }
+}
+
+fn parse_byte_range(value: &str, file_size: u64) -> Result<(u64, u64), ()> {
+    if file_size == 0 {
+        return Err(());
+    }
+    let raw = value.trim();
+    let Some(range) = raw.strip_prefix("bytes=") else {
+        return Err(());
+    };
+    let Some((start_raw, end_raw)) = range.split_once('-') else {
+        return Err(());
+    };
+
+    if start_raw.is_empty() {
+        let suffix_len = end_raw.parse::<u64>().map_err(|_| ())?;
+        if suffix_len == 0 {
+            return Err(());
+        }
+        if suffix_len >= file_size {
+            return Ok((0, file_size - 1));
+        }
+        return Ok((file_size - suffix_len, file_size - 1));
+    }
+
+    let start = start_raw.parse::<u64>().map_err(|_| ())?;
+    if start >= file_size {
+        return Err(());
+    }
+
+    let end = if end_raw.is_empty() {
+        file_size - 1
+    } else {
+        end_raw.parse::<u64>().map_err(|_| ())?
+    };
+
+    if end < start {
+        return Err(());
+    }
+
+    Ok((start, end.min(file_size - 1)))
 }
 
 async fn get_recording_rules() -> Response {

--- a/src/app.rs
+++ b/src/app.rs
@@ -139,6 +139,7 @@ pub fn build_router(config: &AppConfig, access_code_hash: String) -> Result<Rout
         .route("/api/recordings/start", post(start_recording))
         .route("/api/recordings/stop", post(stop_recording))
         .route("/api/recordings/delete", post(delete_recording_file))
+        .route("/api/recordings/playlist.m3u8", get(play_recording_playlist))
         .route("/api/recordings/play", get(play_recording_file))
         .route("/api/recordings", get(get_recordings))
         .route("/api/recording-rules", get(get_recording_rules))
@@ -593,6 +594,52 @@ async fn play_recording_file(
             error_response(StatusCode::INTERNAL_SERVER_ERROR, "recording playback failed")
         }
     }
+}
+
+async fn play_recording_playlist(
+    State(state): State<RecordingState>,
+    Query(query): Query<PlayRecordingFileQuery>,
+) -> Response {
+    let path = match state
+        .service
+        .resolve_completed_file_path(&query.channel_login, &query.filename)
+    {
+        Ok(path) => path,
+        Err(error) => {
+            let (status, message) = classify_recording_error(&error);
+            return error_response(status, message);
+        }
+    };
+
+    if !path.exists() {
+        return error_response(StatusCode::NOT_FOUND, "recording file not found");
+    }
+
+    let media_uri = format!(
+        "/api/recordings/play?channel_login={}&filename={}",
+        query.channel_login, query.filename
+    );
+    let playlist = format!(
+        "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-PLAYLIST-TYPE:VOD\n#EXT-X-MEDIA-SEQUENCE:0\n#EXT-X-TARGETDURATION:600\n#EXTINF:600.0,\n{media_uri}\n#EXT-X-ENDLIST\n"
+    );
+
+    let mut response = Response::new(Body::from(playlist));
+    *response.status_mut() = StatusCode::OK;
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/vnd.apple.mpegurl"),
+    );
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("no-store, no-cache, must-revalidate"),
+    );
+    response
+        .headers_mut()
+        .insert(header::PRAGMA, HeaderValue::from_static("no-cache"));
+    response
+        .headers_mut()
+        .insert(header::EXPIRES, HeaderValue::from_static("0"));
+    response
 }
 
 fn parse_byte_range(value: &str, file_size: u64) -> Result<(u64, u64), ()> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,11 +4,11 @@ use std::{
 };
 
 use axum::{
-    body::Body,
     Json, Router,
+    body::Body,
     extract::{Path, Query, State},
-    http::{HeaderMap, HeaderValue, header},
     http::StatusCode,
+    http::{HeaderMap, HeaderValue, header},
     middleware,
     response::{Html, IntoResponse, Response},
     routing::{delete, get, post},
@@ -139,7 +139,10 @@ pub fn build_router(config: &AppConfig, access_code_hash: String) -> Result<Rout
         .route("/api/recordings/start", post(start_recording))
         .route("/api/recordings/stop", post(stop_recording))
         .route("/api/recordings/delete", post(delete_recording_file))
-        .route("/api/recordings/playlist.m3u8", get(play_recording_playlist))
+        .route(
+            "/api/recordings/playlist.m3u8",
+            get(play_recording_playlist),
+        )
         .route("/api/recordings/play", get(play_recording_file))
         .route("/api/recordings", get(get_recordings))
         .route("/api/recording-rules", get(get_recording_rules))
@@ -220,7 +223,9 @@ pub fn build_router(config: &AppConfig, access_code_hash: String) -> Result<Rout
         .merge(stream_routes)
         .nest_service("/static/images", ServeDir::new(&images_path))
         .nest_service("/static", ServeDir::new(&assets_path))
-        .fallback_service(ServeDir::new(&static_path).fallback(ServeFile::new(static_path.join("index.html"))));
+        .fallback_service(
+            ServeDir::new(&static_path).fallback(ServeFile::new(static_path.join("index.html"))),
+        );
 
     Ok(router)
 }
@@ -505,7 +510,10 @@ async fn play_recording_file(
         Ok(meta) => meta.len(),
         Err(error) => {
             tracing::error!(error = %error, path = %path.display(), "failed to read recording metadata");
-            return error_response(StatusCode::INTERNAL_SERVER_ERROR, "recording playback failed");
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "recording playback failed",
+            );
         }
     };
 
@@ -528,7 +536,8 @@ async fn play_recording_file(
         Some(raw) => match parse_byte_range(&raw, file_size) {
             Ok((start, end)) => (start, end, true),
             Err(()) => {
-                let mut response = error_response(StatusCode::RANGE_NOT_SATISFIABLE, "invalid range");
+                let mut response =
+                    error_response(StatusCode::RANGE_NOT_SATISFIABLE, "invalid range");
                 if let Ok(value) = HeaderValue::from_str(&format!("bytes */{file_size}")) {
                     response.headers_mut().insert(header::CONTENT_RANGE, value);
                 }
@@ -547,26 +556,40 @@ async fn play_recording_file(
     let length = if file_size == 0 { 0 } else { end - start + 1 };
     let length_usize = match usize::try_from(length) {
         Ok(value) => value,
-        Err(_) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, "recording playback failed"),
+        Err(_) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "recording playback failed",
+            );
+        }
     };
 
     let mut file = match std::fs::File::open(&path) {
         Ok(file) => file,
         Err(error) => {
             tracing::error!(error = %error, path = %path.display(), "failed to open recording file");
-            return error_response(StatusCode::INTERNAL_SERVER_ERROR, "recording playback failed");
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "recording playback failed",
+            );
         }
     };
 
     if let Err(error) = file.seek(SeekFrom::Start(start)) {
         tracing::error!(error = %error, path = %path.display(), "failed to seek recording file");
-        return error_response(StatusCode::INTERNAL_SERVER_ERROR, "recording playback failed");
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "recording playback failed",
+        );
     }
 
     let mut chunk = Vec::with_capacity(length_usize);
     if let Err(error) = file.take(length).read_to_end(&mut chunk) {
         tracing::error!(error = %error, path = %path.display(), "failed to read recording file bytes");
-        return error_response(StatusCode::INTERNAL_SERVER_ERROR, "recording playback failed");
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "recording playback failed",
+        );
     }
 
     let mut response = if partial {
@@ -581,8 +604,7 @@ async fn play_recording_file(
     .header(header::EXPIRES, "0")
     .header(header::CONTENT_LENGTH, chunk.len().to_string());
 
-    if partial
-        && let Ok(value) = HeaderValue::from_str(&format!("bytes {start}-{end}/{file_size}"))
+    if partial && let Ok(value) = HeaderValue::from_str(&format!("bytes {start}-{end}/{file_size}"))
     {
         response = response.header(header::CONTENT_RANGE, value);
     }
@@ -591,7 +613,10 @@ async fn play_recording_file(
         Ok(response) => response.into_response(),
         Err(error) => {
             tracing::error!(error = %error, "failed to build playback response");
-            error_response(StatusCode::INTERNAL_SERVER_ERROR, "recording playback failed")
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "recording playback failed",
+            )
         }
     }
 }

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -258,17 +258,34 @@ impl RecordingService {
         channel_login: &str,
         filename: &str,
     ) -> Result<(), String> {
-        let channel_login = Self::normalize_channel_login(channel_login)?;
-        let filename = validate_recording_filename(filename)?;
-        let target_path = self
-            .channel_bucket_dir(bucket.as_str(), &channel_login)
-            .join(&filename);
+        let target_path = self.resolve_recording_file_path(bucket, channel_login, filename)?;
 
         if !target_path.exists() {
             return Err("recording file not found".to_string());
         }
 
         fs::remove_file(&target_path).map_err(|error| format!("recording delete failed: {error}"))
+    }
+
+    pub fn resolve_completed_file_path(
+        &self,
+        channel_login: &str,
+        filename: &str,
+    ) -> Result<PathBuf, String> {
+        self.resolve_recording_file_path(RecordingBucket::Completed, channel_login, filename)
+    }
+
+    fn resolve_recording_file_path(
+        &self,
+        bucket: RecordingBucket,
+        channel_login: &str,
+        filename: &str,
+    ) -> Result<PathBuf, String> {
+        let channel_login = Self::normalize_channel_login(channel_login)?;
+        let filename = validate_recording_filename(filename)?;
+        Ok(self
+            .channel_bucket_dir(bucket.as_str(), &channel_login)
+            .join(filename))
     }
 
     async fn reconcile_exited_recordings(&self) {

--- a/src/templates/watch.html
+++ b/src/templates/watch.html
@@ -13,7 +13,10 @@
     <strong>__CHANNEL__</strong>
     <span>via Twitch Relay · v__APP_VERSION__</span>
   </div>
-  <a class="connect-twitch-btn hidden" id="connectTwitchBtn" href="/api/twitch/connect">Connect Twitch</a>
+  <div class="header-actions">
+    <a class="nav-chip-btn" href="/?view=channels">Back to channels</a>
+    <a class="nav-chip-btn hidden" id="connectTwitchBtn" href="/api/twitch/connect">Connect Twitch</a>
+  </div>
 </header>
 <main class="watch-shell">
   <div class="video-container" id="videoContainer">

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -847,10 +847,12 @@
   }
 
   .shell {
-    min-height: 100vh;
+    min-height: 100dvh;
+    box-sizing: border-box;
     display: grid;
-    place-items: center;
-    padding: 2rem 1rem 3rem;
+    justify-items: center;
+    align-content: start;
+    padding: 1rem 1rem 3rem;
   }
 
   .app-version {

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -62,9 +62,19 @@
 
   onMount(async () => {
     liveOnly = loadLiveOnlyPreference();
+    currentView = loadInitialViewFromQuery();
     void loadVersion();
     await initialize();
   });
+
+  function loadInitialViewFromQuery(): 'channels' | 'recordings' {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      return params.get('view') === 'recordings' ? 'recordings' : 'channels';
+    } catch {
+      return 'channels';
+    }
+  }
 
   async function loadVersion(): Promise<void> {
     try {
@@ -253,6 +263,14 @@
 
   function recordingDeleteKey(bucket: 'completed' | 'incomplete', file: RecordingFileEntry): string {
     return `${bucket}:${file.channel_login}:${file.filename}`;
+  }
+
+  function openRecordingPlayer(file: RecordingFileEntry): void {
+    const query = new URLSearchParams({
+      channel_login: file.channel_login,
+      filename: file.filename
+    });
+    window.location.assign(`/recordings/play?${query.toString()}`);
   }
 
   async function removeRecordingFile(bucket: 'completed' | 'incomplete', file: RecordingFileEntry): Promise<void> {
@@ -695,30 +713,41 @@
                         <span class="entry-main" title={file.filename}>{file.filename}</span>
                         <span class="entry-meta" title={file.path_display}>{file.path_display}</span>
                       </div>
-                      <button
-                        type="button"
-                        class="recording-delete-btn"
-                        onclick={() => removeRecordingFile('completed', file)}
-                        title="Delete recording"
-                        aria-label="Delete recording"
-                        aria-busy={deletingRecordingKey === deleteKey}
-                        disabled={deletingRecordingKey === deleteKey}
-                      >
-                        {#if deletingRecordingKey === deleteKey}
-                          <svg class="recording-delete-spinner" viewBox="0 0 24 24" aria-hidden="true">
-                            <circle cx="12" cy="12" r="8" class="spinner-track"></circle>
-                            <path d="M12 4a8 8 0 0 1 8 8" class="spinner-head"></path>
-                          </svg>
-                        {:else}
-                          <svg class="recording-delete-icon" viewBox="0 0 24 24" aria-hidden="true">
-                            <path d="M9 4h6"></path>
-                            <path d="M5 7h14"></path>
-                            <path d="M7 7l1 12h8l1-12"></path>
-                            <path d="M10 10v6"></path>
-                            <path d="M14 10v6"></path>
-                          </svg>
-                        {/if}
-                      </button>
+                      <div class="recording-item-actions">
+                        <button
+                          type="button"
+                          class="recording-play-btn"
+                          onclick={() => openRecordingPlayer(file)}
+                          title="Play recording"
+                          aria-label="Play recording"
+                        >
+                          Play
+                        </button>
+                        <button
+                          type="button"
+                          class="recording-delete-btn"
+                          onclick={() => removeRecordingFile('completed', file)}
+                          title="Delete recording"
+                          aria-label="Delete recording"
+                          aria-busy={deletingRecordingKey === deleteKey}
+                          disabled={deletingRecordingKey === deleteKey}
+                        >
+                          {#if deletingRecordingKey === deleteKey}
+                            <svg class="recording-delete-spinner" viewBox="0 0 24 24" aria-hidden="true">
+                              <circle cx="12" cy="12" r="8" class="spinner-track"></circle>
+                              <path d="M12 4a8 8 0 0 1 8 8" class="spinner-head"></path>
+                            </svg>
+                          {:else}
+                            <svg class="recording-delete-icon" viewBox="0 0 24 24" aria-hidden="true">
+                              <path d="M9 4h6"></path>
+                              <path d="M5 7h14"></path>
+                              <path d="M7 7l1 12h8l1-12"></path>
+                              <path d="M10 10v6"></path>
+                              <path d="M14 10v6"></path>
+                            </svg>
+                          {/if}
+                        </button>
+                      </div>
                     </li>
                   {/each}
                 </ul>
@@ -1161,6 +1190,28 @@
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
     gap: 0.5rem;
+  }
+
+  .recording-item-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .recording-play-btn {
+    height: 2rem;
+    border: 1px solid rgba(160, 181, 216, 0.3);
+    border-radius: 0.55rem;
+    background: rgba(14, 22, 36, 0.92);
+    color: var(--fg);
+    padding: 0 0.62rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+  }
+
+  .recording-play-btn:hover {
+    border-color: color-mix(in srgb, var(--accent) 68%, white);
+    background: color-mix(in srgb, var(--accent) 34%, #1b2436);
   }
 
   .recordings-item-with-action > div {

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -481,13 +481,13 @@
       {#if authMode === 'authenticated'}
         <div class="header-actions">
           {#if twitchStatus.connected}
-            <button type="button" class="ghost compact" onclick={unlinkTwitch} disabled={isTwitchBusy}>
+            <button type="button" class="nav-chip-btn" onclick={unlinkTwitch} disabled={isTwitchBusy}>
               {isTwitchBusy ? 'Disconnecting...' : 'Disconnect'}
             </button>
           {:else}
             <button type="button" class="compact" onclick={connectTwitch}>Connect Twitch</button>
           {/if}
-          <button class="ghost compact" onclick={signOut} disabled={isBusy}>
+          <button class="nav-chip-btn" onclick={signOut} disabled={isBusy}>
             Sign out
           </button>
         </div>
@@ -526,7 +526,7 @@
             </label>
           </div>
           <div class="channels-actions">
-            <button type="button" class="overview-btn" onclick={openRecordingsOverview}>
+            <button type="button" class="nav-chip-btn" onclick={openRecordingsOverview}>
               Recordings overview
             </button>
             {#if !showAddForm}
@@ -666,10 +666,10 @@
         <div class="recordings-view">
           <div class="recordings-header">
             <div>
-              <p class="channels-label">Recordings overview</p>
+              <span class="channels-label">Recordings overview</span>
               <p class="recordings-subtle">Recent recording activity and files</p>
             </div>
-            <button type="button" class="ghost" onclick={backToChannels}>Back to channels</button>
+            <button type="button" class="nav-chip-btn" onclick={backToChannels}>Back to channels</button>
           </div>
 
           <div class="recordings-filter-row">
@@ -1091,12 +1091,21 @@
     font-size: 0.85rem;
   }
 
-  .overview-btn {
+  .nav-chip-btn {
     background: transparent;
     border: 1px solid rgba(162, 182, 217, 0.45);
+    border-radius: 0.6rem;
     color: var(--fg);
     padding: 0.4rem 0.8rem;
+    font: inherit;
     font-size: 0.85rem;
+    font-weight: 600;
+    line-height: 1;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2rem;
   }
 
   .add-btn:hover {
@@ -1104,7 +1113,7 @@
     color: var(--fg);
   }
 
-  .overview-btn:hover {
+  .nav-chip-btn:hover {
     border-color: rgba(190, 206, 234, 0.72);
     background: rgba(17, 26, 41, 0.72);
   }

--- a/web/src/routes/channels/[login]/+page.svelte
+++ b/web/src/routes/channels/[login]/+page.svelte
@@ -222,10 +222,12 @@
   }
 
   .shell {
-    min-height: 100vh;
+    min-height: 100dvh;
+    box-sizing: border-box;
     display: grid;
-    place-items: center;
-    padding: 2rem 1rem;
+    justify-items: center;
+    align-content: start;
+    padding: 1rem;
   }
 
   .panel {

--- a/web/src/routes/channels/[login]/+page.svelte
+++ b/web/src/routes/channels/[login]/+page.svelte
@@ -138,7 +138,7 @@
         <h1>{channelDisplayName}</h1>
         <p class="subtle">Configure recording behavior for <strong>{channelLogin}</strong></p>
       </div>
-      <button type="button" class="ghost" onclick={goBack}>Back to channels</button>
+      <button type="button" class="nav-chip-btn" onclick={goBack}>Back to channels</button>
     </header>
 
     {#if errorMessage}
@@ -311,10 +311,26 @@
     cursor: pointer;
   }
 
-  .ghost {
+  .nav-chip-btn {
     background: transparent;
-    border: 1px solid rgba(162, 182, 217, 0.35);
+    border: 1px solid rgba(162, 182, 217, 0.45);
+    border-radius: 0.6rem;
     color: var(--fg);
+    padding: 0.4rem 0.8rem;
+    font: inherit;
+    font-size: 0.85rem;
+    font-weight: 600;
+    line-height: 1;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2rem;
+  }
+
+  .nav-chip-btn:hover {
+    border-color: rgba(190, 206, 234, 0.72);
+    background: rgba(17, 26, 41, 0.72);
   }
 
   .actions {

--- a/web/src/routes/recordings/play/+page.svelte
+++ b/web/src/routes/recordings/play/+page.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+  let channelLogin = $state('');
+  let filename = $state('');
+
+  function playbackUrl(): string {
+    const params = new URLSearchParams({
+      channel_login: channelLogin,
+      filename
+    });
+    return `/api/recordings/play?${params.toString()}`;
+  }
+
+  if (typeof window !== 'undefined') {
+    const params = new URLSearchParams(window.location.search);
+    channelLogin = params.get('channel_login') || '';
+    filename = params.get('filename') || '';
+  }
+
+  function goBack(): void {
+    window.location.assign('/?view=recordings');
+  }
+</script>
+
+<svelte:head>
+  <title>Recording Playback - Twitch Relay</title>
+</svelte:head>
+
+<main class="shell">
+  <section class="panel">
+    <header class="player-header">
+      <div>
+        <p class="eyebrow">Recording Playback</p>
+        <h1>{channelLogin || 'unknown channel'}</h1>
+        {#if filename}
+          <p class="subtle" title={filename}>{filename}</p>
+        {/if}
+      </div>
+      <button type="button" class="ghost" onclick={goBack}>Back to recordings</button>
+    </header>
+
+    {#if !channelLogin || !filename}
+      <p class="error">Missing recording playback parameters.</p>
+    {:else}
+      <!-- svelte-ignore a11y_media_has_caption -->
+      <video class="player" controls preload="metadata" src={playbackUrl()}>
+        Your browser cannot play this recording format.
+      </video>
+      <p class="hint">If playback fails, the browser may not support this stream container/codec combination.</p>
+    {/if}
+  </section>
+</main>
+
+<style>
+  :global(body) {
+    --bg: #1e2030;
+    --fg: #c8d3f5;
+    --muted: #a9b8e8;
+    --accent: #82aaff;
+    --danger: #ff757f;
+    margin: 0;
+    min-height: 100vh;
+    background: radial-gradient(circle at 20% -10%, #3b4261 0%, #222436 45%, #1e2030 100%);
+    color: var(--fg);
+    font-family: 'Space Grotesk', 'IBM Plex Sans', 'Noto Sans', sans-serif;
+  }
+
+  .shell {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    padding: 2rem 1rem;
+  }
+
+  .panel {
+    width: min(56rem, 100%);
+    background: linear-gradient(160deg, rgba(47, 51, 77, 0.95), rgba(34, 36, 54, 0.95));
+    border: 1px solid rgba(68, 74, 115, 0.65);
+    border-radius: 1rem;
+    padding: 1.2rem;
+    box-shadow: 0 1rem 2.5rem rgba(3, 8, 16, 0.45);
+    display: grid;
+    gap: 0.8rem;
+  }
+
+  .player-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .eyebrow {
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    font-size: 0.68rem;
+    color: var(--muted);
+  }
+
+  h1 {
+    margin: 0.18rem 0 0;
+    font-size: clamp(1.35rem, 3vw, 1.85rem);
+    line-height: 1.1;
+  }
+
+  .subtle {
+    margin: 0.35rem 0 0;
+    color: var(--muted);
+    font-size: 0.84rem;
+    overflow-wrap: anywhere;
+  }
+
+  .player {
+    width: 100%;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(156, 178, 215, 0.22);
+    background: #000;
+    min-height: 16rem;
+  }
+
+  .ghost {
+    background: transparent;
+    border: 1px solid rgba(162, 182, 217, 0.35);
+    color: var(--fg);
+    border-radius: 0.6rem;
+    padding: 0.58rem 0.86rem;
+    font: inherit;
+    cursor: pointer;
+  }
+
+  .hint {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.83rem;
+  }
+
+  .error {
+    margin: 0;
+    border-radius: 0.6rem;
+    padding: 0.65rem 0.72rem;
+    background: rgba(194, 67, 89, 0.18);
+    border: 1px solid rgba(246, 135, 154, 0.45);
+    color: color-mix(in srgb, var(--danger) 72%, white);
+  }
+</style>

--- a/web/src/routes/recordings/play/+page.svelte
+++ b/web/src/routes/recordings/play/+page.svelte
@@ -1,8 +1,50 @@
 <script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+
+  type HlsCtor = {
+    isSupported: () => boolean;
+    new (config?: Record<string, unknown>): {
+      attachMedia: (video: HTMLVideoElement) => void;
+      loadSource: (url: string) => void;
+      on: (event: string, handler: (...args: unknown[]) => void) => void;
+      destroy: () => void;
+    };
+    Events: {
+      MEDIA_ATTACHED: string;
+      ERROR: string;
+    };
+  };
+
   let channelLogin = $state('');
   let filename = $state('');
+  let playbackError = $state<string | null>(null);
 
-  function playbackUrl(): string {
+  let playerEl = $state<HTMLVideoElement | null>(null);
+  let hlsInstance: {
+    attachMedia: (video: HTMLVideoElement) => void;
+    loadSource: (url: string) => void;
+    on: (event: string, handler: (...args: unknown[]) => void) => void;
+    destroy: () => void;
+  } | null = null;
+
+  function getHlsCtor(): HlsCtor | null {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+
+    const candidate = (window as Window & { Hls?: HlsCtor }).Hls;
+    return candidate ?? null;
+  }
+
+  function playlistUrl(): string {
+    const params = new URLSearchParams({
+      channel_login: channelLogin,
+      filename
+    });
+    return `/api/recordings/playlist.m3u8?${params.toString()}`;
+  }
+
+  function rawPlaybackUrl(): string {
     const params = new URLSearchParams({
       channel_login: channelLogin,
       filename
@@ -19,10 +61,54 @@
   function goBack(): void {
     window.location.assign('/?view=recordings');
   }
+
+  function openRawStream(): void {
+    window.location.assign(rawPlaybackUrl());
+  }
+
+  onMount(() => {
+    if (!playerEl || !channelLogin || !filename) {
+      return;
+    }
+
+    const sourceUrl = playlistUrl();
+    playbackError = null;
+
+    if (playerEl.canPlayType('application/vnd.apple.mpegurl')) {
+      playerEl.src = sourceUrl;
+      return;
+    }
+
+    const Hls = getHlsCtor();
+    if (Hls?.isSupported()) {
+      hlsInstance = new Hls({
+        enableWorker: true
+      });
+      hlsInstance.attachMedia(playerEl);
+      hlsInstance.on(Hls.Events.MEDIA_ATTACHED, () => {
+        hlsInstance?.loadSource(sourceUrl);
+      });
+      hlsInstance.on(Hls.Events.ERROR, (_event, data) => {
+        const details = data as { fatal?: boolean };
+        if (details.fatal) {
+          playbackError = 'Playback failed for this recording. Try opening the raw stream instead.';
+        }
+      });
+      return;
+    }
+
+    playbackError = 'This browser does not support HLS playback.';
+  });
+
+  onDestroy(() => {
+    hlsInstance?.destroy();
+    hlsInstance = null;
+  });
 </script>
 
 <svelte:head>
   <title>Recording Playback - Twitch Relay</title>
+  <script src="/hls.js"></script>
 </svelte:head>
 
 <main class="shell">
@@ -41,11 +127,14 @@
     {#if !channelLogin || !filename}
       <p class="error">Missing recording playback parameters.</p>
     {:else}
-      <!-- svelte-ignore a11y_media_has_caption -->
-      <video class="player" controls preload="metadata" src={playbackUrl()}>
+      <video class="player" controls preload="metadata" bind:this={playerEl}>
         Your browser cannot play this recording format.
       </video>
-      <p class="hint">If playback fails, the browser may not support this stream container/codec combination.</p>
+      <p class="hint">Using HLS playback for better browser compatibility.</p>
+      {#if playbackError}
+        <p class="error" role="alert">{playbackError}</p>
+      {/if}
+      <button type="button" class="ghost raw-link" onclick={openRawStream}>Open raw TS stream</button>
     {/if}
   </section>
 </main>
@@ -65,14 +154,16 @@
   }
 
   .shell {
-    min-height: 100vh;
+    min-height: 100dvh;
+    box-sizing: border-box;
     display: grid;
-    place-items: center;
-    padding: 2rem 1rem;
+    justify-items: center;
+    align-content: start;
+    padding: 1rem;
   }
 
   .panel {
-    width: min(56rem, 100%);
+    width: min(74rem, 96vw);
     background: linear-gradient(160deg, rgba(47, 51, 77, 0.95), rgba(34, 36, 54, 0.95));
     border: 1px solid rgba(68, 74, 115, 0.65);
     border-radius: 1rem;
@@ -113,10 +204,11 @@
 
   .player {
     width: 100%;
-    border-radius: 0.75rem;
-    border: 1px solid rgba(156, 178, 215, 0.22);
+    border-radius: 0;
+    border: 1px solid rgba(180, 198, 236, 0.35);
     background: #000;
     min-height: 16rem;
+    object-fit: contain;
   }
 
   .ghost {
@@ -135,6 +227,12 @@
     font-size: 0.83rem;
   }
 
+  .raw-link {
+    width: fit-content;
+    font-size: 0.82rem;
+    padding: 0.45rem 0.72rem;
+  }
+
   .error {
     margin: 0;
     border-radius: 0.6rem;
@@ -142,5 +240,15 @@
     background: rgba(194, 67, 89, 0.18);
     border: 1px solid rgba(246, 135, 154, 0.45);
     color: color-mix(in srgb, var(--danger) 72%, white);
+  }
+
+  @media (min-width: 1100px) {
+    .shell {
+      padding: 0.75rem 1rem;
+    }
+
+    .player {
+      height: min(74vh, 52rem);
+    }
   }
 </style>

--- a/web/src/routes/recordings/play/+page.svelte
+++ b/web/src/routes/recordings/play/+page.svelte
@@ -121,7 +121,7 @@
           <p class="subtle" title={filename}>{filename}</p>
         {/if}
       </div>
-      <button type="button" class="ghost" onclick={goBack}>Back to recordings</button>
+      <button type="button" class="nav-chip-btn" onclick={goBack}>Back to recordings</button>
     </header>
 
     {#if !channelLogin || !filename}
@@ -134,7 +134,7 @@
       {#if playbackError}
         <p class="error" role="alert">{playbackError}</p>
       {/if}
-      <button type="button" class="ghost raw-link" onclick={openRawStream}>Open raw TS stream</button>
+      <button type="button" class="nav-chip-btn raw-link" onclick={openRawStream}>Open raw TS stream</button>
     {/if}
   </section>
 </main>
@@ -211,14 +211,26 @@
     object-fit: contain;
   }
 
-  .ghost {
+  .nav-chip-btn {
     background: transparent;
-    border: 1px solid rgba(162, 182, 217, 0.35);
-    color: var(--fg);
+    border: 1px solid rgba(162, 182, 217, 0.45);
     border-radius: 0.6rem;
-    padding: 0.58rem 0.86rem;
+    color: var(--fg);
+    padding: 0.4rem 0.8rem;
     font: inherit;
+    font-size: 0.85rem;
+    font-weight: 600;
+    line-height: 1;
     cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2rem;
+  }
+
+  .nav-chip-btn:hover {
+    border-color: rgba(190, 206, 234, 0.72);
+    background: rgba(17, 26, 41, 0.72);
   }
 
   .hint {

--- a/web/static/watch.css
+++ b/web/static/watch.css
@@ -40,6 +40,11 @@
     justify-content: space-between;
     flex-shrink: 0;
   }
+  .header-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
   .header-meta {
     display: flex;
     align-items: baseline;
@@ -56,25 +61,27 @@
     font-size: 0.82rem;
     color: var(--muted);
   }
-  .connect-twitch-btn {
+  .nav-chip-btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    background: var(--surface);
+    border: 1px solid rgba(162, 182, 217, 0.45);
+    border-radius: 0.6rem;
+    background: transparent;
     color: var(--fg);
-    padding: 0.4rem 0.62rem;
+    padding: 0.4rem 0.8rem;
     text-decoration: none;
-    font-size: 0.82rem;
+    font-size: 0.85rem;
     font-weight: 600;
+    line-height: 1;
+    min-height: 2rem;
     white-space: nowrap;
   }
-  .connect-twitch-btn:hover {
-    border-color: var(--accent);
-    background: var(--surface-2);
+  .nav-chip-btn:hover {
+    border-color: rgba(190, 206, 234, 0.72);
+    background: rgba(17, 26, 41, 0.72);
   }
-  .connect-twitch-btn.hidden {
+  .nav-chip-btn.hidden {
     display: none;
   }
   .video-container {


### PR DESCRIPTION
- Added support for HLS streaming and playlists in recording playback.
- Implemented new API endpoints \`/api/recordings/playlist.m3u8\` and \`/api/recordings/play\`.
- Refactored \`resolve_completed_file_path\` and \`resolve_recording_file_path\` in \`src/recording.rs\`.
- Updated the UI to include header actions with "Back to channels" button.
- Added a new route for playing recordings, accessible via \`/recordings/play\`.