### PR TITLE
test: add focused backend coverage

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -368,4 +368,29 @@ mod tests {
             None => unsafe { env::remove_var("TWITCH_RELAY_ROTATE_PASSWORD") },
         }
     }
+
+    #[test]
+    fn parse_bool_invalid_rotate_password_returns_config_error() {
+        let _lock = env_test_lock().lock().expect("env test lock");
+        const VAR_NAME: &str = "TWITCH_RELAY_ROTATE_PASSWORD";
+
+        // Save any existing value
+        let previous = env::var(VAR_NAME).ok();
+        unsafe { env::set_var(VAR_NAME, "invalid_value") };
+
+        let result = parse_bool(VAR_NAME);
+        assert!(result.is_err());
+        if let Err(AppError::Config(msg)) = result {
+            assert!(msg.contains("TWITCH_RELAY_ROTATE_PASSWORD"));
+            assert!(msg.contains("expected boolean"));
+        } else {
+            panic!("expected AppError::Config for invalid bool value");
+        }
+
+        // Restore
+        match previous {
+            Some(value) => unsafe { env::set_var(VAR_NAME, value) },
+            None => unsafe { env::remove_var(VAR_NAME) },
+        }
+    }
 }

--- a/src/invidious.rs
+++ b/src/invidious.rs
@@ -732,10 +732,53 @@ mod tests {
     }
 
     #[test]
+    fn test_is_valid_channel_id_rejects_invalid_characters() {
+        // Valid channel ID format: UC prefix + 22 alphanumeric/underscore/hyphen chars
+        let base = "UC_x5XG1OV2P6uZZ5FSM9Tt";
+        assert!(!is_valid_channel_id(
+            &format!("{}w", base).replace('w', "!")
+        ));
+        assert!(!is_valid_channel_id(
+            &format!("{}w", base).replace('w', "@")
+        ));
+        assert!(!is_valid_channel_id(
+            &format!("{}w", base).replace('w', "#")
+        ));
+        assert!(!is_valid_channel_id(
+            &format!("{}w", base).replace('w', "$")
+        ));
+        assert!(!is_valid_channel_id(
+            &format!("{}w", base).replace('w', "%")
+        ));
+        assert!(!is_valid_channel_id(
+            &format!("{}w", base).replace('w', "+")
+        ));
+        assert!(!is_valid_channel_id(
+            &format!("{}w", base).replace('w', "=")
+        ));
+        assert!(!is_valid_channel_id(
+            &format!("{}w", base).replace('w', " ")
+        ));
+    }
+
+    #[test]
     fn test_is_valid_video_id() {
         assert!(is_valid_video_id("dQw4w9WgXcQ"));
         assert!(!is_valid_video_id("tooshort"));
         assert!(!is_valid_video_id("waytoolongforvideoid"));
+    }
+
+    #[test]
+    fn test_is_valid_video_id_rejects_invalid_characters() {
+        // Valid video ID format: 11 alphanumeric/underscore/hyphen chars
+        assert!(!is_valid_video_id("dQw4w9WgXc!"));
+        assert!(!is_valid_video_id("dQw4w9WgXc@"));
+        assert!(!is_valid_video_id("dQw4w9WgXc#"));
+        assert!(!is_valid_video_id("dQw4w9WgXc$"));
+        assert!(!is_valid_video_id("dQw4w9WgXc%"));
+        assert!(!is_valid_video_id("dQw4w9WgXc+"));
+        assert!(!is_valid_video_id("dQw4w9WgXc="));
+        assert!(!is_valid_video_id("dQw4w9WgXcQ "));
     }
 
     #[test]
@@ -744,5 +787,18 @@ mod tests {
         assert!(!is_valid_playlist_id("PL"));
         assert!(!is_valid_playlist_id("invalid"));
         assert!(!is_valid_playlist_id("UC_invalid_playlist"));
+    }
+
+    #[test]
+    fn test_is_valid_playlist_id_rejects_invalid_characters() {
+        // Valid playlist ID format: valid prefix + at least 1 alphanumeric/underscore/hyphen
+        assert!(!is_valid_playlist_id("PLxxxxxxxxxxxxxxxxxxxxxxxxxx!x"));
+        assert!(!is_valid_playlist_id("PLxxxxxxxxxxxxxxxxxxxxxxxxxx@x"));
+        assert!(!is_valid_playlist_id("PLxxxxxxxxxxxxxxxxxxxxxxxxxx#x"));
+        assert!(!is_valid_playlist_id("PLxxxxxxxxxxxxxxxxxxxxxxxxxx$x"));
+        assert!(!is_valid_playlist_id("PLxxxxxxxxxxxxxxxxxxxxxxxxxx%x"));
+        assert!(!is_valid_playlist_id("PLxxxxxxxxxxxxxxxxxxxxxxxxxx+x"));
+        assert!(!is_valid_playlist_id("PLxxxxxxxxxxxxxxxxxxxxxxxxxx=x"));
+        assert!(!is_valid_playlist_id("PLxxxxxxxxxxxxxxxxxxxxxxxxxx x"));
     }
 }

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -931,4 +931,25 @@ mod tests {
             Err(RecordingError::InvalidFilename)
         );
     }
+
+    #[test]
+    fn validate_recording_filename_rejects_path_traversal() {
+        // Path traversal patterns
+        assert_eq!(
+            validate_recording_filename("../foo.mp4"),
+            Err(RecordingError::InvalidFilename)
+        );
+        assert_eq!(
+            validate_recording_filename("../recording.ts"),
+            Err(RecordingError::InvalidFilename)
+        );
+        assert_eq!(
+            validate_recording_filename("../../etc/passwd"),
+            Err(RecordingError::InvalidFilename)
+        );
+        assert_eq!(
+            validate_recording_filename("foo/../bar.ts"),
+            Err(RecordingError::InvalidFilename)
+        );
+    }
 }


### PR DESCRIPTION
## Summary

This PR adds focused backend tests to improve confidence around behavior-preserving refactors. The tests are pure/offline and do not require external services.

### Test Areas Added

**Config Parsing** (`src/config.rs`)
- `parse_bool_invalid_rotate_password_returns_config_error`: Tests that invalid boolean values for `TWITCH_RELAY_ROTATE_PASSWORD` return a proper `AppError::Config` with expected message content

**Recording Validation** (`src/recording.rs`)
- `validate_recording_filename_rejects_path_traversal`: Tests that various path traversal patterns (`../foo.mp4`, `../../etc/passwd`, `foo/../bar.ts`) are rejected

**Invidious Validators** (`src/invidious.rs`)
- `test_is_valid_channel_id_rejects_invalid_characters`: Tests channel ID validation rejects invalid characters (`!`, `@`, `#`, `$`, `%`, `+`, `=`, space)
- `test_is_valid_video_id_rejects_invalid_characters`: Tests video ID validation rejects invalid characters
- `test_is_valid_playlist_id_rejects_invalid_characters`: Tests playlist ID validation rejects invalid characters

### Test Characteristics

- All tests are pure/offline and do not require external services (Twitch, Invidious, Streamlink, FFmpeg, Docker, network)
- No runtime behavior changes
- No new dependencies
- No frontend changes

### Validation Results

```
$ cargo fmt
$ cargo test
running 50 tests
test result: ok. 50 passed; 0 failed; 0 ignored

$ cargo clippy --all-targets --all-features
    Finished dev [unoptimized + debuginfo] target(s) in 6.78s

$ cd web && pnpm run check
pass: All 27 files are correctly formatted
pass: Found no warnings or lint errors in 38 files
svelte-check found 0 errors and 0 warnings
```

### Files Changed
- `src/config.rs` - 25 lines added
- `src/invidious.rs` - 56 lines added
- `src/recording.rs` - 21 lines added

Total: 102 lines added, 5 new tests (50 total)