### PR TITLE
feat(recordings): add pin/unpin functionality

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -145,6 +145,8 @@ pub fn build_router(config: &AppConfig, access_code_hash: String) -> Result<Rout
     let recording_routes = Router::new()
         .route("/api/recordings/start", post(start_recording))
         .route("/api/recordings/stop", post(stop_recording))
+        .route("/api/recordings/pin", post(pin_recording_file))
+        .route("/api/recordings/unpin", post(unpin_recording_file))
         .route("/api/recordings/delete", post(delete_recording_file))
         .route(
             "/api/recordings/playlist.m3u8",
@@ -340,6 +342,13 @@ struct DeleteRecordingFileRequest {
 }
 
 #[derive(Debug, Deserialize)]
+struct PinRecordingFileRequest {
+    bucket: String,
+    channel_login: String,
+    filename: String,
+}
+
+#[derive(Debug, Deserialize)]
 struct PlayRecordingFileQuery {
     channel_login: String,
     filename: String,
@@ -487,6 +496,58 @@ async fn delete_recording_file(
             let (status, message) = classify_recording_error(&error);
             if status == StatusCode::INTERNAL_SERVER_ERROR {
                 tracing::error!(error = %error, "recording file delete failed");
+            }
+            error_response(status, message)
+        }
+    }
+}
+
+async fn pin_recording_file(
+    State(state): State<RecordingState>,
+    Json(payload): Json<PinRecordingFileRequest>,
+) -> Response {
+    if payload.bucket != "completed" {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "pinning is only supported for completed recordings",
+        );
+    }
+
+    match state
+        .service
+        .pin_recording_file(&payload.channel_login, &payload.filename)
+    {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(error) => {
+            let (status, message) = classify_recording_error(&error);
+            if status == StatusCode::INTERNAL_SERVER_ERROR {
+                tracing::error!(error = %error, "recording file pin failed");
+            }
+            error_response(status, message)
+        }
+    }
+}
+
+async fn unpin_recording_file(
+    State(state): State<RecordingState>,
+    Json(payload): Json<PinRecordingFileRequest>,
+) -> Response {
+    if payload.bucket != "completed" {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "unpinning is only supported for completed recordings",
+        );
+    }
+
+    match state
+        .service
+        .unpin_recording_file(&payload.channel_login, &payload.filename)
+    {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(error) => {
+            let (status, message) = classify_recording_error(&error);
+            if status == StatusCode::INTERNAL_SERVER_ERROR {
+                tracing::error!(error = %error, "recording file unpin failed");
             }
             error_response(status, message)
         }

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -53,6 +53,7 @@ pub struct RecordingFileEntry {
     pub filename: String,
     pub path_display: String,
     pub status: String,
+    pub pinned: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -308,9 +309,43 @@ impl RecordingService {
                 fs::remove_file(&nfo_path)
                     .map_err(|error| format!("recording delete failed: {error}"))?;
             }
+
+            let pin_path = pin_marker_path_for_recording(&target_path);
+            if pin_path.exists() {
+                fs::remove_file(&pin_path)
+                    .map_err(|error| format!("recording delete failed: {error}"))?;
+            }
         }
 
         Ok(())
+    }
+
+    pub fn pin_recording_file(&self, channel_login: &str, filename: &str) -> Result<(), String> {
+        let target_path =
+            self.resolve_recording_file_path(RecordingBucket::Completed, channel_login, filename)?;
+
+        if !target_path.exists() {
+            return Err("recording file not found".to_string());
+        }
+
+        let pin_path = pin_marker_path_for_recording(&target_path);
+        fs::write(&pin_path, b"pinned\n").map_err(|error| format!("recording pin failed: {error}"))
+    }
+
+    pub fn unpin_recording_file(&self, channel_login: &str, filename: &str) -> Result<(), String> {
+        let target_path =
+            self.resolve_recording_file_path(RecordingBucket::Completed, channel_login, filename)?;
+
+        if !target_path.exists() {
+            return Err("recording file not found".to_string());
+        }
+
+        let pin_path = pin_marker_path_for_recording(&target_path);
+        if !pin_path.exists() {
+            return Ok(());
+        }
+
+        fs::remove_file(&pin_path).map_err(|error| format!("recording unpin failed: {error}"))
     }
 
     pub fn resolve_completed_file_path(
@@ -981,6 +1016,7 @@ fn list_recording_files(dir: &Path, status: &str, limit: usize) -> Vec<Recording
                 .to_string(),
             path_display: path.display().to_string(),
             status: status.to_string(),
+            pinned: is_recording_pinned(&path),
         })
         .collect()
 }
@@ -1085,6 +1121,8 @@ fn prune_completed_channel_dir(dir: &Path, keep_last: usize) {
     let mut files: Vec<PathBuf> = Vec::new();
     collect_recording_media_paths(dir, &mut files);
 
+    files.retain(|path| !is_recording_pinned(path));
+
     files.sort_by_key(|path| {
         std::cmp::Reverse(
             fs::metadata(path)
@@ -1108,6 +1146,18 @@ fn prune_completed_channel_dir(dir: &Path, keep_last: usize) {
             let _ = fs::remove_file(nfo);
         }
     }
+}
+
+fn pin_marker_path_for_recording(recording_path: &Path) -> PathBuf {
+    let file_name = recording_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("recording");
+    recording_path.with_file_name(format!("{file_name}.pin"))
+}
+
+fn is_recording_pinned(recording_path: &Path) -> bool {
+    pin_marker_path_for_recording(recording_path).exists()
 }
 
 fn collect_recording_media_paths(dir: &Path, out: &mut Vec<PathBuf>) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -55,6 +55,7 @@ export interface RecordingFileEntry {
   filename: string;
   path_display: string;
   status: string;
+  pinned: boolean;
 }
 
 export interface RecordingsResponse {
@@ -451,6 +452,40 @@ export async function deleteRecordingFile(payload: {
   filename: string;
 }): Promise<void> {
   const response = await request('/api/recordings/delete', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    const body = await safeJson(response);
+    throw new Error(readError(body));
+  }
+}
+
+export async function pinRecordingFile(payload: {
+  bucket: 'completed';
+  channel_login: string;
+  filename: string;
+}): Promise<void> {
+  const response = await request('/api/recordings/pin', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    const body = await safeJson(response);
+    throw new Error(readError(body));
+  }
+}
+
+export async function unpinRecordingFile(payload: {
+  bucket: 'completed';
+  channel_login: string;
+  filename: string;
+}): Promise<void> {
+  const response = await request('/api/recordings/unpin', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(payload)

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -16,9 +16,11 @@
     getTwitchStatus,
     login,
     logout,
+    pinRecordingFile,
     removeChannel,
     startRecording,
     stopRecording,
+    unpinRecordingFile,
     upsertRecordingRule,
     type ActiveRecording,
     type ChannelEntry,
@@ -50,6 +52,7 @@
   let currentView = $state<'channels' | 'recordings'>('channels');
   let recordingsChannelFilter = $state('all');
   let deletingRecordingKey = $state<string | null>(null);
+  let pinningRecordingKey = $state<string | null>(null);
 
   let showAddForm = $state(false);
   let newChannelLogin = $state('');
@@ -293,6 +296,33 @@
       errorMessage = readMessage(err, 'failed to delete recording');
     } finally {
       deletingRecordingKey = null;
+    }
+  }
+
+  async function toggleRecordingPin(file: RecordingFileEntry): Promise<void> {
+    const key = recordingDeleteKey('completed', file);
+    pinningRecordingKey = key;
+    errorMessage = null;
+
+    try {
+      if (file.pinned) {
+        await unpinRecordingFile({
+          bucket: 'completed',
+          channel_login: file.channel_login,
+          filename: file.filename
+        });
+      } else {
+        await pinRecordingFile({
+          bucket: 'completed',
+          channel_login: file.channel_login,
+          filename: file.filename
+        });
+      }
+      await loadRecordingState();
+    } catch (err) {
+      errorMessage = readMessage(err, file.pinned ? 'failed to unpin recording' : 'failed to pin recording');
+    } finally {
+      pinningRecordingKey = null;
     }
   }
 
@@ -714,6 +744,18 @@
                         <span class="entry-meta" title={file.path_display}>{file.path_display}</span>
                       </div>
                       <div class="recording-item-actions">
+                        <button
+                          type="button"
+                          class="recording-pin-btn"
+                          onclick={() => toggleRecordingPin(file)}
+                          title={file.pinned ? 'Unpin recording' : 'Pin recording'}
+                          aria-label={file.pinned ? 'Unpin recording' : 'Pin recording'}
+                          aria-pressed={file.pinned}
+                          aria-busy={pinningRecordingKey === deleteKey}
+                          disabled={pinningRecordingKey === deleteKey}
+                        >
+                          {file.pinned ? '★' : '☆'}
+                        </button>
                         <button
                           type="button"
                           class="recording-play-btn"
@@ -1227,6 +1269,34 @@
 
   .recordings-item-with-action > div {
     min-width: 0;
+  }
+
+  .recording-pin-btn {
+    width: 2rem;
+    height: 2rem;
+    border: 1px solid rgba(160, 181, 216, 0.3);
+    border-radius: 0.55rem;
+    background: rgba(14, 22, 36, 0.92);
+    color: var(--muted);
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.9rem;
+    line-height: 1;
+    cursor: pointer;
+    transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+  }
+
+  .recording-pin-btn:hover {
+    border-color: color-mix(in srgb, var(--accent) 68%, white);
+    background: color-mix(in srgb, var(--accent) 34%, #1b2436);
+    color: var(--fg);
+  }
+
+  .recording-pin-btn:disabled {
+    opacity: 0.55;
+    cursor: progress;
   }
 
   .entry-main {

--- a/web/src/routes/channels/[login]/+page.svelte
+++ b/web/src/routes/channels/[login]/+page.svelte
@@ -68,8 +68,13 @@
     keepLastVideosInput = rule.keep_last_videos == null ? '' : String(rule.keep_last_videos);
   }
 
-  function parseOptionalPositiveInt(value: string, label: string): number | null {
-    const trimmed = value.trim();
+  function parseOptionalPositiveInt(
+    value: string | number | null | undefined,
+    label: string
+  ): number | null {
+    const normalized =
+      value == null ? '' : typeof value === 'number' ? String(value) : value;
+    const trimmed = normalized.trim();
     if (!trimmed) {
       return null;
     }


### PR DESCRIPTION
- Added endpoints for pinning and unpinning recordings in the API.
- Updated \`RecordingService\` to handle pinning and unpinning logic.
- Modified frontend to include buttons for toggling recording pins.
- Enhanced CSS styles for the new pin button.