### PR TITLE
feat(youtube): add endpoint and function to fetch YouTube thumbnail URL

### DIFF
--- a/src/invidious.rs
+++ b/src/invidious.rs
@@ -18,7 +18,7 @@ const DESCRIPTION_CACHE_TTL_SECS: u64 = 86400; // 24 hours
 #[derive(Debug, Clone)]
 pub struct InvidiousClient {
     base_url: String,
-    http: reqwest::Client,
+    pub http: reqwest::Client,
     avatar_cache: Arc<RwLock<HashMap<String, (String, Instant)>>>, // channel_id -> (url, fetched_at)
     description_cache: Arc<RwLock<HashMap<String, (String, Instant)>>>, // channel_id -> (description, fetched_at)
     basic_auth: Option<(String, String)>, // (user, password) for reverse proxy

--- a/src/youtube.rs
+++ b/src/youtube.rs
@@ -237,11 +237,7 @@ async fn get_thumbnail(
 ) -> Response {
     // Validate video_id format
     if !is_valid_video_id(&video_id) {
-        return (
-            StatusCode::BAD_REQUEST,
-            "invalid video_id format",
-        )
-            .into_response();
+        return (StatusCode::BAD_REQUEST, "invalid video_id format").into_response();
     }
 
     let Some(base_url) = state.invidious_base_url.as_ref() else {
@@ -256,20 +252,11 @@ async fn get_thumbnail(
     let invidious_url = format!("{}/vi/{}/hqdefault.jpg", base_url, video_id);
 
     // Fetch thumbnail through InvidiousClient (handles Basic auth + SID cookie)
-    let response = match client
-        .http
-        .get(&invidious_url)
-        .send()
-        .await
-    {
+    let response = match client.http.get(&invidious_url).send().await {
         Ok(r) => r,
         Err(e) => {
             tracing::error!(error = %e, video_id = %video_id, "Failed to fetch thumbnail from Invidious");
-            return (
-                StatusCode::BAD_GATEWAY,
-                "Failed to fetch thumbnail",
-            )
-                .into_response();
+            return (StatusCode::BAD_GATEWAY, "Failed to fetch thumbnail").into_response();
         }
     };
 
@@ -301,11 +288,7 @@ async fn get_thumbnail(
         Ok(b) => b,
         Err(e) => {
             tracing::error!(error = %e, video_id = %video_id, "Failed to read thumbnail bytes");
-            return (
-                StatusCode::BAD_GATEWAY,
-                "Failed to read thumbnail",
-            )
-                .into_response();
+            return (StatusCode::BAD_GATEWAY, "Failed to read thumbnail").into_response();
         }
     };
 
@@ -313,9 +296,8 @@ async fn get_thumbnail(
     let mut headers = HeaderMap::new();
     headers.insert(
         "content-type",
-        HeaderValue::from_str(&content_type).unwrap_or_else(|_| {
-            HeaderValue::from_static("image/jpeg")
-        }),
+        HeaderValue::from_str(&content_type)
+            .unwrap_or_else(|_| HeaderValue::from_static("image/jpeg")),
     );
     // Cache for 24 hours since thumbnails rarely change
     headers.insert(

--- a/src/youtube.rs
+++ b/src/youtube.rs
@@ -1,7 +1,8 @@
 use axum::{
     Json, Router,
+    body::Body,
     extract::{Path, State},
-    http::StatusCode,
+    http::{HeaderMap, HeaderValue, StatusCode},
     middleware,
     response::{IntoResponse, Response},
     routing::get,
@@ -120,6 +121,7 @@ pub fn build_routes(auth: WebAuthConfig, config: &AppConfig) -> Router {
             get(get_channel_info),
         )
         .route("/api/youtube/video/{video_id}/meta", get(get_video_meta))
+        .route("/api/youtube/thumbnail/{video_id}", get(get_thumbnail))
         .route("/api/youtube/embed-config", get(get_embed_config))
         .with_state(state)
         .layer(middleware::from_fn_with_state(
@@ -218,4 +220,108 @@ async fn get_embed_config(State(state): State<YoutubeState>) -> Response {
         }),
     )
         .into_response()
+}
+
+/// Validate YouTube video ID format (11 alphanumeric chars)
+fn is_valid_video_id(video_id: &str) -> bool {
+    video_id.len() == 11
+        && video_id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
+/// Proxy thumbnail requests to avoid basic auth popup in browser
+async fn get_thumbnail(
+    State(state): State<YoutubeState>,
+    Path(video_id): Path<String>,
+) -> Response {
+    // Validate video_id format
+    if !is_valid_video_id(&video_id) {
+        return (
+            StatusCode::BAD_REQUEST,
+            "invalid video_id format",
+        )
+            .into_response();
+    }
+
+    let Some(base_url) = state.invidious_base_url.as_ref() else {
+        return AppError::InvidiousNotConfigured.into_response();
+    };
+
+    let Some(client) = state.invidious.as_ref() else {
+        return AppError::InvidiousNotConfigured.into_response();
+    };
+
+    // Construct Invidious thumbnail URL
+    let invidious_url = format!("{}/vi/{}/hqdefault.jpg", base_url, video_id);
+
+    // Fetch thumbnail through InvidiousClient (handles Basic auth + SID cookie)
+    let response = match client
+        .http
+        .get(&invidious_url)
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(error = %e, video_id = %video_id, "Failed to fetch thumbnail from Invidious");
+            return (
+                StatusCode::BAD_GATEWAY,
+                "Failed to fetch thumbnail",
+            )
+                .into_response();
+        }
+    };
+
+    // Check if request succeeded
+    if !response.status().is_success() {
+        let status = response.status();
+        tracing::warn!(
+            status = %status,
+            video_id = %video_id,
+            "Invidious returned error for thumbnail"
+        );
+        return (
+            StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::BAD_GATEWAY),
+            "Thumbnail not available",
+        )
+            .into_response();
+    }
+
+    // Get content type from response, default to image/jpeg
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "image/jpeg".to_string());
+
+    // Get image bytes
+    let bytes = match response.bytes().await {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::error!(error = %e, video_id = %video_id, "Failed to read thumbnail bytes");
+            return (
+                StatusCode::BAD_GATEWAY,
+                "Failed to read thumbnail",
+            )
+                .into_response();
+        }
+    };
+
+    // Build response with cache headers
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "content-type",
+        HeaderValue::from_str(&content_type).unwrap_or_else(|_| {
+            HeaderValue::from_static("image/jpeg")
+        }),
+    );
+    // Cache for 24 hours since thumbnails rarely change
+    headers.insert(
+        "cache-control",
+        HeaderValue::from_static("public, max-age=86400"),
+    );
+
+    (headers, bytes).into_response()
 }

--- a/src/youtube.rs
+++ b/src/youtube.rs
@@ -1,6 +1,5 @@
 use axum::{
     Json, Router,
-    body::Body,
     extract::{Path, State},
     http::{HeaderMap, HeaderValue, StatusCode},
     middleware,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -786,6 +786,10 @@ export async function getYouTubeEmbedConfig(): Promise<YouTubeEmbedConfig> {
   return config;
 }
 
+export function getYouTubeThumbnailUrl(videoId: string): string {
+  return `/api/youtube/thumbnail/${encodeURIComponent(videoId)}`;
+}
+
 export async function getYouTubeVideoMeta(videoId: string): Promise<YouTubeVideoMeta> {
   const response = await request(`/api/youtube/video/${encodeURIComponent(videoId)}/meta`);
   if (!response.ok) {

--- a/web/src/routes/youtube/channel/[channel_id]/+page.svelte
+++ b/web/src/routes/youtube/channel/[channel_id]/+page.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
   import { goto } from '$app/navigation';
-  import { getYouTubeChannelVideos, refreshYouTubeChannelVideos } from '$lib/api';
+  import { getYouTubeChannelVideos, refreshYouTubeChannelVideos, getYouTubeThumbnailUrl } from '$lib/api';
   import type { YoutubeVideo } from '$lib/api';
 
   let videos = $state<YoutubeVideo[]>([]);
@@ -101,7 +101,7 @@
             <div class="youtube-video-thumb-wrap">
               <img
                 class="youtube-video-thumb"
-                src={video.thumbnail}
+                src={getYouTubeThumbnailUrl(video.video_id)}
                 alt={video.title}
                 loading="lazy"
               />


### PR DESCRIPTION
- Added endpoint \`/api/youtube/thumbnail/{video_id}\` to fetch YouTube thumbnail URL.
- Implemented validation for YouTube video ID format.
- Proxy thumbnail requests through Invidious client to avoid browser authentication popups.
- Handled errors and returned appropriate HTTP status codes.
- Updated frontend to use new API endpoint for fetching thumbnail URLs.