### PR TITLE
refactor(backend): share time and token helpers

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -3,7 +3,6 @@ use std::{
     fs,
     path::PathBuf,
     sync::{Arc, RwLock},
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 use argon2::{
@@ -18,10 +17,11 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use directories::ProjectDirs;
-use rand::{Rng, distr::Alphanumeric};
 use serde::{Deserialize, Serialize};
 
 use crate::error::AppError;
+use crate::util::time::now_unix_secs;
+use crate::util::token::{generate_access_code, generate_qr_session_token, generate_session_token};
 
 const QR_SESSION_TTL_SECS: u64 = 5 * 60; // 5 minutes
 
@@ -132,7 +132,7 @@ struct ErrorResponse {
 impl WebAuthConfig {
     fn create_session(&self) -> Option<String> {
         let expires_at = now_unix_secs().saturating_add(self.session_ttl_secs);
-        let token = generate_session_token(48);
+        let token = generate_session_token();
         let mut guard = self.sessions.write().ok()?;
         guard.insert(token.clone(), expires_at);
 
@@ -265,7 +265,7 @@ impl WebAuthConfig {
 
     fn create_qr_session(&self) -> Option<(String, u64)> {
         let expires_at = now_unix_secs().saturating_add(QR_SESSION_TTL_SECS);
-        let token = generate_session_token(32);
+        let token = generate_qr_session_token();
         let mut guard = self.qr_sessions.write().ok()?;
 
         // Clean expired sessions
@@ -462,21 +462,6 @@ fn login_attempt_key(headers: &HeaderMap) -> String {
     "unknown-client".to_string()
 }
 
-fn generate_session_token(length: usize) -> String {
-    rand::rng()
-        .sample_iter(Alphanumeric)
-        .take(length)
-        .map(char::from)
-        .collect()
-}
-
-fn now_unix_secs() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_secs())
-        .unwrap_or(0)
-}
-
 fn error_response(status: StatusCode, message: &str, retry_after_secs: Option<u64>) -> Response {
     let mut response = (
         status,
@@ -508,7 +493,7 @@ fn sessions_file_path() -> Option<PathBuf> {
 
 pub fn load_or_initialize_access_code(rotate: bool) -> ResolvedAccessCode {
     if rotate {
-        let generated = generate_access_code(24);
+        let generated = generate_access_code();
         let hash = match hash_access_code(&generated) {
             Ok(value) => value,
             Err(_) => {
@@ -545,7 +530,7 @@ pub fn load_or_initialize_access_code(rotate: bool) -> ResolvedAccessCode {
         };
     }
 
-    let generated = generate_access_code(24);
+    let generated = generate_access_code();
     let hash = match hash_access_code(&generated) {
         Ok(value) => value,
         Err(_) => {
@@ -569,14 +554,6 @@ pub fn load_or_initialize_access_code(rotate: bool) -> ResolvedAccessCode {
             state: PasswordState::GeneratedEphemeral,
         },
     }
-}
-
-fn generate_access_code(length: usize) -> String {
-    rand::rng()
-        .sample_iter(Alphanumeric)
-        .take(length)
-        .map(char::from)
-        .collect()
 }
 
 fn load_stored_auth() -> Option<StoredAuth> {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -5,7 +5,6 @@ use std::{
         Arc,
         atomic::{AtomicU64, Ordering},
     },
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 use axum::{
@@ -21,6 +20,7 @@ use tokio_stream::wrappers::BroadcastStream;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 
 use crate::twitch_auth::TwitchAuthService;
+use crate::util::time::now_unix_secs;
 
 #[derive(Debug, Clone)]
 pub struct ChatService {
@@ -1926,13 +1926,6 @@ fn normalize_channel(channel: &str) -> Result<String, String> {
         return Err("channel login cannot be empty".to_string());
     }
     Ok(normalized)
-}
-
-fn now_unix_secs() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_secs())
-        .unwrap_or(0)
 }
 
 fn resolve_sender_color(raw_color: Option<&str>, raw_login: Option<&str>) -> Option<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,8 @@ mod twitch_auth;
 
 mod twitch_follows;
 
+mod util;
+
 mod youtube;
 
 mod youtube_channels;

--- a/src/playback.rs
+++ b/src/playback.rs
@@ -1,11 +1,12 @@
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
-    time::{SystemTime, UNIX_EPOCH},
 };
 
-use rand::{Rng, distr::Alphanumeric};
 use thiserror::Error;
+
+use crate::util::time::now_unix_secs;
+use crate::util::token::generate_ticket;
 
 #[derive(Debug, Clone)]
 pub struct PlaybackTicketService {
@@ -55,7 +56,7 @@ impl PlaybackTicketService {
 
         let now = now_unix_secs();
         let expires_at_unix = now.saturating_add(self.ttl_secs);
-        let ticket_value = generate_ticket(48);
+        let ticket_value = generate_ticket();
 
         let ticket = WatchTicket {
             channel_login: normalized_channel,
@@ -102,19 +103,4 @@ impl PlaybackTicketService {
             channel_login: ticket.channel_login,
         })
     }
-}
-
-fn generate_ticket(length: usize) -> String {
-    rand::rng()
-        .sample_iter(Alphanumeric)
-        .take(length)
-        .map(char::from)
-        .collect()
-}
-
-fn now_unix_secs() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_secs())
-        .unwrap_or(0)
 }

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -12,6 +12,7 @@ use crate::{
     config::RecordingNfoStyle,
     recording_rules,
     twitch_auth::{HelixChannelMetadata, TwitchAuthService},
+    util::time::now_unix_secs,
 };
 
 mod files;
@@ -101,7 +102,7 @@ impl RecordingService {
             }
         }
 
-        let started_at_unix = now_unix();
+        let started_at_unix = now_unix_secs();
         let filename = build_recording_filename(
             &channel_login,
             started_at_unix,
@@ -662,7 +663,7 @@ impl RecordingService {
         chapter_events: &[ChapterEvent],
     ) {
         let mut chapters = chapter_events.to_vec();
-        let end_offset = now_unix().saturating_sub(metadata.started_at_unix);
+        let end_offset = now_unix_secs().saturating_sub(metadata.started_at_unix);
         chapters.push(ChapterEvent {
             offset_secs: end_offset,
             title: "Stream End".to_string(),

--- a/src/recording/files.rs
+++ b/src/recording/files.rs
@@ -1,20 +1,13 @@
 use std::{
     fs,
     path::{Path, PathBuf},
-    time::{SystemTime, UNIX_EPOCH},
+    time::SystemTime,
 };
 
 use time::format_description;
 
 use super::nfo::{datetime_from_unix, next_same_day_suffix_index};
 use super::types::*;
-
-pub(super) fn now_unix() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
-}
 
 pub(super) fn sanitize_filename(value: &str) -> String {
     let mut sanitized = value

--- a/src/recording_scheduler.rs
+++ b/src/recording_scheduler.rs
@@ -7,6 +7,7 @@ use crate::{
     live_status::LiveStatusService,
     recording::{RecordingMode, RecordingService},
     recording_rules,
+    util::time::now_unix_secs,
 };
 
 #[derive(Debug, Default, Clone)]
@@ -102,7 +103,7 @@ impl RecordingScheduler {
                             .note_game_observation(
                                 &login,
                                 channel_status.game.as_deref(),
-                                now_unix(),
+                                now_unix_secs(),
                             )
                             .await;
 
@@ -113,7 +114,7 @@ impl RecordingScheduler {
                         let max_minutes = rule.max_duration_minutes;
                         if let Some(limit) = max_minutes {
                             let elapsed_secs =
-                                now_unix().saturating_sub(active_recording.started_at_unix);
+                                now_unix_secs().saturating_sub(active_recording.started_at_unix);
                             if elapsed_secs >= limit.saturating_mul(60) {
                                 if let Err(error) = service.stop_recording(&login).await {
                                     tracing::warn!(channel = %login, error = %error, "auto recording max-duration stop failed");
@@ -134,11 +135,4 @@ impl RecordingScheduler {
             }
         });
     }
-}
-
-fn now_unix() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
 }

--- a/src/twitch_auth.rs
+++ b/src/twitch_auth.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 use axum::{
@@ -10,7 +9,6 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Redirect, Response},
 };
-use rand::{Rng, distr::Alphanumeric};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
@@ -22,6 +20,8 @@ use crate::{
     prewarm::PrewarmCoordinator,
     secure_store::{SecureStore, twitch_account_store_path},
     twitch_follows::{self, FollowedChannel},
+    util::time::now_unix_secs,
+    util::token::generate_oauth_state,
 };
 
 const REQUIRED_FOLLOW_SCOPE: &str = "user:read:follows";
@@ -188,7 +188,7 @@ impl TwitchAuthService {
     }
 
     pub async fn build_connect_url(&self, session_token: &str) -> String {
-        let state = generate_state(42);
+        let state = generate_oauth_state();
         let expires_at_unix = now_unix_secs().saturating_add(300);
 
         {
@@ -609,21 +609,6 @@ fn validate_scopes(scopes: &[String], required_scopes: &[&str]) -> Result<(), St
         }
     }
     Ok(())
-}
-
-fn now_unix_secs() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_secs())
-        .unwrap_or(0)
-}
-
-fn generate_state(length: usize) -> String {
-    rand::rng()
-        .sample_iter(Alphanumeric)
-        .take(length)
-        .map(char::from)
-        .collect()
 }
 
 fn error_response(status: StatusCode, message: &str) -> Response {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,2 @@
+pub mod time;
+pub mod token;

--- a/src/util/time.rs
+++ b/src/util/time.rs
@@ -1,0 +1,8 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}

--- a/src/util/token.rs
+++ b/src/util/token.rs
@@ -1,0 +1,29 @@
+use rand::{Rng, distr::Alphanumeric};
+
+pub fn generate_alphanumeric(length: usize) -> String {
+    rand::rng()
+        .sample_iter(Alphanumeric)
+        .take(length)
+        .map(char::from)
+        .collect()
+}
+
+pub fn generate_session_token() -> String {
+    generate_alphanumeric(48)
+}
+
+pub fn generate_qr_session_token() -> String {
+    generate_alphanumeric(32)
+}
+
+pub fn generate_access_code() -> String {
+    generate_alphanumeric(24)
+}
+
+pub fn generate_oauth_state() -> String {
+    generate_alphanumeric(42)
+}
+
+pub fn generate_ticket() -> String {
+    generate_alphanumeric(48)
+}


### PR DESCRIPTION
## Summary

Deduplicates timestamp and token generation helpers across the backend.

## Background

Multiple modules defined identical helper functions:
- `now_unix_secs()` / `now_unix()` - 5 duplicate implementations
- Token generators (Alphanumeric) - 4 duplicate implementations

## Changes

### New `src/util/` module
- `time.rs`: Shared `now_unix_secs()` helper
- `token.rs`: Shared token generators with fixed lengths:
  - `generate_session_token()` - 48 chars
  - `generate_qr_session_token()` - 32 chars  
  - `generate_access_code()` - 24 chars
  - `generate_oauth_state()` - 42 chars
  - `generate_ticket()` - 48 chars

### Refactored modules
- `src/auth.rs`: Import from util, removed local helpers
- `src/twitch_auth.rs`: Import from util, replaced `generate_state()` with `generate_oauth_state()`
- `src/playback.rs`: Import from util, removed local helpers
- `src/recording_scheduler.rs`: Import from util, replaced `now_unix()` calls
- `src/chat.rs`: Import from util, removed local helper
- `src/recording.rs`: Import from util, replaced `now_unix()` calls
- `src/recording/files.rs`: Import from util, removed local helper

## Net Result
- 92 lines removed, 62 lines added
- 5 duplicate timestamp functions consolidated
- 4 duplicate token functions consolidated
- No behavioral changes (same lengths, same fallback behavior)

## Verification
- [x] `cargo fmt -- --check` passes
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test` - 57 tests pass