### PR TITLE
fix(docker-compose.yml): add Watchtower service for automatic image updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,22 @@ services:
       timeout: 5s
       retries: 3
       start_period: 15s
+    labels:
+      - com.centurylinklabs.watchtower.enable=true
+
+  watchtower:
+    image: containrrr/watchtower:latest
+    container_name: watchtower
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command:
+      - --label-enable
+      - --cleanup
+      - --interval
+      - "300"
+      - --stop-timeout
+      - "30s"
 
 volumes:
   twitch-relay-data:


### PR DESCRIPTION
- Added Watchtower service to automatically update Docker images
- Enabled Watchtower via labels on existing services
- Configured Watchtower to run every 5 minutes (300 seconds)
- Set stop timeout to 30 seconds for graceful container termination
- Mounted Docker socket to enable image updates
- Enabled label-based image update management