### PR TITLE
refactor(frontend): extract home state helpers

### DIFF
--- a/web/src/lib/components/home/RecordingsOverview.svelte
+++ b/web/src/lib/components/home/RecordingsOverview.svelte
@@ -4,6 +4,13 @@
     ActiveRecording,
     RecordingFileEntry
   } from './types';
+  import {
+    latestThree,
+    recordingDeleteKey,
+    recordingChannelOptions,
+    filterRecordingsByChannel,
+    shownRecordingEntries
+  } from '$lib/home/recordings';
 
   let {
     activeRecordings,
@@ -19,46 +26,17 @@
     onToggleRecordingPin
   }: RecordingsOverviewProps = $props();
 
-  function latestThree<T>(entries: Array<T>): Array<T> {
-    return entries.slice(0, 3);
-  }
-
-  function recordingsChannelOptions(): Array<string> {
-    const known: Record<string, true> = {};
-    for (const item of completedRecordings) {
-      known[item.channel_login] = true;
-    }
-    for (const item of incompleteRecordings) {
-      known[item.channel_login] = true;
-    }
-    for (const item of Object.values(activeRecordings)) {
-      known[item.channel_login] = true;
-    }
-    return Object.keys(known).sort((a, b) => a.localeCompare(b));
-  }
-
-  function withFilter<T extends { channel_login: string }>(entries: Array<T>): Array<T> {
-    if (recordingsChannelFilter === 'all') {
-      return entries;
-    }
-    return entries.filter((entry) => entry.channel_login === recordingsChannelFilter);
-  }
-
-  function shownEntries<T extends { channel_login: string }>(entries: Array<T>): Array<T> {
-    const filtered = withFilter(entries);
-    return recordingsChannelFilter === 'all' ? latestThree(filtered) : filtered;
-  }
-
-  function recordingDeleteKey(bucket: 'completed' | 'incomplete', file: RecordingFileEntry): string {
-    return `${bucket}:${file.channel_login}:${file.filename}`;
-  }
-
-  const activeList = $derived(withFilter(Object.values(activeRecordings)));
-  const completedList = $derived(withFilter(completedRecordings));
-  const incompleteList = $derived(withFilter(incompleteRecordings));
-  const shownActive = $derived(shownEntries(Object.values(activeRecordings)));
-  const shownCompleted = $derived(shownEntries(completedRecordings));
-  const shownIncomplete = $derived(shownEntries(incompleteRecordings));
+  const channelOptions = $derived(recordingChannelOptions(
+    completedRecordings,
+    incompleteRecordings,
+    activeRecordings
+  ));
+  const activeList = $derived(filterRecordingsByChannel(Object.values(activeRecordings), recordingsChannelFilter));
+  const completedList = $derived(filterRecordingsByChannel(completedRecordings, recordingsChannelFilter));
+  const incompleteList = $derived(filterRecordingsByChannel(incompleteRecordings, recordingsChannelFilter));
+  const shownActive = $derived(shownRecordingEntries(Object.values(activeRecordings), recordingsChannelFilter));
+  const shownCompleted = $derived(shownRecordingEntries(completedRecordings, recordingsChannelFilter));
+  const shownIncomplete = $derived(shownRecordingEntries(incompleteRecordings, recordingsChannelFilter));
 </script>
 
 <div class="recordings-view">
@@ -79,7 +57,7 @@
       onchange={(e) => onUpdateFilter(e.currentTarget.value)}
     >
       <option value="all">All channels</option>
-      {#each recordingsChannelOptions() as channelLogin (channelLogin)}
+      {#each channelOptions as channelLogin (channelLogin)}
         <option value={channelLogin}>{channelLogin}</option>
       {/each}
     </select>

--- a/web/src/lib/home/errors.ts
+++ b/web/src/lib/home/errors.ts
@@ -1,0 +1,6 @@
+export function readMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+  return fallback;
+}

--- a/web/src/lib/home/preferences.ts
+++ b/web/src/lib/home/preferences.ts
@@ -1,0 +1,17 @@
+export const LIVE_ONLY_PREF_KEY = "twitchRelay.liveOnly";
+
+export function loadLiveOnlyPreference(): boolean {
+  try {
+    return window.localStorage.getItem(LIVE_ONLY_PREF_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function saveLiveOnlyPreference(value: boolean): void {
+  try {
+    window.localStorage.setItem(LIVE_ONLY_PREF_KEY, value ? "1" : "0");
+  } catch {
+    // Ignore storage failures and keep in-memory state
+  }
+}

--- a/web/src/lib/home/qr.ts
+++ b/web/src/lib/home/qr.ts
@@ -1,0 +1,10 @@
+export const QR_POLL_INTERVAL_MS = 3000;
+
+export const QR_CODE_OPTIONS = {
+  width: 200,
+  margin: 2,
+  color: {
+    dark: "#c8d3f5",
+    light: "#2f334d",
+  },
+} as const;

--- a/web/src/lib/home/recordings.ts
+++ b/web/src/lib/home/recordings.ts
@@ -1,0 +1,48 @@
+import type { ActiveRecording, RecordingFileEntry } from "$lib/api";
+
+export function latestThree<T>(entries: Array<T>): Array<T> {
+  return entries.slice(0, 3);
+}
+
+export function recordingDeleteKey(
+  bucket: "completed" | "incomplete",
+  file: RecordingFileEntry,
+): string {
+  return `${bucket}:${file.channel_login}:${file.filename}`;
+}
+
+export function recordingChannelOptions(
+  completedRecordings: Array<RecordingFileEntry>,
+  incompleteRecordings: Array<RecordingFileEntry>,
+  activeRecordings: Record<string, ActiveRecording>,
+): Array<string> {
+  const known: Record<string, true> = {};
+  for (const item of completedRecordings) {
+    known[item.channel_login] = true;
+  }
+  for (const item of incompleteRecordings) {
+    known[item.channel_login] = true;
+  }
+  for (const item of Object.values(activeRecordings)) {
+    known[item.channel_login] = true;
+  }
+  return Object.keys(known).sort((a, b) => a.localeCompare(b));
+}
+
+export function filterRecordingsByChannel<T extends { channel_login: string }>(
+  entries: Array<T>,
+  channelFilter: string,
+): Array<T> {
+  if (channelFilter === "all") {
+    return entries;
+  }
+  return entries.filter((entry) => entry.channel_login === channelFilter);
+}
+
+export function shownRecordingEntries<T extends { channel_login: string }>(
+  entries: Array<T>,
+  channelFilter: string,
+): Array<T> {
+  const filtered = filterRecordingsByChannel(entries, channelFilter);
+  return channelFilter === "all" ? latestThree(filtered) : filtered;
+}

--- a/web/src/lib/home/routeView.ts
+++ b/web/src/lib/home/routeView.ts
@@ -1,0 +1,21 @@
+export type InitialHomeView =
+  | { relayMode: "twitch"; twitchView: "channels" | "recordings" }
+  | { relayMode: "youtube"; youtubeView: "subscriptions" | "playlists" };
+
+export function parseInitialHomeView(search: string): InitialHomeView {
+  const params = new URLSearchParams(search);
+  const twitchView = params.get("twitch");
+  const youtubeView = params.get("youtube");
+
+  if (twitchView === "recordings") {
+    return { relayMode: "twitch", twitchView: "recordings" };
+  } else if (twitchView === "channels") {
+    return { relayMode: "twitch", twitchView: "channels" };
+  } else if (youtubeView === "subscriptions") {
+    return { relayMode: "youtube", youtubeView: "subscriptions" };
+  } else if (youtubeView === "playlists") {
+    return { relayMode: "youtube", youtubeView: "playlists" };
+  } else {
+    return { relayMode: "twitch", twitchView: "channels" };
+  }
+}

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -46,9 +46,13 @@
   } from '$lib/api';
   import AppVersion from '$lib/components/AppVersion.svelte';
 
+  import { loadLiveOnlyPreference, saveLiveOnlyPreference } from '$lib/home/preferences';
+  import { readMessage } from '$lib/home/errors';
+  import { parseInitialHomeView } from '$lib/home/routeView';
+  import { QR_POLL_INTERVAL_MS, QR_CODE_OPTIONS } from '$lib/home/qr';
+
   type AuthMode = 'checking' | 'authenticated' | 'unauthenticated';
   type YouTubeViewMode = 'subscriptions' | 'playlists';
-  const LIVE_ONLY_PREF_KEY = 'twitchRelay.liveOnly';
 
   let authMode = $state<AuthMode>('checking');
   let isBusy = $state(false);
@@ -93,26 +97,13 @@
     liveOnly = loadLiveOnlyPreference();
 
     // Parse URL parameters for view state
-    const params = new URLSearchParams(window.location.search);
-    const twitchView = params.get('twitch');
-    const youtubeView = params.get('youtube');
-
-    if (twitchView === 'recordings') {
-      currentView = 'recordings';
+    const initialView = parseInitialHomeView(window.location.search);
+    if (initialView.relayMode === 'twitch') {
+      currentView = initialView.twitchView;
       relayMode.setTwitch();
-    } else if (twitchView === 'channels') {
-      currentView = 'channels';
-      relayMode.setTwitch();
-    } else if (youtubeView === 'subscriptions') {
-      youtubeViewMode = 'subscriptions';
-      relayMode.setYoutube();
-    } else if (youtubeView === 'playlists') {
-      youtubeViewMode = 'playlists';
-      relayMode.setYoutube();
     } else {
-      // Default to twitch channels
-      currentView = 'channels';
-      relayMode.setTwitch();
+      youtubeViewMode = initialView.youtubeView;
+      relayMode.setYoutube();
     }
 
     await initialize();
@@ -162,22 +153,6 @@
       liveStatusError = null;
     } catch {
       liveStatusError = 'Live status refresh is temporarily unavailable';
-    }
-  }
-
-  function loadLiveOnlyPreference(): boolean {
-    try {
-      return window.localStorage.getItem(LIVE_ONLY_PREF_KEY) === '1';
-    } catch {
-      return false;
-    }
-  }
-
-  function saveLiveOnlyPreference(value: boolean): void {
-    try {
-      window.localStorage.setItem(LIVE_ONLY_PREF_KEY, value ? '1' : '0');
-    } catch {
-      // Ignore storage failures and keep in-memory state
     }
   }
 
@@ -235,14 +210,7 @@
 
       // Generate QR code data URL
       const qrUrl = `${window.location.origin}/qr-login/${encodeURIComponent(session.token)}`;
-      qrDataUrl = await QRCode.toDataURL(qrUrl, {
-        width: 200,
-        margin: 2,
-        color: {
-          dark: '#c8d3f5',
-          light: '#2f334d'
-        }
-      });
+      qrDataUrl = await QRCode.toDataURL(qrUrl, QR_CODE_OPTIONS);
 
       // Start polling for status
       startQrPolling();
@@ -283,7 +251,7 @@
       } catch {
         // Ignore polling errors, session might just not be ready yet
       }
-    }, 3000); // Poll every 3 seconds
+    }, QR_POLL_INTERVAL_MS); // Poll every 3 seconds
   }
 
   async function loadChannels(): Promise<void> {
@@ -543,13 +511,6 @@
     } finally {
       isBusy = false;
     }
-  }
-
-  function readMessage(error: unknown, fallback: string): string {
-    if (error instanceof Error && error.message.trim().length > 0) {
-      return error.message;
-    }
-    return fallback;
   }
 
   function handleToggleMode(): void {


### PR DESCRIPTION
## Summary

Extract small pure frontend helpers from home page and recordings overview into focused modules under `web/src/lib/home/`.

### New Helper Modules

| Module | Exports | Description |
|--------|---------|-------------|
| `preferences.ts` | `LIVE_ONLY_PREF_KEY`, `loadLiveOnlyPreference()`, `saveLiveOnlyPreference()` | localStorage helpers for live-only filter preference |
| `routeView.ts` | `InitialHomeView`, `parseInitialHomeView()` | URL query parsing for initial home view state |
| `errors.ts` | `readMessage()` | Error message extraction with fallback |
| `recordings.ts` | `latestThree()`, `recordingDeleteKey()`, `recordingChannelOptions()`, `filterRecordingsByChannel()`, `shownRecordingEntries()` | Pure recordings list/filter helpers |
| `qr.ts` | `QR_POLL_INTERVAL_MS`, `QR_CODE_OPTIONS` | QR code constants (polling interval, dimensions, colors) |

### Modified Components

- `+page.svelte`: Import and use helpers; remove inline definitions
- `RecordingsOverview.svelte`: Import and use recording helpers; remove inline definitions

### Design Notes

- State ownership remains in routes/components (Svelte runes unchanged)
- Helpers are pure functions with explicit arguments
- No new dependencies added
- No backend changes
- No UI changes (CSS classes, markup, text preserved)
- No behavior changes (localStorage keys, API calls, polling intervals preserved)

### Validation

```bash
cd web && pnpm run check    # ✓ 0 errors, 0 warnings
cd web && pnpm run build    # ✓ Build successful
cargo test                     # ✓ 57 passed
```