### PR TITLE
refactor(recording): use typed errors

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -24,7 +24,7 @@ use crate::{
     playback::{PlaybackTicketError, PlaybackTicketService},
     prewarm::PrewarmCoordinator,
     recording::{
-        ActiveRecording, RecordingBucket, RecordingMode, RecordingProcessingConfig,
+        ActiveRecording, RecordingBucket, RecordingError, RecordingMode, RecordingProcessingConfig,
         RecordingService,
     },
     recording_rules::{self, RecordingRule},
@@ -99,7 +99,7 @@ pub fn build_router(config: &AppConfig, access_code_hash: String) -> Result<Rout
             chapter_change_confirmations: config.recording.chapter_change_confirmations,
         },
     )
-    .map_err(AppError::Config)?;
+    .map_err(|e| AppError::Config(e.to_string()))?;
     RecordingScheduler::start(
         config.recording.clone(),
         live_status_state.service.clone(),
@@ -860,45 +860,30 @@ async fn delete_recording_rule(Path(channel_login): Path<String>) -> Response {
     }
 }
 
-fn classify_recording_error(error: &str) -> (StatusCode, &str) {
-    if error.contains("channel login cannot be empty") {
-        return (StatusCode::BAD_REQUEST, "channel login cannot be empty");
-    }
-    if error.contains("invalid quality") {
-        return (StatusCode::BAD_REQUEST, "invalid quality");
-    }
-    if error.contains("already active") {
-        return (StatusCode::CONFLICT, "recording already active");
-    }
-    if error.contains("not active") {
-        return (StatusCode::NOT_FOUND, "recording not active");
-    }
-    if error.contains("file not found") {
-        return (StatusCode::NOT_FOUND, "recording file not found");
-    }
-    if error.contains("filename cannot be empty") {
-        return (StatusCode::BAD_REQUEST, "filename cannot be empty");
-    }
-    if error.contains("invalid filename") {
-        return (StatusCode::BAD_REQUEST, "invalid filename");
-    }
-    if error.contains("delete failed") {
-        return (StatusCode::INTERNAL_SERVER_ERROR, "recording delete failed");
-    }
-    if error.contains("spawn failed") {
-        return (StatusCode::BAD_GATEWAY, "streamlink spawn failed");
-    }
-    if error.contains("not writable") {
-        return (
+fn classify_recording_error(error: &RecordingError) -> (StatusCode, &'static str) {
+    match error {
+        RecordingError::EmptyChannelLogin => {
+            (StatusCode::BAD_REQUEST, "channel login cannot be empty")
+        }
+        RecordingError::InvalidQuality => (StatusCode::BAD_REQUEST, "invalid quality"),
+        RecordingError::AlreadyActive => (StatusCode::CONFLICT, "recording already active"),
+        RecordingError::NotActive => (StatusCode::NOT_FOUND, "recording not active"),
+        RecordingError::FileNotFound => (StatusCode::NOT_FOUND, "recording file not found"),
+        RecordingError::EmptyFilename => (StatusCode::BAD_REQUEST, "filename cannot be empty"),
+        RecordingError::InvalidFilename => (StatusCode::BAD_REQUEST, "invalid filename"),
+        RecordingError::DeleteFailed(_) => {
+            (StatusCode::INTERNAL_SERVER_ERROR, "recording delete failed")
+        }
+        RecordingError::SpawnFailed(_) => (StatusCode::BAD_GATEWAY, "streamlink spawn failed"),
+        RecordingError::DirectoryNotWritable(_) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             "recordings directory not writable",
-        );
+        ),
+        RecordingError::PinFailed(_) | RecordingError::UnpinFailed(_) | RecordingError::Io(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "recording operation failed",
+        ),
     }
-
-    (
-        StatusCode::INTERNAL_SERVER_ERROR,
-        "recording operation failed",
-    )
 }
 
 async fn healthz() -> Json<ProbeResponse<'static>> {
@@ -1200,4 +1185,108 @@ fn render_error_page(channel: &str, message: &str) -> Response {
 
 fn error_response(status: StatusCode, message: &str) -> Response {
     (status, Json(serde_json::json!({ "error": message }))).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::recording::RecordingError;
+
+    #[test]
+    fn classify_recording_error_maps_empty_channel_login() {
+        let (status, message) = classify_recording_error(&RecordingError::EmptyChannelLogin);
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(message, "channel login cannot be empty");
+    }
+
+    #[test]
+    fn classify_recording_error_maps_invalid_quality() {
+        let (status, message) = classify_recording_error(&RecordingError::InvalidQuality);
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(message, "invalid quality");
+    }
+
+    #[test]
+    fn classify_recording_error_maps_already_active() {
+        let (status, message) = classify_recording_error(&RecordingError::AlreadyActive);
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(message, "recording already active");
+    }
+
+    #[test]
+    fn classify_recording_error_maps_not_active() {
+        let (status, message) = classify_recording_error(&RecordingError::NotActive);
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(message, "recording not active");
+    }
+
+    #[test]
+    fn classify_recording_error_maps_file_not_found() {
+        let (status, message) = classify_recording_error(&RecordingError::FileNotFound);
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(message, "recording file not found");
+    }
+
+    #[test]
+    fn classify_recording_error_maps_empty_filename() {
+        let (status, message) = classify_recording_error(&RecordingError::EmptyFilename);
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(message, "filename cannot be empty");
+    }
+
+    #[test]
+    fn classify_recording_error_maps_invalid_filename() {
+        let (status, message) = classify_recording_error(&RecordingError::InvalidFilename);
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(message, "invalid filename");
+    }
+
+    #[test]
+    fn classify_recording_error_maps_delete_failed() {
+        let (status, message) =
+            classify_recording_error(&RecordingError::DeleteFailed("some error".to_string()));
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(message, "recording delete failed");
+    }
+
+    #[test]
+    fn classify_recording_error_maps_spawn_failed() {
+        let (status, message) =
+            classify_recording_error(&RecordingError::SpawnFailed("some error".to_string()));
+        assert_eq!(status, StatusCode::BAD_GATEWAY);
+        assert_eq!(message, "streamlink spawn failed");
+    }
+
+    #[test]
+    fn classify_recording_error_maps_directory_not_writable() {
+        let (status, message) = classify_recording_error(&RecordingError::DirectoryNotWritable(
+            "some error".to_string(),
+        ));
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(message, "recordings directory not writable");
+    }
+
+    #[test]
+    fn classify_recording_error_maps_pin_failed_to_fallback() {
+        let (status, message) =
+            classify_recording_error(&RecordingError::PinFailed("some error".to_string()));
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(message, "recording operation failed");
+    }
+
+    #[test]
+    fn classify_recording_error_maps_unpin_failed_to_fallback() {
+        let (status, message) =
+            classify_recording_error(&RecordingError::UnpinFailed("some error".to_string()));
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(message, "recording operation failed");
+    }
+
+    #[test]
+    fn classify_recording_error_maps_io_to_fallback() {
+        let (status, message) =
+            classify_recording_error(&RecordingError::Io("some error".to_string()));
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(message, "recording operation failed");
+    }
 }

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use time::{OffsetDateTime, format_description};
 use tokio::{process::Command, sync::RwLock};
 
@@ -16,6 +17,37 @@ use crate::{
     recording_rules,
     twitch_auth::{HelixChannelMetadata, TwitchAuthService},
 };
+
+/// Typed error for recording operations.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum RecordingError {
+    #[error("channel login cannot be empty")]
+    EmptyChannelLogin,
+    #[error("invalid quality")]
+    InvalidQuality,
+    #[error("recording already active")]
+    AlreadyActive,
+    #[error("recording not active")]
+    NotActive,
+    #[error("recording file not found")]
+    FileNotFound,
+    #[error("filename cannot be empty")]
+    EmptyFilename,
+    #[error("invalid filename")]
+    InvalidFilename,
+    #[error("recording delete failed: {0}")]
+    DeleteFailed(String),
+    #[error("recording pin failed: {0}")]
+    PinFailed(String),
+    #[error("recording unpin failed: {0}")]
+    UnpinFailed(String),
+    #[error("streamlink spawn failed: {0}")]
+    SpawnFailed(String),
+    #[error("recordings directory not writable: {0}")]
+    DirectoryNotWritable(String),
+    #[error("io error: {0}")]
+    Io(String),
+}
 
 const QUALITY_OPTIONS: [&str; 9] = [
     "best", "source", "1080p60", "1080p", "720p60", "720p", "480p", "360p", "160p",
@@ -123,7 +155,7 @@ impl RecordingService {
         nfo_style: RecordingNfoStyle,
         twitch: TwitchAuthService,
         processing: RecordingProcessingConfig,
-    ) -> Result<Self, String> {
+    ) -> Result<Self, RecordingError> {
         let service = Self {
             streamlink_path,
             recordings_dir: PathBuf::from(recordings_dir),
@@ -140,19 +172,19 @@ impl RecordingService {
         Ok(service)
     }
 
-    pub fn validate_quality(quality: &str) -> Result<String, String> {
+    pub fn validate_quality(quality: &str) -> Result<String, RecordingError> {
         let normalized = quality.trim().to_ascii_lowercase();
         if QUALITY_OPTIONS.contains(&normalized.as_str()) {
             Ok(normalized)
         } else {
-            Err("invalid quality".to_string())
+            Err(RecordingError::InvalidQuality)
         }
     }
 
-    pub fn normalize_channel_login(channel_login: &str) -> Result<String, String> {
+    pub fn normalize_channel_login(channel_login: &str) -> Result<String, RecordingError> {
         let normalized = channel_login.trim().to_ascii_lowercase();
         if normalized.is_empty() {
-            return Err("channel login cannot be empty".to_string());
+            return Err(RecordingError::EmptyChannelLogin);
         }
         Ok(normalized)
     }
@@ -163,7 +195,7 @@ impl RecordingService {
         quality: &str,
         mode: RecordingMode,
         stream_title: Option<&str>,
-    ) -> Result<ActiveRecording, String> {
+    ) -> Result<ActiveRecording, RecordingError> {
         let channel_login = Self::normalize_channel_login(channel_login)?;
         let quality = Self::validate_quality(quality)?;
 
@@ -172,7 +204,7 @@ impl RecordingService {
         {
             let active = self.active.read().await;
             if active.contains_key(&channel_login) {
-                return Err("recording already active for this channel".to_string());
+                return Err(RecordingError::AlreadyActive);
             }
         }
 
@@ -188,8 +220,11 @@ impl RecordingService {
             .channel_bucket_dir("tmp", &channel_login)
             .join(filename);
         if let Some(parent) = output_path.parent() {
-            fs::create_dir_all(parent)
-                .map_err(|e| format!("recordings directory not writable: {e}"))?;
+            fs::create_dir_all(parent).map_err(|e| {
+                RecordingError::DirectoryNotWritable(format!(
+                    "recordings directory not writable: {e}"
+                ))
+            })?;
         }
 
         let mut command = Command::new(&self.streamlink_path);
@@ -204,7 +239,7 @@ impl RecordingService {
 
         let child = command
             .spawn()
-            .map_err(|e| format!("streamlink spawn failed: {e}"))?;
+            .map_err(|e| RecordingError::SpawnFailed(format!("streamlink spawn failed: {e}")))?;
 
         let pid = child.id();
         let metadata = ActiveRecording {
@@ -250,7 +285,10 @@ impl RecordingService {
         Ok(metadata)
     }
 
-    pub async fn stop_recording(&self, channel_login: &str) -> Result<ActiveRecording, String> {
+    pub async fn stop_recording(
+        &self,
+        channel_login: &str,
+    ) -> Result<ActiveRecording, RecordingError> {
         self.reconcile_exited_recordings().await;
 
         let channel_login = Self::normalize_channel_login(channel_login)?;
@@ -258,7 +296,7 @@ impl RecordingService {
             let mut active = self.active.write().await;
             active.remove(&channel_login)
         }
-        .ok_or_else(|| "recording not active for this channel".to_string())?;
+        .ok_or(RecordingError::NotActive)?;
 
         let _ = process.child.kill().await;
         let _ = process.child.wait().await;
@@ -331,57 +369,70 @@ impl RecordingService {
         bucket: RecordingBucket,
         channel_login: &str,
         filename: &str,
-    ) -> Result<(), String> {
+    ) -> Result<(), RecordingError> {
         let target_path = self.resolve_recording_file_path(bucket, channel_login, filename)?;
 
         if !target_path.exists() {
-            return Err("recording file not found".to_string());
+            return Err(RecordingError::FileNotFound);
         }
 
-        fs::remove_file(&target_path)
-            .map_err(|error| format!("recording delete failed: {error}"))?;
+        fs::remove_file(&target_path).map_err(|error| {
+            RecordingError::DeleteFailed(format!("recording delete failed: {error}"))
+        })?;
 
         if matches!(bucket, RecordingBucket::Completed) {
             let nfo_path = target_path.with_extension("nfo");
             if nfo_path.exists() {
-                fs::remove_file(&nfo_path)
-                    .map_err(|error| format!("recording delete failed: {error}"))?;
+                fs::remove_file(&nfo_path).map_err(|error| {
+                    RecordingError::DeleteFailed(format!("recording delete failed: {error}"))
+                })?;
             }
 
             let pin_path = pin_marker_path_for_recording(&target_path);
             if pin_path.exists() {
-                fs::remove_file(&pin_path)
-                    .map_err(|error| format!("recording delete failed: {error}"))?;
+                fs::remove_file(&pin_path).map_err(|error| {
+                    RecordingError::DeleteFailed(format!("recording delete failed: {error}"))
+                })?;
             }
 
             let m3u8_path = target_path.with_extension("m3u8");
             if m3u8_path.exists() {
-                fs::remove_file(&m3u8_path)
-                    .map_err(|error| format!("recording delete failed: {error}"))?;
+                fs::remove_file(&m3u8_path).map_err(|error| {
+                    RecordingError::DeleteFailed(format!("recording delete failed: {error}"))
+                })?;
             }
         }
 
         Ok(())
     }
 
-    pub fn pin_recording_file(&self, channel_login: &str, filename: &str) -> Result<(), String> {
+    pub fn pin_recording_file(
+        &self,
+        channel_login: &str,
+        filename: &str,
+    ) -> Result<(), RecordingError> {
         let target_path =
             self.resolve_recording_file_path(RecordingBucket::Completed, channel_login, filename)?;
 
         if !target_path.exists() {
-            return Err("recording file not found".to_string());
+            return Err(RecordingError::FileNotFound);
         }
 
         let pin_path = pin_marker_path_for_recording(&target_path);
-        fs::write(&pin_path, b"pinned\n").map_err(|error| format!("recording pin failed: {error}"))
+        fs::write(&pin_path, b"pinned\n")
+            .map_err(|error| RecordingError::PinFailed(format!("recording pin failed: {error}")))
     }
 
-    pub fn unpin_recording_file(&self, channel_login: &str, filename: &str) -> Result<(), String> {
+    pub fn unpin_recording_file(
+        &self,
+        channel_login: &str,
+        filename: &str,
+    ) -> Result<(), RecordingError> {
         let target_path =
             self.resolve_recording_file_path(RecordingBucket::Completed, channel_login, filename)?;
 
         if !target_path.exists() {
-            return Err("recording file not found".to_string());
+            return Err(RecordingError::FileNotFound);
         }
 
         let pin_path = pin_marker_path_for_recording(&target_path);
@@ -389,14 +440,16 @@ impl RecordingService {
             return Ok(());
         }
 
-        fs::remove_file(&pin_path).map_err(|error| format!("recording unpin failed: {error}"))
+        fs::remove_file(&pin_path).map_err(|error| {
+            RecordingError::UnpinFailed(format!("recording unpin failed: {error}"))
+        })
     }
 
     pub fn resolve_completed_file_path(
         &self,
         channel_login: &str,
         filename: &str,
-    ) -> Result<PathBuf, String> {
+    ) -> Result<PathBuf, RecordingError> {
         self.resolve_recording_file_path(RecordingBucket::Completed, channel_login, filename)
     }
 
@@ -464,7 +517,7 @@ impl RecordingService {
         bucket: RecordingBucket,
         channel_login: &str,
         filename: &str,
-    ) -> Result<PathBuf, String> {
+    ) -> Result<PathBuf, RecordingError> {
         let channel_login = Self::normalize_channel_login(channel_login)?;
         let filename = validate_recording_filename(filename)?;
         let channel_dir = self.channel_bucket_dir(bucket.as_str(), &channel_login);
@@ -571,21 +624,25 @@ impl RecordingService {
         );
     }
 
-    fn ensure_directories(&self) -> Result<(), String> {
-        fs::create_dir_all(self.tmp_dir())
-            .map_err(|e| format!("recordings directory not writable: {e}"))?;
-        fs::create_dir_all(self.completed_dir())
-            .map_err(|e| format!("recordings directory not writable: {e}"))?;
-        fs::create_dir_all(self.incomplete_dir())
-            .map_err(|e| format!("recordings directory not writable: {e}"))?;
+    fn ensure_directories(&self) -> Result<(), RecordingError> {
+        fs::create_dir_all(self.tmp_dir()).map_err(|e| {
+            RecordingError::DirectoryNotWritable(format!("recordings directory not writable: {e}"))
+        })?;
+        fs::create_dir_all(self.completed_dir()).map_err(|e| {
+            RecordingError::DirectoryNotWritable(format!("recordings directory not writable: {e}"))
+        })?;
+        fs::create_dir_all(self.incomplete_dir()).map_err(|e| {
+            RecordingError::DirectoryNotWritable(format!("recordings directory not writable: {e}"))
+        })?;
         Ok(())
     }
 
-    fn cleanup_startup_tmp(&self) -> Result<(), String> {
+    fn cleanup_startup_tmp(&self) -> Result<(), RecordingError> {
         let tmp = self.tmp_dir();
         let incomplete = self.incomplete_dir();
-        let entries =
-            fs::read_dir(&tmp).map_err(|e| format!("read recordings tmp directory failed: {e}"))?;
+        let entries = fs::read_dir(&tmp).map_err(|e| {
+            RecordingError::Io(format!("read recordings tmp directory failed: {e}"))
+        })?;
         for entry in entries.flatten() {
             let path = entry.path();
             if path.is_file() {
@@ -1256,16 +1313,16 @@ fn is_visible_recording_file(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
-fn validate_recording_filename(filename: &str) -> Result<String, String> {
+fn validate_recording_filename(filename: &str) -> Result<String, RecordingError> {
     let trimmed = filename.trim();
     if trimmed.is_empty() {
-        return Err("filename cannot be empty".to_string());
+        return Err(RecordingError::EmptyFilename);
     }
     if trimmed.contains('/') || trimmed.contains('\\') {
-        return Err("invalid filename".to_string());
+        return Err(RecordingError::InvalidFilename);
     }
     if trimmed == "." || trimmed == ".." {
-        return Err("invalid filename".to_string());
+        return Err(RecordingError::InvalidFilename);
     }
 
     Ok(trimmed.to_string())
@@ -1424,5 +1481,98 @@ mod tests {
         assert!(is_visible_recording_file(Path::new("video.mp4")));
         assert!(!is_visible_recording_file(Path::new("video.nfo")));
         assert!(!is_visible_recording_file(Path::new("video.NFO")));
+    }
+
+    #[test]
+    fn validate_quality_accepts_valid_options() {
+        assert_eq!(RecordingService::validate_quality("best").unwrap(), "best");
+        assert_eq!(
+            RecordingService::validate_quality("1080p60").unwrap(),
+            "1080p60"
+        );
+        assert_eq!(
+            RecordingService::validate_quality("  BEST  ").unwrap(),
+            "best"
+        );
+    }
+
+    #[test]
+    fn validate_quality_rejects_invalid_options() {
+        assert_eq!(
+            RecordingService::validate_quality("invalid"),
+            Err(RecordingError::InvalidQuality)
+        );
+        assert_eq!(
+            RecordingService::validate_quality(""),
+            Err(RecordingError::InvalidQuality)
+        );
+    }
+
+    #[test]
+    fn normalize_channel_login_accepts_valid_input() {
+        assert_eq!(
+            RecordingService::normalize_channel_login("shroud").unwrap(),
+            "shroud"
+        );
+        assert_eq!(
+            RecordingService::normalize_channel_login("  Shroud  ").unwrap(),
+            "shroud"
+        );
+    }
+
+    #[test]
+    fn normalize_channel_login_rejects_empty() {
+        assert_eq!(
+            RecordingService::normalize_channel_login(""),
+            Err(RecordingError::EmptyChannelLogin)
+        );
+        assert_eq!(
+            RecordingService::normalize_channel_login("   "),
+            Err(RecordingError::EmptyChannelLogin)
+        );
+    }
+
+    #[test]
+    fn validate_recording_filename_accepts_valid_names() {
+        assert_eq!(
+            validate_recording_filename("recording.ts").unwrap(),
+            "recording.ts"
+        );
+        assert_eq!(
+            validate_recording_filename("  recording.ts  ").unwrap(),
+            "recording.ts"
+        );
+    }
+
+    #[test]
+    fn validate_recording_filename_rejects_empty() {
+        assert_eq!(
+            validate_recording_filename(""),
+            Err(RecordingError::EmptyFilename)
+        );
+        assert_eq!(
+            validate_recording_filename("   "),
+            Err(RecordingError::EmptyFilename)
+        );
+    }
+
+    #[test]
+    fn validate_recording_filename_rejects_invalid() {
+        assert_eq!(
+            validate_recording_filename("path/to/recording.ts"),
+            Err(RecordingError::InvalidFilename)
+        );
+        assert_eq!(
+            validate_recording_filename("recording\\.ts"),
+            Err(RecordingError::InvalidFilename)
+        );
+        assert_eq!(
+            validate_recording_filename("."),
+            Err(RecordingError::InvalidFilename)
+        );
+        assert_eq!(
+            validate_recording_filename(".."),
+            Err(RecordingError::InvalidFilename)
+        );
     }
 }


### PR DESCRIPTION
## Summary

Replace stringly-typed recording errors with a typed `RecordingError` enum. This removes brittle substring matching in error classification.

## Changes

- Add `RecordingError` enum with variants for all recording error cases:
  - `EmptyChannelLogin`
  - `InvalidQuality`
  - `AlreadyActive`
  - `NotActive`
  - `FileNotFound`
  - `EmptyFilename`
  - `InvalidFilename`
  - `DeleteFailed(String)`
  - `PinFailed(String)`
  - `UnpinFailed(String)`
  - `SpawnFailed(String)`
  - `DirectoryNotWritable(String)`
  - `Io(String)`

- Update `RecordingService` methods to return `RecordingError` instead of `String`
- Update `classify_recording_error` to use pattern matching on `RecordingError`
- Preserve exact HTTP status codes and user-facing messages
- Add unit tests for error classification and validation functions

## Behavior Notes

- **HTTP behavior unchanged**: Same status codes and user-facing messages as before
- **Pin/unpin failures fall through to generic fallback** (preserved existing behavior)
- **Logging preserved**: Internal error details are still logged for 500 responses

## Validation

```sh
cargo test              # 45 tests passed
cargo clippy            # clean
cargo clippy --all-targets --no-default-features -- -D warnings  # clean
cargo fmt               # formatted
```