### PR TITLE
docs: clarify docker deployment config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # syntax=docker/dockerfile:1.7
 
+# Stage: web-build
+# Purpose: Build the SvelteKit frontend and prepare static assets.
+# Outputs: /build/web/build (SvelteKit production build) and /build/web/static (watch player assets)
 FROM node:22-alpine AS web-build
 WORKDIR /build/web
 
@@ -13,18 +16,25 @@ COPY web/ ./
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
     pnpm run build
 
+# Stage: rust-base
+# Purpose: Base image with Rust toolchain and cargo-chef for dependency caching.
 FROM rust:1.88-alpine AS rust-base
 WORKDIR /build
 
 RUN apk add --no-cache musl-dev pkgconfig \
     && cargo install cargo-chef --locked
 
+# Stage: rust-planner
+# Purpose: Analyze Cargo.toml/Cargo.lock and src to generate a recipe.json for dependency caching.
 FROM rust-base AS rust-planner
 
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 RUN cargo chef prepare --recipe-path recipe.json
 
+# Stage: rust-cook
+# Purpose: Build and cache dependencies only (no application code yet).
+# This layer is cached and reused if dependencies haven't changed.
 FROM rust-base AS rust-cook
 
 COPY --from=rust-planner /build/recipe.json recipe.json
@@ -33,6 +43,8 @@ RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
     --mount=type=cache,id=cargo-target,target=/build/target \
     cargo chef cook --release --locked --recipe-path recipe.json
 
+# Stage: rust-build
+# Purpose: Build the Rust binary. Dependencies are pre-cooked from the previous stage.
 FROM rust-base AS rust-build
 
 COPY Cargo.toml Cargo.lock ./
@@ -43,9 +55,13 @@ RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
     cargo build --release --locked \
     && cp /build/target/release/twitch-relay /build/twitch-relay
 
+# Stage: runtime
+# Purpose: Minimal production image with only runtime dependencies.
 FROM alpine:3.22 AS runtime
 WORKDIR /app
 
+# Install runtime dependencies and create a non-root user for security.
+# The app user (UID 10001) runs the container to limit potential damage from security issues.
 RUN apk add --no-cache ca-certificates python3 py3-pip ffmpeg \
     && pip3 install --no-cache-dir --break-system-packages "streamlink==8.3.0" \
     && addgroup -S app \
@@ -53,10 +69,17 @@ RUN apk add --no-cache ca-certificates python3 py3-pip ffmpeg \
     && mkdir -p /app/web/build /app/web/static /app/recordings /data \
     && chown -R app:app /app /data
 
+# Copy the compiled Rust binary into the runtime image.
 COPY --from=rust-build /build/twitch-relay /app/twitch-relay
+
+# Copy the built frontend assets into the runtime image.
+# /app/web/build: SvelteKit production build (served by the backend at root routes).
+# /app/web/static: Static watch player assets (watch.js, watch.css) served at /static.
 COPY --from=web-build /build/web/build /app/web/build
 COPY --from=web-build /build/web/static /app/web/static
 
+# Default runtime configuration values.
+# These can be overridden at runtime via environment variables or docker-compose.yml.
 ENV BIND_ADDR=0.0.0.0:8080
 ENV STREAMLINK_PATH=streamlink
 ENV STREAM_RESOLVER_MODE=auto
@@ -71,11 +94,10 @@ ENV RECORDING_STOP_OFFLINE_CONFIRMATIONS=3
 ENV FFMPEG_PATH=ffmpeg
 ENV RECORDING_CHAPTER_MIN_GAP_SECS=180
 ENV RECORDING_CHAPTER_CHANGE_CONFIRMATIONS=2
-ENV RECORDING_HLS_SEGMENT_DURATION=6
-ENV RECORDING_HLS_CACHE_TTL_SECS=259200
 
 EXPOSE 8080
 
+# Run as non-root user for security.
 USER app
 
 ENTRYPOINT ["/app/twitch-relay"]

--- a/README.md
+++ b/README.md
@@ -80,16 +80,27 @@ pnpm run preview
 
 The simplest way to run Twitch Relay is via Docker Compose using the pre-built image from GitHub Container Registry.
 
+### Quick Start
+
 ```bash
 # Create your env file from the example
 cp .env.example .env
 
 # Edit .env with your Twitch OAuth credentials
 # Then start the container
+docker compose pull
 docker compose up -d
+docker compose logs -f twitch-relay
 ```
 
 The container exposes port 8080 internally. The compose file maps host port 18081 to container port 8080.
+
+### Setup Notes
+
+- **Environment file**: Create `.env` from `.env.example` and fill in your Twitch OAuth credentials. See `.env.example` for all available options.
+- **Recordings directory**: Ensure `./recordings` exists and is writable by the configured user (default `1000:1000`). Recordings will be owned by this UID/GID.
+- **Image source**: The compose file uses the published GHCR image (`ghcr.io/wandabastyle/twitch_relay:latest`).
+- **Networking**: Compose uses the default project network unless you customize networking in your override file.
 
 ### Data Paths
 
@@ -104,10 +115,6 @@ The compose file mounts:
 ### Permissions
 
 The compose file sets `user: "1000:1000"` to ensure recordings written to the host-mounted `./recordings` directory are owned by your local user (UID/GID 1000). Adjust this to match your host user if needed.
-
-### Environment
-
-Copy `.env.example` to `.env` and configure required values. See `.env.example` for all available options.
 
 ## Configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 # Docker Compose configuration for Twitch Relay
 # Before starting, copy .env.example to .env and configure your Twitch OAuth credentials.
+# The .env file should be based on .env.example with your actual values filled in.
 
 services:
   twitch-relay:
@@ -8,6 +9,7 @@ services:
     container_name: twitch-relay
     # Run as host user (1000:1000) to ensure recordings in ./recordings are writable
     # and owned by your local user. Adjust if your host user has a different UID/GID.
+    # This user needs write access to the ./recordings host directory.
     user: "1000:1000"
     restart: unless-stopped
     ports:
@@ -16,11 +18,13 @@ services:
       - .env
     environment:
       BIND_ADDR: 0.0.0.0:8080
-      STREAM_DELIVERY_MODE: cdn_first # cdn_first | relay
+      # Delivery mode: cdn_first (use Twitch CDN directly) or relay (proxy through this server)
+      STREAM_DELIVERY_MODE: cdn_first
       STREAMLINK_PATH: streamlink
       # Compose intentionally pins streamlink mode for deployed containers,
       # while the image default remains 'auto' (see Dockerfile).
-      STREAM_RESOLVER_MODE: streamlink # auto | native | streamlink
+      # Resolver mode: auto | native | streamlink
+      STREAM_RESOLVER_MODE: streamlink
       TWITCH_CLIENT_ID: kimne78kx3ncx6brgo4mv6wki5h1ko
       XDG_DATA_HOME: /data
       RECORDINGS_DIR: /app/recordings
@@ -34,6 +38,7 @@ services:
       RECORDING_CHAPTER_CHANGE_CONFIRMATIONS: 2
     volumes:
       - twitch-relay-data:/data
+      # Host-mounted recordings directory. Must exist and be writable by the configured user (1000:1000).
       - ./recordings:/app/recordings
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/healthz > /dev/null || exit 1"]


### PR DESCRIPTION
## Summary
Cleaned up Docker, Compose, and deployment documentation with clarifying comments and removed obsolete configuration.

## Changes
- **Dockerfile**: Removed obsolete env vars (`RECORDING_HLS_SEGMENT_DURATION`, `RECORDING_HLS_CACHE_TTL_SECS`); Added comments explaining each build stage purpose, why frontend assets are copied, and the security rationale for the non-root user
- **docker-compose.yml**: Added clarifying comments about `.env` setup, user permissions, recordings directory, and stream mode values; No network removal needed—compose already uses the default project network
- **README.md**: Enhanced Docker Usage section with deployment commands (`docker compose pull`, `up -d`, `logs -f`) and setup notes

## GitHub Actions Workflows
Reviewed 4 workflows (`publish-ghcr.yml`, `docker-checks.yml`, `deploy-prod.yml`, `app-checks.yml`); no changes needed.

## Validation
- `cargo test`: 50 tests passed
- `pnpm run check`: 0 errors, 0 warnings
- `docker compose config`: Valid syntax

## Notes
- Application/API behavior unchanged
- No new dependencies added
- No new workflows created