### PR TITLE
refactor(backend): reuse shared API error responses

### DIFF
--- a/src/routes/error.rs
+++ b/src/routes/error.rs
@@ -3,9 +3,43 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
+use serde::Serialize;
 
-/// Minimal shared error helper for route modules.
-/// Returns a JSON response with the shape: `{ "error": message }`
+/// Standard API error response body with `{ "error": "message" }` shape.
+#[derive(Debug, Serialize)]
+pub struct ApiErrorBody {
+    pub error: String,
+}
+
+/// Create a JSON error response with the standard `{ "error": message }` shape.
+///
+/// This is the shared helper for consistent API error responses across route modules.
+/// For rate-limiting with `Retry-After` headers, use local error handling in `auth.rs`.
 pub fn error_response(status: StatusCode, message: &str) -> Response {
-    (status, Json(serde_json::json!({ "error": message }))).into_response()
+    (
+        status,
+        Json(ApiErrorBody {
+            error: message.to_string(),
+        }),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn error_response_produces_json_shape() {
+        let response: Response = error_response(StatusCode::BAD_REQUEST, "test error message");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body_bytes = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .expect("read body");
+        let json: serde_json::Value = serde_json::from_slice(&body_bytes).expect("parse json");
+
+        assert_eq!(json["error"], "test error message");
+    }
 }

--- a/src/routes/recordings.rs
+++ b/src/routes/recordings.rs
@@ -17,6 +17,7 @@ use crate::{
         ActiveRecording, RecordingBucket, RecordingError, RecordingMode, RecordingService,
     },
     recording_rules::{self, RecordingRule},
+    routes::error::error_response,
 };
 
 /// State for recording routes.
@@ -570,11 +571,6 @@ fn classify_recording_error(error: &RecordingError) -> (StatusCode, &'static str
             "recording operation failed",
         ),
     }
-}
-
-/// Minimal shared error helper for route modules.
-fn error_response(status: StatusCode, message: &str) -> Response {
-    (status, Json(serde_json::json!({ "error": message }))).into_response()
 }
 
 #[cfg(test)]

--- a/src/routes/watch.rs
+++ b/src/routes/watch.rs
@@ -13,7 +13,7 @@ use crate::{
     auth::{self, WebAuthConfig},
     channel_catalog::CatalogChannel,
     playback::PlaybackTicketError,
-    routes::APP_VERSION,
+    routes::{APP_VERSION, error::error_response},
     stream_proxy::{self, RelayQuery},
 };
 
@@ -342,9 +342,4 @@ fn render_error_page(channel: &str, message: &str) -> Response {
     );
 
     (StatusCode::OK, Html(html)).into_response()
-}
-
-/// Minimal shared error helper for route modules.
-fn error_response(status: StatusCode, message: &str) -> Response {
-    (status, Json(serde_json::json!({ "error": message }))).into_response()
 }

--- a/src/stream_proxy.rs
+++ b/src/stream_proxy.rs
@@ -14,6 +14,7 @@ use serde::Deserialize;
 use tokio::{process::Command, sync::RwLock};
 
 use crate::config::{StreamDeliveryMode, StreamResolverMode};
+use crate::routes::error::error_response;
 
 #[derive(Debug, Clone)]
 pub struct StreamProxyState {
@@ -1399,10 +1400,6 @@ pub async fn proxy_segment(
             error_response(StatusCode::BAD_GATEWAY, "failed to fetch stream segment")
         }
     }
-}
-
-fn error_response(status: StatusCode, message: &str) -> Response {
-    (status, axum::Json(serde_json::json!({ "error": message }))).into_response()
 }
 
 #[cfg(test)]

--- a/src/twitch_auth.rs
+++ b/src/twitch_auth.rs
@@ -18,6 +18,7 @@ use crate::{
     config::TwitchOAuthConfig,
     error::AppError,
     prewarm::PrewarmCoordinator,
+    routes::error::error_response,
     secure_store::{SecureStore, twitch_account_store_path},
     twitch_follows::{self, FollowedChannel},
     util::time::now_unix_secs,
@@ -609,8 +610,4 @@ fn validate_scopes(scopes: &[String], required_scopes: &[&str]) -> Result<(), St
         }
     }
     Ok(())
-}
-
-fn error_response(status: StatusCode, message: &str) -> Response {
-    (status, Json(serde_json::json!({ "error": message }))).into_response()
 }


### PR DESCRIPTION
## Summary
Centralize backend API error response handling by reusing the existing shared helper in `src/routes/error.rs`.

## Changes
- Enhanced `src/routes/error.rs` with a proper `ApiErrorBody` struct and documentation
- Migrated 4 modules to use the shared `error_response` helper:
  - `src/twitch_auth.rs`
  - `src/stream_proxy.rs`
  - `src/routes/watch.rs`
  - `src/routes/recordings.rs`
- Added unit test verifying the JSON error shape

## Behavior Preserved
- JSON error response shape: `{ "error": "..." }` (unchanged)
- All HTTP status codes preserved
- `auth.rs` Retry-After rate-limiting kept local (per design)
- `channels.rs` already used shared helper - no changes needed
- No frontend changes

## Verification
- `cargo fmt -- --check` ✓
- `cargo check` ✓
- `cargo test` (70 passed, including new test) ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓

## Intentionally Skipped
- `src/auth.rs` - Rate-limiting with Retry-After header kept in local helper to preserve exact behavior