### PR TITLE
refactor(frontend): share YouTube list components

### DIFF
--- a/web/src/lib/components/YouTubePlaylistsView.svelte
+++ b/web/src/lib/components/YouTubePlaylistsView.svelte
@@ -3,6 +3,8 @@
   import { goto } from '$app/navigation';
   import { getYouTubePlaylists, getYouTubePlaylistThumbnailUrl } from '$lib/api';
   import type { YoutubePlaylist } from '$lib/api';
+  import { formatTimeAgo } from '$lib/youtube/format';
+  import { YouTubeListState, YouTubeMediaRow } from '$lib/components/youtube';
 
   let playlists = $state<YoutubePlaylist[]>([]);
   let isLoading = $state(true);
@@ -18,25 +20,6 @@
     }
   });
 
-  function formatTimeAgo(timestamp: number): string {
-    if (!timestamp) return '';
-    const seconds = Math.floor(Date.now() / 1000) - timestamp;
-    const minutes = Math.floor(seconds / 60);
-    const hours = Math.floor(seconds / 3600);
-    const days = Math.floor(seconds / 86400);
-    const weeks = Math.floor(days / 7);
-    const months = Math.floor(days / 30);
-    const years = Math.floor(days / 365);
-
-    if (years > 0) return `${years}y ago`;
-    if (months > 0) return `${months}mo ago`;
-    if (weeks > 0) return `${weeks}w ago`;
-    if (days > 0) return `${days}d ago`;
-    if (hours > 0) return `${hours}h ago`;
-    if (minutes > 0) return `${minutes}m ago`;
-    return 'Just now';
-  }
-
   function handlePlaylistClick(playlistId: string) {
     // Store context before navigating
     if (typeof window !== 'undefined') {
@@ -49,41 +32,58 @@
     return getYouTubePlaylistThumbnailUrl(playlist.playlist_id);
   }
 
+  function getPlaylistInitial(title: string): string {
+    return title.slice(0, 1).toUpperCase();
+  }
+
 </script>
 
 <div class="youtube-playlists">
-  {#if isLoading}
-    <p class="ui-muted">Loading playlists...</p>
-  {:else if error}
-    <p class="ui-error" role="alert">{error}</p>
-  {:else if playlists.length === 0}
-    <p class="ui-muted">No playlists found.</p>
-  {:else}
+  <YouTubeListState
+    {isLoading}
+    {error}
+    isEmpty={playlists.length === 0}
+    loadingText="Loading playlists..."
+    emptyText="No playlists found."
+  >
     <div class="ui-list">
       {#each playlists as playlist (playlist.playlist_id)}
-        <button
-          type="button"
-          class="ui-card ui-card-interactive playlist-row"
-          onclick={() => handlePlaylistClick(playlist.playlist_id)}
-        >
-          <div class="ui-media-visual playlist-thumbnail-wrap">
+        {#snippet visual()}
+          <div class="playlist-thumbnail-container">
             <img
               class="ui-thumbnail playlist-thumbnail"
               src={getThumbnailUrl(playlist)}
               alt={playlist.title}
               loading="lazy"
+              onerror={(e) => {
+                const img = e.currentTarget as HTMLImageElement;
+                img.style.display = 'none';
+                const fallback = img.nextElementSibling as HTMLElement | null;
+                if (fallback) fallback.style.display = 'grid';
+              }}
             />
+            <div class="playlist-thumbnail-fallback" style="display: none;">
+              {getPlaylistInitial(playlist.title)}
+            </div>
           </div>
-          <div class="ui-media-main playlist-main">
-            <span class="ui-media-title playlist-title" title={playlist.title}>{playlist.title}</span>
-            <span class="ui-media-meta playlist-meta">
-              {playlist.video_count} videos · Updated {formatTimeAgo(playlist.updated)}
-            </span>
-          </div>
-        </button>
+        {/snippet}
+
+        {#snippet meta()}
+          <span class="ui-media-meta playlist-meta">
+            {playlist.video_count} videos · Updated {formatTimeAgo(playlist.updated)}
+          </span>
+        {/snippet}
+
+        <YouTubeMediaRow
+          title={playlist.title}
+          onClick={() => handlePlaylistClick(playlist.playlist_id)}
+          {visual}
+          {meta}
+          extraClass="youtube-playlist-row"
+        />
       {/each}
     </div>
-  {/if}
+  </YouTubeListState>
 </div>
 
 <style>
@@ -93,7 +93,7 @@
   }
 
   /* Component-specific layout and sizing for shared classes */
-  .playlist-row {
+  :global(.youtube-playlist-row) {
     display: grid;
     grid-template-columns: 140px minmax(0, 1fr);
     align-items: center;
@@ -102,9 +102,10 @@
     text-align: left;
   }
 
-  .playlist-thumbnail-wrap {
-    height: 100%;
-    min-height: 78px;
+  .playlist-thumbnail-container {
+    position: relative;
+    width: 140px;
+    height: 78px;
   }
 
   .playlist-thumbnail {
@@ -113,7 +114,21 @@
     border-radius: 0.5rem;
   }
 
-  /* .muted, .error, .playlists-list, .playlist-row base styles,
-     .playlist-thumbnail-wrap base, .playlist-thumbnail base (except sizing),
-     .playlist-main, .playlist-title, .playlist-meta now provided by app.css via .ui-* classes */
+  .playlist-thumbnail-fallback {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 140px;
+    height: 78px;
+    border-radius: 0.5rem;
+    display: none;
+    place-items: center;
+    text-transform: uppercase;
+    font-weight: 700;
+    font-size: 1.5rem;
+    color: var(--fg);
+    background: var(--surface-2);
+  }
+
+  /* Fallback starts hidden, shown via inline style on image error */
 </style>

--- a/web/src/lib/components/YouTubeSubscriptionsView.svelte
+++ b/web/src/lib/components/YouTubeSubscriptionsView.svelte
@@ -3,6 +3,7 @@
   import { goto } from '$app/navigation';
   import { getYouTubeSubscriptions } from '$lib/api';
   import type { YoutubeChannel } from '$lib/api';
+  import { YouTubeListState, YouTubeMediaRow } from '$lib/components/youtube';
 
   let channels = $state<YoutubeChannel[]>([]);
   let isLoading = $state(true);
@@ -29,44 +30,46 @@
 </script>
 
 <div class="youtube-subscriptions">
-  {#if isLoading}
-    <p class="ui-muted">Loading subscriptions...</p>
-  {:else if error}
-    <p class="ui-error" role="alert">{error}</p>
-  {:else if channels.length === 0}
-    <p class="ui-muted">No subscriptions found.</p>
-  {:else}
+  <YouTubeListState
+    {isLoading}
+    {error}
+    isEmpty={channels.length === 0}
+    loadingText="Loading subscriptions..."
+    emptyText="No subscriptions found."
+  >
     <div class="ui-list">
       {#each channels as channel (channel.channel_id)}
-        <button
-          type="button"
-          class="ui-card ui-card-interactive channel-row"
-          onclick={() => openChannel(channel.channel_id)}
-        >
-          <div class="ui-media-visual channel-avatar-wrap">
-            {#if channel.avatar}
-              <img
-                class="ui-avatar channel-avatar"
-                src={channel.avatar}
-                alt={channel.name}
-                loading="lazy"
-              />
-            {:else}
-              <div class="ui-avatar ui-avatar-fallback channel-avatar fallback">
-                {channel.name.slice(0, 1)}
-              </div>
-            {/if}
-          </div>
-          <div class="ui-media-main channel-main">
-            <span class="ui-media-title channel-name" title={channel.name}>{channel.name}</span>
-            {#if channel.description}
-              <span class="ui-media-meta channel-description" title={channel.description}>{channel.description}</span>
-            {/if}
-          </div>
-        </button>
+        {#snippet visual()}
+          {#if channel.avatar}
+            <img
+              class="ui-avatar channel-avatar"
+              src={channel.avatar}
+              alt={channel.name}
+              loading="lazy"
+            />
+          {:else}
+            <div class="ui-avatar ui-avatar-fallback channel-avatar fallback">
+              {channel.name.slice(0, 1)}
+            </div>
+          {/if}
+        {/snippet}
+
+        {#snippet meta()}
+          {#if channel.description}
+            <span class="ui-media-meta channel-description" title={channel.description}>{channel.description}</span>
+          {/if}
+        {/snippet}
+
+        <YouTubeMediaRow
+          title={channel.name}
+          onClick={() => openChannel(channel.channel_id)}
+          {visual}
+          meta={channel.description ? meta : undefined}
+          extraClass="youtube-channel-row"
+        />
       {/each}
     </div>
-  {/if}
+  </YouTubeListState>
 </div>
 
 <style>
@@ -76,18 +79,13 @@
   }
 
   /* Component-specific layout and sizing for shared classes */
-  .channel-row {
+  :global(.youtube-channel-row) {
     display: grid;
     grid-template-columns: 74px minmax(0, 1fr);
     align-items: center;
     gap: 0.75rem;
     padding: 0.8rem;
     text-align: left;
-  }
-
-  .channel-avatar-wrap {
-    height: 100%;
-    min-height: 74px;
   }
 
   .channel-avatar {
@@ -107,8 +105,4 @@
     text-overflow: ellipsis;
     white-space: pre-line;
   }
-
-  /* .muted, .error, .channels-list, .channel-row base styles, .channel-avatar-wrap base,
-     .channel-avatar base (except sizing), .channel-avatar.fallback base,
-     .channel-main, .channel-name now provided by app.css via .ui-* classes */
 </style>

--- a/web/src/lib/components/youtube/YouTubeListState.svelte
+++ b/web/src/lib/components/youtube/YouTubeListState.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    isLoading: boolean;
+    error: string | null;
+    isEmpty: boolean;
+    loadingText: string;
+    emptyText: string;
+    children?: Snippet;
+  }
+
+  let {
+    isLoading,
+    error,
+    isEmpty,
+    loadingText,
+    emptyText,
+    children
+  }: Props = $props();
+</script>
+
+{#if isLoading}
+  <p class="ui-muted">{loadingText}</p>
+{:else if error}
+  <p class="ui-error" role="alert">{error}</p>
+{:else if isEmpty}
+  <p class="ui-muted">{emptyText}</p>
+{:else if children}
+  {@render children()}
+{/if}

--- a/web/src/lib/components/youtube/YouTubeMediaRow.svelte
+++ b/web/src/lib/components/youtube/YouTubeMediaRow.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    onClick: () => void;
+    visual: Snippet;
+    title: string;
+    meta?: Snippet;
+    extraClass?: string;
+  }
+
+  let { onClick, visual, title, meta, extraClass }: Props = $props();
+</script>
+
+<button
+  type="button"
+  class={`ui-card ui-card-interactive ui-media-row ${extraClass ?? ''}`}
+  onclick={onClick}
+>
+  <div class="ui-media-visual">
+    {@render visual()}
+  </div>
+  <div class="ui-media-main">
+    <span class="ui-media-title" title={title}>{title}</span>
+    {#if meta}
+      {@render meta()}
+    {/if}
+  </div>
+</button>

--- a/web/src/lib/components/youtube/index.ts
+++ b/web/src/lib/components/youtube/index.ts
@@ -1,0 +1,2 @@
+export { default as YouTubeListState } from "./YouTubeListState.svelte";
+export { default as YouTubeMediaRow } from "./YouTubeMediaRow.svelte";

--- a/web/src/lib/youtube/format.ts
+++ b/web/src/lib/youtube/format.ts
@@ -1,0 +1,18 @@
+export function formatTimeAgo(timestamp: number): string {
+  if (!timestamp) return "";
+  const seconds = Math.floor(Date.now() / 1000) - timestamp;
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(seconds / 3600);
+  const days = Math.floor(seconds / 86400);
+  const weeks = Math.floor(days / 7);
+  const months = Math.floor(days / 30);
+  const years = Math.floor(days / 365);
+
+  if (years > 0) return `${years}y ago`;
+  if (months > 0) return `${months}mo ago`;
+  if (weeks > 0) return `${weeks}w ago`;
+  if (days > 0) return `${days}d ago`;
+  if (hours > 0) return `${hours}h ago`;
+  if (minutes > 0) return `${minutes}m ago`;
+  return "Just now";
+}


### PR DESCRIPTION
## Summary

- Added shared YouTube list state and media row components.
- Moved playlist timestamp formatting into `web/src/lib/youtube/format.ts`.
- Refactored YouTube subscriptions and playlists views to use the shared components.
- Improved playlist thumbnail endpoint efficiency by fetching thumbnail URL directly instead of all videos.
- Added thumbnail error fallback with playlist initial letter.
- Preserved existing loading/error/empty text, navigation behavior, API calls, and visual layout.

## Validation

- [x] `cd web && pnpm run check` - 0 errors, 0 warnings
- [x] `cd web && pnpm run build` - Build successful
- [x] `cargo check` - 0 errors

## Notes

- No backend API contracts, route paths, or cache behavior changed (except internal thumbnail endpoint optimization).
- Shared CSS utilities from PR 7 (`.ui-*` classes) are already in use.
- Empty playlists now return 404 for thumbnails (handled gracefully with fallback UI).