### PR TITLE
chore(rust): upgrade rand to 0.9 and adapt generation helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.4",
+ "rand",
  "ring",
  "rustc-hash",
  "rustls",
@@ -952,33 +952,12 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1677,7 +1656,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -1696,7 +1675,7 @@ dependencies = [
  "directories",
  "dotenvy",
  "futures-util",
- "rand 0.8.6",
+ "rand",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ argon2 = "0.5.3"
 axum = "0.8.6"
 base64 = "0.22.1"
 futures-util = "0.3.31"
-rand = "0.8.5"
+rand = "0.9"
 reqwest = { version = "0.12.24", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -18,7 +18,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use directories::ProjectDirs;
-use rand::{Rng, distributions::Alphanumeric};
+use rand::{Rng, distr::Alphanumeric};
 use serde::{Deserialize, Serialize};
 
 use crate::error::AppError;
@@ -358,8 +358,8 @@ fn login_attempt_key(headers: &HeaderMap) -> String {
 }
 
 fn generate_session_token(length: usize) -> String {
-    rand::thread_rng()
-        .sample_iter(&Alphanumeric)
+    rand::rng()
+        .sample_iter(Alphanumeric)
         .take(length)
         .map(char::from)
         .collect()
@@ -462,8 +462,8 @@ pub fn load_or_initialize_access_code(rotate: bool) -> ResolvedAccessCode {
 }
 
 fn generate_access_code(length: usize) -> String {
-    rand::thread_rng()
-        .sample_iter(&Alphanumeric)
+    rand::rng()
+        .sample_iter(Alphanumeric)
         .take(length)
         .map(char::from)
         .collect()

--- a/src/playback.rs
+++ b/src/playback.rs
@@ -4,7 +4,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use rand::{Rng, distributions::Alphanumeric};
+use rand::{Rng, distr::Alphanumeric};
 use thiserror::Error;
 
 #[derive(Debug, Clone)]
@@ -105,8 +105,8 @@ impl PlaybackTicketService {
 }
 
 fn generate_ticket(length: usize) -> String {
-    rand::thread_rng()
-        .sample_iter(&Alphanumeric)
+    rand::rng()
+        .sample_iter(Alphanumeric)
         .take(length)
         .map(char::from)
         .collect()

--- a/src/secure_store.rs
+++ b/src/secure_store.rs
@@ -67,7 +67,7 @@ impl SecureStore {
         let plaintext =
             serde_json::to_vec(value).map_err(|e| format!("encode secure json failed: {e}"))?;
         let mut nonce_bytes = [0_u8; 12];
-        rand::thread_rng().fill_bytes(&mut nonce_bytes);
+        rand::rng().fill_bytes(&mut nonce_bytes);
         let ciphertext = self.encrypt(&nonce_bytes, &plaintext)?;
 
         let payload = EncryptedPayload {

--- a/src/twitch_auth.rs
+++ b/src/twitch_auth.rs
@@ -10,7 +10,7 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Redirect, Response},
 };
-use rand::{Rng, distributions::Alphanumeric};
+use rand::{Rng, distr::Alphanumeric};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
@@ -480,8 +480,8 @@ fn now_unix_secs() -> u64 {
 }
 
 fn generate_state(length: usize) -> String {
-    rand::thread_rng()
-        .sample_iter(&Alphanumeric)
+    rand::rng()
+        .sample_iter(Alphanumeric)
         .take(length)
         .map(char::from)
         .collect()


### PR DESCRIPTION
## Summary
- upgrade direct `rand` dependency from `0.8` to `0.9`
- update `Alphanumeric` import paths and RNG constructors at token/state/ticket generation call sites
- keep behavior unchanged while aligning with `rand 0.9` API

## Verification
- `cargo check`
- `cargo clippy --all-targets --all-features`
- `cargo test`