### PR TITLE
feat: add basic auth support for YouTube embeds

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,9 @@ pub struct AppConfig {
 pub struct InvidiousConfig {
     pub base_url: String,
     pub token: String,
+    pub sid_cookie: Option<String>,
+    pub basic_auth_user: Option<String>,
+    pub basic_auth_password: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -190,7 +193,30 @@ fn parse_invidious_config() -> Result<Option<InvidiousConfig>, AppError> {
         ));
     }
 
-    Ok(Some(InvidiousConfig { base_url, token }))
+    // Optional SID cookie for Invidious auth (preferred over Bearer token when using basic auth)
+    let sid_cookie = env::var("INVIDIOUS_SID")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty());
+
+    // Optional basic auth credentials for reverse proxy
+    let basic_auth_user = env::var("INVIDIOUS_BASIC_AUTH_USER")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty());
+
+    let basic_auth_password = env::var("INVIDIOUS_BASIC_AUTH_PASSWORD")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty());
+
+    Ok(Some(InvidiousConfig {
+        base_url,
+        token,
+        sid_cookie,
+        basic_auth_user,
+        basic_auth_password,
+    }))
 }
 
 fn parse_required_string(name: &str) -> Result<String, AppError> {

--- a/src/invidious.rs
+++ b/src/invidious.rs
@@ -21,6 +21,7 @@ pub struct InvidiousClient {
     http: reqwest::Client,
     avatar_cache: Arc<RwLock<HashMap<String, (String, Instant)>>>, // channel_id -> (url, fetched_at)
     description_cache: Arc<RwLock<HashMap<String, (String, Instant)>>>, // channel_id -> (description, fetched_at)
+    basic_auth: Option<(String, String)>, // (user, password) for reverse proxy
 }
 
 /// Normalized YouTube channel from Invidious subscriptions
@@ -153,8 +154,18 @@ impl InvidiousClient {
     /// Create a new Invidious client from config
     pub fn new(config: &InvidiousConfig) -> Self {
         let mut headers = HeaderMap::new();
+
+        // Add Bearer token for Invidious API auth (fallback if SID cookie not available)
         if let Ok(value) = HeaderValue::from_str(&format!("Bearer {}", config.token)) {
             headers.insert(AUTHORIZATION, value);
+        }
+
+        // Add SID cookie header for Invidious auth (preferred when using basic auth)
+        // This allows Authorization header to be used for reverse proxy basic auth
+        if let Some(ref sid) = config.sid_cookie
+            && let Ok(value) = HeaderValue::from_str(&format!("SID={}", sid))
+        {
+            headers.insert(reqwest::header::COOKIE, value);
         }
 
         let http = reqwest::Client::builder()
@@ -163,11 +174,27 @@ impl InvidiousClient {
             .build()
             .expect("failed to build reqwest client");
 
+        let basic_auth = config
+            .basic_auth_user
+            .as_ref()
+            .zip(config.basic_auth_password.as_ref())
+            .map(|(u, p)| (u.clone(), p.clone()));
+
         Self {
             base_url: config.base_url.clone(),
             http,
             avatar_cache: Arc::new(RwLock::new(HashMap::new())),
             description_cache: Arc::new(RwLock::new(HashMap::new())),
+            basic_auth,
+        }
+    }
+
+    /// Helper to apply basic auth to a request builder if configured
+    fn with_basic_auth(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if let Some((ref user, ref pass)) = self.basic_auth {
+            request.basic_auth(user, Some(pass))
+        } else {
+            request
         }
     }
 
@@ -176,8 +203,7 @@ impl InvidiousClient {
         let url = format!("{}/api/v1/auth/subscriptions", self.base_url);
 
         let response = self
-            .http
-            .get(&url)
+            .with_basic_auth(self.http.get(&url))
             .send()
             .await
             .map_err(map_reqwest_error)?;
@@ -265,8 +291,7 @@ impl InvidiousClient {
         );
 
         let response = self
-            .http
-            .get(&url)
+            .with_basic_auth(self.http.get(&url))
             .send()
             .await
             .map_err(map_reqwest_error)?;
@@ -325,8 +350,7 @@ impl InvidiousClient {
         let url = format!("{}/api/v1/channels/{}", self.base_url, channel_id);
 
         let response = self
-            .http
-            .get(&url)
+            .with_basic_auth(self.http.get(&url))
             .send()
             .await
             .map_err(map_reqwest_error)?;
@@ -374,8 +398,7 @@ impl InvidiousClient {
         let url = format!("{}/api/v1/videos/{}", self.base_url, video_id);
 
         let response = self
-            .http
-            .get(&url)
+            .with_basic_auth(self.http.get(&url))
             .send()
             .await
             .map_err(map_reqwest_error)?;
@@ -424,8 +447,7 @@ impl InvidiousClient {
         let url = format!("{}/api/v1/channels/{}", self.base_url, channel_id);
 
         let response = self
-            .http
-            .get(&url)
+            .with_basic_auth(self.http.get(&url))
             .send()
             .await
             .map_err(map_reqwest_error)?;
@@ -453,7 +475,7 @@ impl InvidiousClient {
             })
             .ok_or_else(|| AppError::InvidiousBadResponse)?;
 
-        // 4. Download the image
+        // 4. Download the image (external URL, no basic auth needed)
         let image_response = self.http.get(&avatar_url).send().await.map_err(|e| {
             tracing::error!(error = %e, channel_id = %channel_id, "Failed to download channel avatar");
             AppError::Http(e)
@@ -494,8 +516,7 @@ impl InvidiousClient {
         let url = format!("{}/api/v1/channels/{}", self.base_url, channel_id);
 
         let response = self
-            .http
-            .get(&url)
+            .with_basic_auth(self.http.get(&url))
             .send()
             .await
             .map_err(map_reqwest_error)?;

--- a/src/youtube.rs
+++ b/src/youtube.rs
@@ -22,15 +22,27 @@ use crate::{
 pub struct YoutubeState {
     invidious: Option<InvidiousClient>,
     invidious_base_url: Option<String>,
+    basic_auth_user: Option<String>,
+    basic_auth_password: Option<String>,
 }
 
 impl YoutubeState {
     pub fn new(_auth: WebAuthConfig, config: &AppConfig) -> Self {
         let invidious = config.invidious.as_ref().map(InvidiousClient::new);
         let invidious_base_url = config.invidious.as_ref().map(|c| c.base_url.clone());
+        let basic_auth_user = config
+            .invidious
+            .as_ref()
+            .and_then(|c| c.basic_auth_user.clone());
+        let basic_auth_password = config
+            .invidious
+            .as_ref()
+            .and_then(|c| c.basic_auth_password.clone());
         Self {
             invidious,
             invidious_base_url,
+            basic_auth_user,
+            basic_auth_password,
         }
     }
 
@@ -82,6 +94,8 @@ pub struct EmbedConfigResponse {
     pub invidious_base_url: String,
     pub defaults: EmbedDefaults,
     pub referrer_policy: String,
+    pub basic_auth_user: Option<String>,
+    pub basic_auth_password: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -199,6 +213,8 @@ async fn get_embed_config(State(state): State<YoutubeState>) -> Response {
                 quality_dash: "auto".to_string(),
             },
             referrer_policy: "no-referrer".to_string(),
+            basic_auth_user: state.basic_auth_user.clone(),
+            basic_auth_password: state.basic_auth_password.clone(),
         }),
     )
         .into_response()

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -614,6 +614,8 @@ export interface YouTubeEmbedConfig {
     quality_dash: string;
   };
   referrer_policy: string;
+  basic_auth_user?: string;
+  basic_auth_password?: string;
 }
 
 export interface YouTubeVideoMeta {
@@ -763,7 +765,7 @@ export async function getYouTubeEmbedConfig(): Promise<YouTubeEmbedConfig> {
     throw new Error("youtube embed config payload is invalid");
   }
 
-  return {
+  const config: YouTubeEmbedConfig = {
     invidious_base_url: payload.invidious_base_url,
     defaults: {
       autoplay: payload.defaults.autoplay,
@@ -772,6 +774,16 @@ export async function getYouTubeEmbedConfig(): Promise<YouTubeEmbedConfig> {
     },
     referrer_policy: payload.referrer_policy,
   };
+
+  // Optional basic auth credentials
+  if (typeof payload.basic_auth_user === "string") {
+    config.basic_auth_user = payload.basic_auth_user;
+  }
+  if (typeof payload.basic_auth_password === "string") {
+    config.basic_auth_password = payload.basic_auth_password;
+  }
+
+  return config;
 }
 
 export async function getYouTubeVideoMeta(videoId: string): Promise<YouTubeVideoMeta> {

--- a/web/src/routes/youtube/watch/[video_id]/+page.svelte
+++ b/web/src/routes/youtube/watch/[video_id]/+page.svelte
@@ -16,12 +16,24 @@
     baseUrl: string,
     id: string,
     defaults: { autoplay: number; quality: string; quality_dash: string },
+    basicAuthUser?: string,
+    basicAuthPassword?: string,
   ): string {
     const params = new URLSearchParams({
       autoplay: String(defaults.autoplay),
       quality: defaults.quality,
       quality_dash: defaults.quality_dash,
     });
+
+    // If basic auth credentials are provided, embed them in the URL
+    if (basicAuthUser && basicAuthPassword) {
+      // Parse base URL and insert credentials
+      const url = new URL(baseUrl);
+      url.username = encodeURIComponent(basicAuthUser);
+      url.password = encodeURIComponent(basicAuthPassword);
+      return `${url.origin}/embed/${encodeURIComponent(id)}?${params.toString()}`;
+    }
+
     return `${baseUrl}/embed/${encodeURIComponent(id)}?${params.toString()}`;
   }
 
@@ -36,7 +48,13 @@
 
     try {
       const [config, meta] = await Promise.all([getYouTubeEmbedConfig(), getYouTubeVideoMeta(videoId)]);
-      embedUrl = buildEmbedUrl(config.invidious_base_url, videoId, config.defaults);
+      embedUrl = buildEmbedUrl(
+        config.invidious_base_url,
+        videoId,
+        config.defaults,
+        config.basic_auth_user,
+        config.basic_auth_password,
+      );
       videoTitle = meta.title;
       videoDuration = meta.duration;
       referrerPolicy =


### PR DESCRIPTION
- Added basic auth support for YouTube embeds through environment variables \`INVIDIOUS_SID\`, \`INVIDIOUS_BASIC_AUTH_USER\`, and \`INVIDIOUS_BASIC_AUTH_PASSWORD\`.
- Updated \`InvidiousClient\` to handle both Bearer tokens and SID cookies for authentication, preferring the SID cookie when using basic auth.
- Integrated basic auth into the YouTube state and embed configuration retrieval process.
- Modified \`getYouTubeEmbedConfig\` in \`web/src/lib/api.ts\` to accept and return optional basic auth credentials.
- Updated the YouTube watch page route to handle basic auth credentials by embedding them directly in the URL if provided.