### PR TITLE
chore(ci): upgrade pnpm/action-setup to Node24-compatible v6

### DIFF
--- a/.github/workflows/app-checks.yml
+++ b/.github/workflows/app-checks.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6.0.4
         with:
           version: 10
 


### PR DESCRIPTION
## Summary
- bump `pnpm/action-setup` from `v4` to `v6.0.4`
- keep `version: 10` and existing CI commands unchanged
- remove remaining Node20 action deprecation path in web checks