### PR TITLE
refactor(src/app.rs): stream media files for playback improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,8 @@ services:
       STREAM_RESOLVER_MODE: streamlink # auto | native | streamlink
       TWITCH_CLIENT_ID: kimne78kx3ncx6brgo4mv6wki5h1ko
       # Playback range sizes (MiB)
-      PLAYBACK_INITIAL_RANGE_MB: 2
-      PLAYBACK_FOLLOWUP_RANGE_MB: 4
+      PLAYBACK_INITIAL_RANGE_MB: 8
+      PLAYBACK_FOLLOWUP_RANGE_MB: 8
       XDG_DATA_HOME: /data
       RECORDINGS_DIR: /app/recordings
       RECORDING_DEFAULT_QUALITY: best

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,6 @@ services:
       FFMPEG_PATH: ffmpeg
       RECORDING_CHAPTER_MIN_GAP_SECS: 180
       RECORDING_CHAPTER_CHANGE_CONFIRMATIONS: 2
-      RECORDING_HLS_SEGMENT_DURATION: 6
-      RECORDING_HLS_CACHE_TTL_SECS: 259200
     volumes:
       - twitch-relay-data:/data
       - ./recordings:/app/recordings

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
       STREAMLINK_PATH: streamlink
       STREAM_RESOLVER_MODE: streamlink # auto | native | streamlink
       TWITCH_CLIENT_ID: kimne78kx3ncx6brgo4mv6wki5h1ko
+      # Playback range sizes (MiB)
+      PLAYBACK_INITIAL_RANGE_MB: 2
+      PLAYBACK_FOLLOWUP_RANGE_MB: 4
       XDG_DATA_HOME: /data
       RECORDINGS_DIR: /app/recordings
       RECORDING_DEFAULT_QUALITY: best

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       STREAM_RESOLVER_MODE: streamlink # auto | native | streamlink
       TWITCH_CLIENT_ID: kimne78kx3ncx6brgo4mv6wki5h1ko
       # Playback range sizes (MiB)
-      PLAYBACK_INITIAL_RANGE_MB: 8
+      PLAYBACK_INITIAL_RANGE_MB: 16
       PLAYBACK_FOLLOWUP_RANGE_MB: 8
       XDG_DATA_HOME: /data
       RECORDINGS_DIR: /app/recordings

--- a/src/app.rs
+++ b/src/app.rs
@@ -560,7 +560,8 @@ async fn play_recording_asset(
     Query(query): Query<PlayRecordingAssetQuery>,
     headers: HeaderMap,
 ) -> Response {
-    const MAX_INITIAL_RANGE_BYTES: u64 = 8 * 1024 * 1024;
+    const INITIAL_RANGE_BYTES: u64 = 4 * 1024 * 1024;
+    const FOLLOWUP_RANGE_BYTES: u64 = 8 * 1024 * 1024;
 
     let media_path = match state
         .service
@@ -604,8 +605,13 @@ async fn play_recording_asset(
             Err(_) => return error_response(StatusCode::BAD_REQUEST, "invalid range start"),
         };
         let end: u64 = if end_str.is_empty() {
+            let max_open_ended_bytes = if start == 0 {
+                INITIAL_RANGE_BYTES
+            } else {
+                FOLLOWUP_RANGE_BYTES
+            };
             start
-                .saturating_add(MAX_INITIAL_RANGE_BYTES.saturating_sub(1))
+                .saturating_add(max_open_ended_bytes.saturating_sub(1))
                 .min(file_size.saturating_sub(1))
         } else {
             match end_str.parse() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -117,6 +117,8 @@ pub fn build_router(config: &AppConfig, access_code_hash: String) -> Result<Rout
     let recording_state = RecordingState {
         service: recording_service,
         default_quality: config.recording.default_quality.clone(),
+        playback_initial_range_bytes: config.playback.initial_range_bytes,
+        playback_followup_range_bytes: config.playback.followup_range_bytes,
     };
 
     let channel_routes = Router::new()
@@ -300,6 +302,8 @@ struct LiveStatusState {
 struct RecordingState {
     service: RecordingService,
     default_quality: String,
+    playback_initial_range_bytes: u64,
+    playback_followup_range_bytes: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -560,9 +564,6 @@ async fn play_recording_asset(
     Query(query): Query<PlayRecordingAssetQuery>,
     headers: HeaderMap,
 ) -> Response {
-    const INITIAL_RANGE_BYTES: u64 = 2 * 1024 * 1024;
-    const FOLLOWUP_RANGE_BYTES: u64 = 4 * 1024 * 1024;
-
     let media_path = match state
         .service
         .resolve_completed_file_path(&query.channel_login, &query.filename)
@@ -606,9 +607,9 @@ async fn play_recording_asset(
         };
         let end: u64 = if end_str.is_empty() {
             let max_open_ended_bytes = if start == 0 {
-                INITIAL_RANGE_BYTES
+                state.playback_initial_range_bytes
             } else {
-                FOLLOWUP_RANGE_BYTES
+                state.playback_followup_range_bytes
             };
             start
                 .saturating_add(max_open_ended_bytes.saturating_sub(1))

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use axum::{
     Json, Router,
-    body::Body,
+    body::{Body, Bytes},
     extract::{Path, Query, State},
     http::StatusCode,
     http::{HeaderMap, HeaderValue, header},
@@ -10,6 +10,7 @@ use axum::{
     response::{Html, IntoResponse, Response},
     routing::{delete, get, post},
 };
+use futures_util::stream;
 use serde::{Deserialize, Serialize};
 use tower_http::services::{ServeDir, ServeFile};
 
@@ -559,6 +560,8 @@ async fn play_recording_asset(
     Query(query): Query<PlayRecordingAssetQuery>,
     headers: HeaderMap,
 ) -> Response {
+    const MAX_INITIAL_RANGE_BYTES: u64 = 8 * 1024 * 1024;
+
     let media_path = match state
         .service
         .resolve_completed_file_path(&query.channel_login, &query.filename)
@@ -601,7 +604,9 @@ async fn play_recording_asset(
             Err(_) => return error_response(StatusCode::BAD_REQUEST, "invalid range start"),
         };
         let end: u64 = if end_str.is_empty() {
-            file_size - 1
+            start
+                .saturating_add(MAX_INITIAL_RANGE_BYTES.saturating_sub(1))
+                .min(file_size.saturating_sub(1))
         } else {
             match end_str.parse() {
                 Ok(v) => v,
@@ -614,8 +619,8 @@ async fn play_recording_asset(
         }
 
         let length = end - start + 1;
-        let bytes = match read_file_range(&media_path, start, length).await {
-            Ok(b) => b,
+        let media_stream = match stream_file_range(&media_path, start, length).await {
+            Ok(stream) => stream,
             Err(error) => {
                 tracing::error!(error = %error, path = %media_path.display(), "failed to read playback range");
                 return error_response(
@@ -626,7 +631,7 @@ async fn play_recording_asset(
         };
 
         let content_range = format!("bytes {start}-{end}/{file_size}");
-        let mut response = Response::new(Body::from(bytes));
+        let mut response = Response::new(Body::from_stream(media_stream));
         *response.status_mut() = StatusCode::PARTIAL_CONTENT;
         response
             .headers_mut()
@@ -644,8 +649,8 @@ async fn play_recording_asset(
             .insert(header::ACCEPT_RANGES, HeaderValue::from_static("bytes"));
         response
     } else {
-        let bytes = match tokio::fs::read(&media_path).await {
-            Ok(b) => b,
+        let media_stream = match stream_file_range(&media_path, 0, file_size).await {
+            Ok(stream) => stream,
             Err(error) => {
                 tracing::error!(error = %error, path = %media_path.display(), "failed to read playback media");
                 return error_response(
@@ -654,7 +659,7 @@ async fn play_recording_asset(
                 );
             }
         };
-        let mut response = Response::new(Body::from(bytes));
+        let mut response = Response::new(Body::from_stream(media_stream));
         *response.status_mut() = StatusCode::OK;
         response
             .headers_mut()
@@ -670,11 +675,14 @@ async fn play_recording_asset(
     }
 }
 
-async fn read_file_range(
+async fn stream_file_range(
     path: &std::path::Path,
     start: u64,
     length: u64,
-) -> Result<Vec<u8>, String> {
+) -> Result<
+    std::pin::Pin<Box<dyn futures_util::Stream<Item = Result<Bytes, std::io::Error>> + Send>>,
+    String,
+> {
     use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
     let mut file = tokio::fs::File::open(path)
@@ -683,13 +691,26 @@ async fn read_file_range(
     file.seek(std::io::SeekFrom::Start(start))
         .await
         .map_err(|error| format!("failed to seek playback media: {error}"))?;
-    let length_usize =
-        usize::try_from(length).map_err(|_| "requested playback range too large".to_string())?;
-    let mut out = vec![0_u8; length_usize];
-    file.read_exact(&mut out)
-        .await
-        .map_err(|error| format!("failed to read playback media range: {error}"))?;
-    Ok(out)
+    let stream = stream::try_unfold((file, length), |(mut file, remaining)| async move {
+        const CHUNK_SIZE: usize = 256 * 1024;
+
+        if remaining == 0 {
+            return Ok(None);
+        }
+
+        let next_len = usize::try_from(remaining.min(CHUNK_SIZE as u64)).unwrap_or(CHUNK_SIZE);
+        let mut chunk = vec![0_u8; next_len];
+        let read = file.read(&mut chunk).await?;
+        if read == 0 {
+            return Ok(None);
+        }
+        chunk.truncate(read);
+        let read_u64 = u64::try_from(read).unwrap_or(0);
+        let next_remaining = remaining.saturating_sub(read_u64);
+        Ok(Some((Bytes::from(chunk), (file, next_remaining))))
+    });
+
+    Ok(Box::pin(stream))
 }
 
 async fn get_recording_rules() -> Response {

--- a/src/app.rs
+++ b/src/app.rs
@@ -560,8 +560,8 @@ async fn play_recording_asset(
     Query(query): Query<PlayRecordingAssetQuery>,
     headers: HeaderMap,
 ) -> Response {
-    const INITIAL_RANGE_BYTES: u64 = 4 * 1024 * 1024;
-    const FOLLOWUP_RANGE_BYTES: u64 = 8 * 1024 * 1024;
+    const INITIAL_RANGE_BYTES: u64 = 2 * 1024 * 1024;
+    const FOLLOWUP_RANGE_BYTES: u64 = 4 * 1024 * 1024;
 
     let media_path = match state
         .service

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,11 @@ pub struct PlaybackConfig {
     pub stream_resolver_mode: String,
     pub stream_delivery_mode: String,
     pub twitch_client_id: String,
+    pub initial_range_bytes: u64,
+    pub followup_range_bytes: u64,
 }
+
+const MIB_BYTES: u64 = 1024 * 1024;
 
 #[derive(Debug, Clone)]
 pub struct TwitchOAuthConfig {
@@ -85,7 +89,28 @@ impl AppConfig {
                 .ok()
                 .filter(|v| !v.trim().is_empty())
                 .unwrap_or_else(|| "kimne78kx3ncx6brgo4mv6wki5h1ko".to_string()),
+            initial_range_bytes: parse_size_mib_or_bytes(
+                "PLAYBACK_INITIAL_RANGE_MB",
+                "PLAYBACK_INITIAL_RANGE_BYTES",
+            )?
+            .unwrap_or(2 * MIB_BYTES),
+            followup_range_bytes: parse_size_mib_or_bytes(
+                "PLAYBACK_FOLLOWUP_RANGE_MB",
+                "PLAYBACK_FOLLOWUP_RANGE_BYTES",
+            )?
+            .unwrap_or(4 * MIB_BYTES),
         };
+
+        if playback.initial_range_bytes == 0 {
+            return Err(AppError::Config(
+                "invalid PLAYBACK_INITIAL_RANGE_BYTES: must be >= 1".to_string(),
+            ));
+        }
+        if playback.followup_range_bytes == 0 {
+            return Err(AppError::Config(
+                "invalid PLAYBACK_FOLLOWUP_RANGE_BYTES: must be >= 1".to_string(),
+            ));
+        }
 
         let twitch_oauth = TwitchOAuthConfig {
             client_id: parse_required_string("TWITCH_OAUTH_CLIENT_ID")?,
@@ -193,4 +218,14 @@ fn parse_u64(name: &str) -> Result<Option<u64>, AppError> {
     raw.parse::<u64>()
         .map(Some)
         .map_err(|err| AppError::Config(format!("invalid {name}: {err}")))
+}
+
+fn parse_size_mib_or_bytes(mib_name: &str, bytes_name: &str) -> Result<Option<u64>, AppError> {
+    if let Some(mib) = parse_u64(mib_name)? {
+        return mib
+            .checked_mul(MIB_BYTES)
+            .map(Some)
+            .ok_or_else(|| AppError::Config(format!("invalid {mib_name}: value too large")));
+    }
+    parse_u64(bytes_name)
 }

--- a/web/src/routes/recordings/play/+page.svelte
+++ b/web/src/routes/recordings/play/+page.svelte
@@ -66,7 +66,7 @@
     {#if !channelLogin || !filename}
       <p class="error">Missing recording playback parameters.</p>
     {:else}
-      <video class="player" controls preload="metadata" bind:this={playerEl}>
+      <video class="player" controls preload="auto" bind:this={playerEl}>
         Your browser cannot play this recording format.
       </video>
       {#if playbackError}

--- a/web/src/routes/recordings/play/+page.svelte
+++ b/web/src/routes/recordings/play/+page.svelte
@@ -66,7 +66,7 @@
     {#if !channelLogin || !filename}
       <p class="error">Missing recording playback parameters.</p>
     {:else}
-      <video class="player" controls preload="auto" bind:this={playerEl}>
+      <video class="player" controls preload="metadata" bind:this={playerEl}>
         Your browser cannot play this recording format.
       </video>
       {#if playbackError}


### PR DESCRIPTION
- Updated the \`play_recording_asset\` function to handle file streaming instead of reading into memory.
- Added a constant \`MAX_INITIAL_RANGE_BYTES\` to limit initial range reads.
- Refactored \`read_file_range\` into \`stream_file_range\`, returning a stream of bytes rather than a single buffer.
- Optimized chunk size for efficient reading and streaming.