### PR TITLE
refactor(src): make InvidiousClient::with_basic_auth public and chain it in get_thumbnail

### DIFF
--- a/src/invidious.rs
+++ b/src/invidious.rs
@@ -190,7 +190,7 @@ impl InvidiousClient {
     }
 
     /// Helper to apply basic auth to a request builder if configured
-    fn with_basic_auth(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+    pub fn with_basic_auth(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
         if let Some((ref user, ref pass)) = self.basic_auth {
             request.basic_auth(user, Some(pass))
         } else {

--- a/src/youtube.rs
+++ b/src/youtube.rs
@@ -251,7 +251,11 @@ async fn get_thumbnail(
     let invidious_url = format!("{}/vi/{}/hqdefault.jpg", base_url, video_id);
 
     // Fetch thumbnail through InvidiousClient (handles Basic auth + SID cookie)
-    let response = match client.http.get(&invidious_url).send().await {
+    let response = match client
+        .with_basic_auth(client.http.get(&invidious_url))
+        .send()
+        .await
+    {
         Ok(r) => r,
         Err(e) => {
             tracing::error!(error = %e, video_id = %video_id, "Failed to fetch thumbnail from Invidious");


### PR DESCRIPTION
- Made \`InvidiousClient::with_basic_auth\` public to allow chaining in other methods.
- Chained \`with_basic_auth\` method when calling \`get_thumbnail\`.
- No additional tests or validation were included.