### PR TITLE
chore(ci): update workflows for Node24-compatible action runtime

### DIFF
--- a/.github/workflows/app-checks.yml
+++ b/.github/workflows/app-checks.yml
@@ -1,5 +1,8 @@
 name: App Checks
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   pull_request:
     paths-ignore:
@@ -53,7 +56,7 @@ jobs:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/docker-checks.yml
+++ b/.github/workflows/docker-checks.yml
@@ -1,5 +1,8 @@
 name: Docker Checks
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
## Summary
- force GitHub JavaScript actions to run on Node 24 via workflow env
- upgrade `actions/setup-node` from v4 to v5 in App Checks
- keep existing CI triggers and verification commands unchanged