### PR TITLE
chore(backend): remove unnecessary dead code allowances

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -702,13 +702,11 @@ mod tests {
         LOCK.get_or_init(|| Mutex::new(()))
     }
 
-    #[allow(dead_code)]
     struct AuthFileRestore {
         path: PathBuf,
         previous: Option<Vec<u8>>,
     }
 
-    #[allow(dead_code)]
     impl AuthFileRestore {
         fn capture() -> Self {
             let path = stored_auth_path().expect("stored auth path");

--- a/src/channels.rs
+++ b/src/channels.rs
@@ -71,13 +71,6 @@ pub fn save_channel_image(login: &str, image_data: &[u8]) -> Result<String, Stri
     Ok(filename)
 }
 
-#[allow(dead_code)]
-pub fn delete_channel_image(login: &str) {
-    if let Some(path) = get_channel_image_path(login) {
-        let _ = fs::remove_file(path);
-    }
-}
-
 pub fn update_channel_image(
     login: &str,
     image_filename: &str,


### PR DESCRIPTION
## Summary

Removes unnecessary `#[allow(dead_code)]` markers from backend files.

### Changes

**`src/channels.rs`**
- Removed unused `delete_channel_image(login: &str)` function (lines 74-79)
  - No callers existed in the codebase
  - `remove_channel()` already handles channel image deletion inline

**`src/auth.rs`**
- Removed unnecessary `#[allow(dead_code)]` attributes from:
  - `AuthFileRestore` struct definition
  - `impl AuthFileRestore` block
  - The helper is actively used in tests and compiles without the allowances

### Verification

All checks pass:
- `cargo fmt -- --check` ✅
- `cargo check` ✅
- `cargo test` (70 tests) ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅

### Behavior

- No runtime behavior changes
- No API changes
- No auth/session behavior changes
- No channel persistence or image deletion behavior changes