### PR TITLE
fix(frontend): prevent UI flash when navigating back to home page (#88)

### DIFF
--- a/web/src/lib/components/home/AppHeader.svelte
+++ b/web/src/lib/components/home/AppHeader.svelte
@@ -5,6 +5,7 @@
   let {
     authMode,
     twitchStatus,
+    isTwitchStatusLoaded,
     isTwitchBusy,
     isBusy,
     onToggleMode,
@@ -48,12 +49,15 @@
 
   {#if authMode === 'authenticated'}
     <div class="header-actions">
-      {#if twitchStatus.connected}
+      {#if !isTwitchStatusLoaded}
+        <!-- Loading placeholder: same dimensions as Disconnect button to prevent layout shift -->
+        <span class="twitch-action-placeholder" aria-label="Loading Twitch status"></span>
+      {:else if twitchStatus.connected}
         <button type="button" class="ui-nav-chip" onclick={onDisconnectTwitch} disabled={isTwitchBusy}>
           {isTwitchBusy ? 'Disconnecting...' : 'Disconnect'}
         </button>
       {:else}
-        <button type="button" class="compact" onclick={onConnectTwitch}>Connect Twitch</button>
+        <button type="button" class="ui-nav-chip" onclick={onConnectTwitch}>Connect Twitch</button>
       {/if}
       <button class="ui-nav-chip" onclick={onSignOut} disabled={isBusy}>
         Sign out
@@ -102,15 +106,30 @@
     justify-content: flex-end;
   }
 
+  /* Loading placeholder: reserves same space as Disconnect button to prevent layout shift */
+  .twitch-action-placeholder {
+    display: inline-block;
+    min-width: 6.5rem;
+    min-height: 2rem;
+    padding: 0.4rem 0.8rem;
+    border-radius: 0.6rem;
+    background: var(--surface-2);
+    animation: pulse 1.5s ease-in-out infinite;
+  }
+
+  @keyframes pulse {
+    0%, 100% {
+      opacity: 0.4;
+    }
+    50% {
+      opacity: 0.7;
+    }
+  }
+
   h1 {
     margin: 0.2rem 0 0;
     font-size: clamp(1.5rem, 4vw, 2rem);
     line-height: 1.1;
-  }
-
-  .compact {
-    padding: 0.52rem 0.8rem;
-    font-size: 0.9rem;
   }
 
   /* .nav-chip-btn styles now provided by app.css via .ui-nav-chip */
@@ -187,6 +206,10 @@
     .header-actions {
       width: 100%;
       justify-content: flex-start;
+    }
+
+    .twitch-action-placeholder {
+      min-width: 5.5rem;
     }
   }
 </style>

--- a/web/src/lib/components/home/types.ts
+++ b/web/src/lib/components/home/types.ts
@@ -21,6 +21,7 @@ export interface AppHeaderProps {
   authMode: AuthMode;
   relayMode: RelayMode;
   twitchStatus: TwitchStatusResponse;
+  isTwitchStatusLoaded: boolean;
   isTwitchBusy: boolean;
   isBusy: boolean;
   onToggleMode: () => void;

--- a/web/src/lib/home/channelsController.svelte.ts
+++ b/web/src/lib/home/channelsController.svelte.ts
@@ -11,6 +11,8 @@ import {
 import { readMessage } from "$lib/home/errors";
 import type { ChannelEntry, ChannelStatus, TwitchStatusResponse } from "$lib/api-client/types";
 
+const TWITCH_STATUS_CACHE_KEY = "twitch_relay:twitch_status";
+
 export interface ChannelsControllerDeps {
   setError: (message: string | null) => void;
   onChannelsLoaded?: () => Promise<void>;
@@ -21,6 +23,7 @@ export interface ChannelsController {
   liveStatus: Record<string, ChannelStatus>;
   liveStatusError: string | null;
   twitchStatus: TwitchStatusResponse;
+  isTwitchStatusLoaded: boolean;
   isTwitchBusy: boolean;
   watchingChannel: string | null;
   isAddingChannel: boolean;
@@ -36,11 +39,49 @@ export interface ChannelsController {
   resetState: () => void;
 }
 
+function loadCachedTwitchStatus(): TwitchStatusResponse | null {
+  try {
+    const cached = sessionStorage.getItem(TWITCH_STATUS_CACHE_KEY);
+    if (cached) {
+      const parsed = JSON.parse(cached) as TwitchStatusResponse;
+      // Basic validation to ensure cached data has expected shape
+      if (typeof parsed.connected === "boolean" && Array.isArray(parsed.scopes)) {
+        return parsed;
+      }
+    }
+  } catch {
+    // Ignore sessionStorage errors (e.g., private browsing mode)
+  }
+  return null;
+}
+
+function saveCachedTwitchStatus(status: TwitchStatusResponse): void {
+  try {
+    sessionStorage.setItem(TWITCH_STATUS_CACHE_KEY, JSON.stringify(status));
+  } catch {
+    // Ignore sessionStorage errors
+  }
+}
+
+function clearCachedTwitchStatus(): void {
+  try {
+    sessionStorage.removeItem(TWITCH_STATUS_CACHE_KEY);
+  } catch {
+    // Ignore sessionStorage errors
+  }
+}
+
 export function createChannelsController(deps: ChannelsControllerDeps): ChannelsController {
+  // Try to load cached status immediately to prevent UI flash
+  const cachedStatus = loadCachedTwitchStatus();
+  const initialStatus: TwitchStatusResponse = cachedStatus ?? { connected: false, scopes: [] };
+
   let channels = $state<Array<ChannelEntry>>([]);
   let liveStatus = $state<Record<string, ChannelStatus>>({});
   let liveStatusError = $state<string | null>(null);
-  let twitchStatus = $state<TwitchStatusResponse>({ connected: false, scopes: [] });
+  let twitchStatus = $state<TwitchStatusResponse>(initialStatus);
+  // If we have cached data, consider it "loaded" initially to avoid showing loading state
+  let isTwitchStatusLoaded = $state<boolean>(cachedStatus !== null);
   let isTwitchBusy = $state(false);
   let watchingChannel = $state<string | null>(null);
   let isAddingChannel = $state(false);
@@ -50,9 +91,19 @@ export function createChannelsController(deps: ChannelsControllerDeps): Channels
 
   async function loadTwitchStatus(): Promise<void> {
     try {
-      twitchStatus = await getTwitchStatus();
+      const newStatus = await getTwitchStatus();
+      twitchStatus = newStatus;
+      isTwitchStatusLoaded = true;
+      // Cache the successful response
+      saveCachedTwitchStatus(newStatus);
     } catch (err) {
-      twitchStatus = { connected: false, scopes: [] };
+      // Conservative failure handling: only update if we don't have a cached value
+      // If API fails but we have cached data, keep showing cached state
+      if (!isTwitchStatusLoaded) {
+        twitchStatus = { connected: false, scopes: [] };
+      }
+      // Mark as loaded even on error so UI doesn't stay in loading state indefinitely
+      isTwitchStatusLoaded = true;
       setError(readMessage(err, "failed to load Twitch status"));
     }
   }
@@ -125,6 +176,8 @@ export function createChannelsController(deps: ChannelsControllerDeps): Channels
     try {
       await disconnectTwitch();
       twitchStatus = { connected: false, scopes: [] };
+      // Clear cache when explicitly disconnected
+      clearCachedTwitchStatus();
       await loadChannels();
     } catch (err) {
       setError(readMessage(err, "failed to disconnect Twitch account"));
@@ -152,10 +205,12 @@ export function createChannelsController(deps: ChannelsControllerDeps): Channels
     liveStatus = {};
     liveStatusError = null;
     twitchStatus = { connected: false, scopes: [] };
+    isTwitchStatusLoaded = false;
     isTwitchBusy = false;
     watchingChannel = null;
     isAddingChannel = false;
     isRemovingChannel = false;
+    clearCachedTwitchStatus();
   }
 
   return {
@@ -170,6 +225,9 @@ export function createChannelsController(deps: ChannelsControllerDeps): Channels
     },
     get twitchStatus() {
       return twitchStatus;
+    },
+    get isTwitchStatusLoaded() {
+      return isTwitchStatusLoaded;
     },
     get isTwitchBusy() {
       return isTwitchBusy;

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -167,6 +167,7 @@
       authMode={authController.authMode}
       relayMode={$relayMode}
       twitchStatus={channelsController.twitchStatus}
+      isTwitchStatusLoaded={channelsController.isTwitchStatusLoaded}
       isTwitchBusy={channelsController.isTwitchBusy}
       isBusy={authController.isBusy}
       onToggleMode={handleToggleMode}


### PR DESCRIPTION
## Description

When navigating back from a YouTube channel video list to the home page, the UI was briefly showing "Connect Twitch" button before switching to "Disconnect" (when Twitch is actually connected).

## Changes

### Root Cause
- `channelsController.twitchStatus` defaulted to `{ connected: false, scopes: [] }`
- AppHeader rendered "Connect Twitch" while waiting for API response
- This caused a ~3-4ms flash of the wrong state

### Solution
1. **sessionStorage cache**: Initialize controller with cached Twitch status on mount, eliminating flash on back navigation
2. **isTwitchStatusLoaded state**: Track whether status has been loaded to show loading state
3. **Loading placeholder**: Show neutral placeholder (same size as Disconnect button) while loading
4. **Conservative failure handling**: On API error, preserve cached connected state rather than showing "Connect Twitch"
5. **Consistent button styling**: Both Connect Twitch and Disconnect now use the same `ui-nav-chip` style

### Acceptance Criteria
- [x] Returning from YouTube channel/recording player no longer flashes "Connect Twitch"
- [x] Disconnected users still see "Connect Twitch" after loading
- [x] Connected users see cached "Disconnect" immediately or loading placeholder
- [x] Session storage failures don't break the app
- [x] No layout jump during loading (placeholder reserves same space)

Fixes #88