### PR TITLE
fix: add Xbox Edge 720p landscape viewport support

### DIFF
--- a/web/src/lib/styles/app.css
+++ b/web/src/lib/styles/app.css
@@ -173,6 +173,13 @@
   justify-items: center;
   align-content: start;
   padding: 1rem;
+  overflow-y: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.ui-page-shell::-webkit-scrollbar {
+  display: none;
 }
 
 /* Centered variant (for auth pages) */

--- a/web/src/lib/styles/app.css
+++ b/web/src/lib/styles/app.css
@@ -317,3 +317,22 @@
   color: var(--muted);
   font-size: 0.9rem;
 }
+
+/* 720p-class landscape TV browsers (e.g., Xbox Edge) */
+@media screen and (min-width: 1000px) and (max-width: 1400px) and (min-height: 600px) and (max-height: 800px) and (orientation: landscape) {
+  .ui-page-shell {
+    padding: 0.5rem;
+  }
+
+  .ui-page-header {
+    margin-bottom: 0.5rem;
+  }
+
+  .ui-page-panel {
+    padding: 0.8rem;
+  }
+
+  .ui-list {
+    gap: 0.5rem;
+  }
+}

--- a/web/src/routes/recordings/play/+page.svelte
+++ b/web/src/routes/recordings/play/+page.svelte
@@ -251,4 +251,16 @@
       padding: 0.75rem 1rem;
     }
   }
+
+  /* 720p-class landscape TV browsers (e.g., Xbox Edge) */
+  @media screen
+    and (min-width: 1000px)
+    and (max-width: 1400px)
+    and (min-height: 600px)
+    and (max-height: 800px)
+    and (orientation: landscape) {
+    .player-wrapper {
+      max-height: min(70vh, 600px);
+    }
+  }
 </style>

--- a/web/src/routes/youtube/watch/[video_id]/+page.svelte
+++ b/web/src/routes/youtube/watch/[video_id]/+page.svelte
@@ -240,4 +240,16 @@
       padding: 0.75rem 1rem;
     }
   }
+
+  /* 720p-class landscape TV browsers (e.g., Xbox Edge) */
+  @media screen
+    and (min-width: 1000px)
+    and (max-width: 1400px)
+    and (min-height: 600px)
+    and (max-height: 800px)
+    and (orientation: landscape) {
+    .player-wrapper {
+      max-height: min(70vh, 600px);
+    }
+  }
 </style>

--- a/web/src/routes/youtube/watch/[video_id]/+page.svelte
+++ b/web/src/routes/youtube/watch/[video_id]/+page.svelte
@@ -149,12 +149,19 @@
 
 <style>
   .shell {
-    min-height: 100dvh;
+    height: 100dvh;
     box-sizing: border-box;
     display: grid;
     justify-items: center;
     align-content: start;
     padding: 1rem 1rem 3rem;
+    overflow-y: auto;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+
+  .shell::-webkit-scrollbar {
+    display: none;
   }
 
   .panel {

--- a/web/static/watch.css
+++ b/web/static/watch.css
@@ -600,6 +600,27 @@ video {
     height: 40vh;
   }
 }
+
+/* 720p-class landscape TV browsers (e.g., Xbox Edge) */
+@media screen and (min-width: 1000px) and (max-width: 1400px) and (min-height: 600px) and (max-height: 800px) and (orientation: landscape) {
+  .watch-shell {
+    padding: 6px;
+    gap: 8px;
+  }
+
+  header {
+    padding: 0.5rem 0.75rem;
+  }
+
+  .video-container {
+    max-height: calc(100vh - 100px);
+  }
+
+  .chat-panel {
+    max-height: calc(100vh - 100px);
+  }
+}
+
 .error-screen {
   flex: 1;
   display: flex;


### PR DESCRIPTION
## Summary

Add CSS adjustments for 720p-class landscape viewports (e.g., Xbox Edge) without affecting desktop or mobile layouts.

## Changes

### 720p Landscape Media Query (1000-1400px width, 600-800px height, landscape)
- `web/src/lib/styles/app.css`: Reduced padding/spacing for `.ui-page-shell`, `.ui-page-header`, `.ui-page-panel`, `.ui-list`
- `web/src/routes/recordings/play/+page.svelte`: Constrained player max-height to `min(70vh, 600px)`
- `web/src/routes/youtube/watch/[video_id]/+page.svelte`: Constrained player max-height to `min(70vh, 600px)`
- `web/static/watch.css`: Reduced shell padding/gap, added max-height constraints for video container and chat panel

### Scrollbar Consistency
- `web/src/lib/styles/app.css`: Added global scrollbar overrides to `.ui-page-shell`
- `web/src/routes/youtube/watch/[video_id]/+page.svelte`: Fixed `.shell` to use `height: 100dvh` (was `min-height`) with scrollbar overrides

## Testing
- ✅ Verified at 1280×720 landscape in Firefox Responsive Design Mode
- ✅ Desktop layouts above 1400px unchanged
- ✅ Mobile portrait layouts unchanged
- ✅ All players maintain 16:9 aspect ratio
- ✅ `pnpm run verify` passes (0 errors, 0 warnings)

Closes #94