### PR TITLE
Persist YouTube watch progress and sync completion to Invidious

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ Optional YouTube/Invidious support:
   `INVIDIOUS_SID` when Invidious is behind a reverse proxy that uses Basic auth.
   The `SID` cookie is used for Invidious session auth because the `Authorization`
   header is consumed by the proxy.
+- When authenticated Invidious access is configured (`INVIDIOUS_TOKEN` and/or
+  `INVIDIOUS_SID`), YouTube watch completion state is synced to Invidious history
+  via authenticated history endpoints.
 - If not configured, YouTube features will be disabled and only Twitch will be available.
 
 See `.env.example` for the complete list of configuration options.

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -572,6 +572,37 @@ Get video metadata (for watch page).
 }
 ```
 
+### `GET /api/youtube/video/{video_id}/progress`
+
+Get persisted watch progress for the current authenticated browser session.
+
+**Response:**
+
+```json
+{
+  "has_progress": "bool",
+  "position_secs": "number",
+  "duration_secs": "number?",
+  "should_resume": "bool"
+}
+```
+
+### `POST /api/youtube/video/{video_id}/progress`
+
+Persist watch progress for the current authenticated browser session.
+
+**Request:**
+
+```json
+{
+  "position_secs": "number",
+  "duration_secs": "number?",
+  "event": "tick | pause | ended | unload?"
+}
+```
+
+**Response:** `204 No Content`
+
 ### `GET /api/youtube/playlists`
 
 Get user's playlists.

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -603,6 +603,12 @@ Persist watch progress for the current authenticated browser session.
 
 **Response:** `204 No Content`
 
+**Notes:**
+- When Invidious auth is configured, the backend may sync watched/unwatched state
+  to Invidious history (`/api/v1/auth/history/:id`) based on playback completion.
+- Upstream Invidious sync is best-effort; this endpoint still returns `204` even if
+  Invidious sync fails.
+
 ### `GET /api/youtube/playlists`
 
 Get user's playlists.

--- a/src/invidious.rs
+++ b/src/invidious.rs
@@ -234,6 +234,38 @@ impl InvidiousClient {
         }
     }
 
+    /// Mark a video as watched in authenticated Invidious history.
+    pub async fn mark_video_watched(&self, video_id: &str) -> Result<(), AppError> {
+        if !is_valid_video_id(video_id) {
+            return Err(AppError::Config(format!("invalid video_id: {}", video_id)));
+        }
+
+        let url = format!("{}/api/v1/auth/history/{}", self.base_url, video_id);
+        let response = self
+            .with_basic_auth(self.http.post(&url))
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
+
+        map_history_mutation_status(response.status())
+    }
+
+    /// Remove a video from authenticated Invidious history.
+    pub async fn unmark_video_watched(&self, video_id: &str) -> Result<(), AppError> {
+        if !is_valid_video_id(video_id) {
+            return Err(AppError::Config(format!("invalid video_id: {}", video_id)));
+        }
+
+        let url = format!("{}/api/v1/auth/history/{}", self.base_url, video_id);
+        let response = self
+            .with_basic_auth(self.http.delete(&url))
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
+
+        map_history_mutation_status(response.status())
+    }
+
     /// Get authenticated user's subscriptions
     pub async fn get_subscriptions(&self) -> Result<Vec<YoutubeChannel>, AppError> {
         let url = format!("{}/api/v1/auth/subscriptions", self.base_url);
@@ -671,6 +703,18 @@ impl InvidiousClient {
     }
 }
 
+fn map_history_mutation_status(status: reqwest::StatusCode) -> Result<(), AppError> {
+    if status.is_success() {
+        return Ok(());
+    }
+
+    match status.as_u16() {
+        401 => Err(AppError::InvidiousAuthFailed),
+        429 => Err(AppError::InvidiousRateLimited),
+        _ => Err(AppError::InvidiousBadResponse),
+    }
+}
+
 /// Validate YouTube channel ID format
 fn is_valid_channel_id(channel_id: &str) -> bool {
     // Channel IDs start with "UC" and are 24 characters long
@@ -728,6 +772,7 @@ pub fn is_valid_playlist_id(playlist_id: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use reqwest::StatusCode;
 
     #[test]
     fn test_is_valid_channel_id() {
@@ -806,5 +851,23 @@ mod tests {
         assert!(!is_valid_playlist_id("PLxxxxxxxxxxxxxxxxxxxxxxxxxx+x"));
         assert!(!is_valid_playlist_id("PLxxxxxxxxxxxxxxxxxxxxxxxxxx=x"));
         assert!(!is_valid_playlist_id("PLxxxxxxxxxxxxxxxxxxxxxxxxxx x"));
+    }
+
+    #[test]
+    fn history_mutation_status_mapping() {
+        assert!(map_history_mutation_status(StatusCode::OK).is_ok());
+        assert!(map_history_mutation_status(StatusCode::NO_CONTENT).is_ok());
+        assert!(matches!(
+            map_history_mutation_status(StatusCode::UNAUTHORIZED),
+            Err(AppError::InvidiousAuthFailed)
+        ));
+        assert!(matches!(
+            map_history_mutation_status(StatusCode::TOO_MANY_REQUESTS),
+            Err(AppError::InvidiousRateLimited)
+        ));
+        assert!(matches!(
+            map_history_mutation_status(StatusCode::INTERNAL_SERVER_ERROR),
+            Err(AppError::InvidiousBadResponse)
+        ));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ mod youtube_channels;
 mod youtube_quality;
 
 mod youtube_embed;
+mod youtube_progress;
 
 use std::process::ExitCode;
 

--- a/src/storage/paths.rs
+++ b/src/storage/paths.rs
@@ -41,6 +41,11 @@ pub fn youtube_channels_path() -> Option<PathBuf> {
     data_file_path("youtube_channels.toml")
 }
 
+/// Path to the youtube_watch_progress.toml file.
+pub fn youtube_watch_progress_path() -> Option<PathBuf> {
+    data_file_path("youtube_watch_progress.toml")
+}
+
 /// Path to the auth.toml file.
 pub fn auth_path() -> Option<PathBuf> {
     data_file_path("auth.toml")

--- a/src/youtube.rs
+++ b/src/youtube.rs
@@ -137,6 +137,18 @@ pub struct VideoProgressUpdateRequest {
     pub event: Option<String>,
 }
 
+fn is_effectively_watched(position_secs: u32, duration_secs: Option<u32>) -> bool {
+    let Some(duration) = duration_secs else {
+        return false;
+    };
+
+    if duration == 0 || position_secs > duration {
+        return false;
+    }
+
+    duration.saturating_sub(position_secs) <= 30
+}
+
 /// Build YouTube API routes
 pub fn build_routes(auth: WebAuthConfig, config: &AppConfig) -> Router {
     let state = YoutubeState::new(auth.clone(), config);
@@ -242,6 +254,7 @@ async fn set_video_progress(
         return (StatusCode::UNAUTHORIZED, "authentication required").into_response();
     };
 
+    let previous = state.progress.get_entry(&session_id, &video_id);
     let completed = matches!(payload.event.as_deref(), Some("ended"));
     let position_secs = if completed { 0 } else { payload.position_secs };
 
@@ -252,6 +265,31 @@ async fn set_video_progress(
         payload.duration_secs,
         completed,
     );
+
+    let previous_watched = previous.as_ref().is_some_and(|entry| {
+        entry.completed || is_effectively_watched(entry.position_secs, entry.duration_secs)
+    });
+    let next_watched =
+        completed || is_effectively_watched(payload.position_secs, payload.duration_secs);
+
+    if let Some(client) = state.invidious_client() {
+        let sync_result = if !previous_watched && next_watched {
+            client.mark_video_watched(&video_id).await
+        } else if previous_watched && !next_watched {
+            client.unmark_video_watched(&video_id).await
+        } else {
+            Ok(())
+        };
+
+        if let Err(error) = sync_result {
+            tracing::warn!(
+                %error,
+                %video_id,
+                event = ?payload.event,
+                "failed to sync youtube history state to invidious"
+            );
+        }
+    }
 
     StatusCode::NO_CONTENT.into_response()
 }
@@ -839,5 +877,23 @@ async fn proxy_static_asset(
             )
                 .into_response()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_effectively_watched;
+
+    #[test]
+    fn effectively_watched_requires_duration() {
+        assert!(!is_effectively_watched(100, None));
+    }
+
+    #[test]
+    fn effectively_watched_checks_near_end_threshold() {
+        assert!(!is_effectively_watched(60, Some(200)));
+        assert!(is_effectively_watched(170, Some(200)));
+        assert!(is_effectively_watched(200, Some(200)));
+        assert!(!is_effectively_watched(205, Some(200)));
     }
 }

--- a/src/youtube.rs
+++ b/src/youtube.rs
@@ -23,6 +23,7 @@ use crate::{
         YoutubeVideoMeta, is_valid_video_id,
     },
     youtube_embed::{get_embed, get_embed_config, rewrite_dash_manifest},
+    youtube_progress::YoutubeWatchProgressStore,
     youtube_quality::{
         QualityObservation, QualityObservedResponse, get_video_quality_observed,
         get_video_quality_stream, observe_quality_from_request,
@@ -32,22 +33,26 @@ use crate::{
 /// State for YouTube routes
 #[derive(Debug, Clone)]
 pub struct YoutubeState {
+    auth: WebAuthConfig,
     invidious: Option<InvidiousClient>,
     invidious_base_url: Option<String>,
     pub(crate) quality_observations: Arc<Mutex<HashMap<String, QualityObservation>>>,
     pub(crate) quality_streams:
         Arc<Mutex<HashMap<String, broadcast::Sender<QualityObservedResponse>>>>,
+    progress: YoutubeWatchProgressStore,
 }
 
 impl YoutubeState {
-    pub fn new(_auth: WebAuthConfig, config: &AppConfig) -> Self {
+    pub fn new(auth: WebAuthConfig, config: &AppConfig) -> Self {
         let invidious = config.invidious.as_ref().map(InvidiousClient::new);
         let invidious_base_url = config.invidious.as_ref().map(|c| c.base_url.clone());
         Self {
+            auth,
             invidious,
             invidious_base_url,
             quality_observations: Arc::new(Mutex::new(HashMap::new())),
             quality_streams: Arc::new(Mutex::new(HashMap::new())),
+            progress: YoutubeWatchProgressStore::new(),
         }
     }
 
@@ -63,6 +68,10 @@ impl YoutubeState {
 
     pub(crate) fn invidious_client(&self) -> Option<&InvidiousClient> {
         self.invidious.as_ref()
+    }
+
+    pub(crate) fn session_token_from_headers(&self, headers: &HeaderMap) -> Option<String> {
+        self.auth.session_token_from_headers(headers)
     }
 }
 
@@ -113,6 +122,21 @@ pub struct PlaylistVideosResponse {
     pub videos: Vec<YoutubeVideo>,
 }
 
+#[derive(Debug, Serialize)]
+pub struct VideoProgressResponse {
+    pub has_progress: bool,
+    pub position_secs: u32,
+    pub duration_secs: Option<u32>,
+    pub should_resume: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct VideoProgressUpdateRequest {
+    pub position_secs: u32,
+    pub duration_secs: Option<u32>,
+    pub event: Option<String>,
+}
+
 /// Build YouTube API routes
 pub fn build_routes(auth: WebAuthConfig, config: &AppConfig) -> Router {
     let state = YoutubeState::new(auth.clone(), config);
@@ -128,6 +152,10 @@ pub fn build_routes(auth: WebAuthConfig, config: &AppConfig) -> Router {
             get(get_channel_info),
         )
         .route("/api/youtube/video/{video_id}/meta", get(get_video_meta))
+        .route(
+            "/api/youtube/video/{video_id}/progress",
+            get(get_video_progress).post(set_video_progress),
+        )
         .route(
             "/api/youtube/video/{video_id}/quality-observed",
             get(get_video_quality_observed),
@@ -160,6 +188,72 @@ pub fn build_routes(auth: WebAuthConfig, config: &AppConfig) -> Router {
             auth,
             auth::require_session_middleware,
         ))
+}
+
+async fn get_video_progress(
+    State(state): State<YoutubeState>,
+    headers: HeaderMap,
+    Path(video_id): Path<String>,
+) -> Response {
+    if !is_valid_video_id(&video_id) {
+        return (StatusCode::BAD_REQUEST, "invalid video_id format").into_response();
+    }
+
+    let Some(session_id) = state.session_token_from_headers(&headers) else {
+        return (StatusCode::UNAUTHORIZED, "authentication required").into_response();
+    };
+
+    if let Some(progress) = state.progress.get(&session_id, &video_id) {
+        return (
+            StatusCode::OK,
+            Json(VideoProgressResponse {
+                has_progress: true,
+                position_secs: progress.position_secs,
+                duration_secs: progress.duration_secs,
+                should_resume: progress.should_resume,
+            }),
+        )
+            .into_response();
+    }
+
+    (
+        StatusCode::OK,
+        Json(VideoProgressResponse {
+            has_progress: false,
+            position_secs: 0,
+            duration_secs: None,
+            should_resume: false,
+        }),
+    )
+        .into_response()
+}
+
+async fn set_video_progress(
+    State(state): State<YoutubeState>,
+    headers: HeaderMap,
+    Path(video_id): Path<String>,
+    Json(payload): Json<VideoProgressUpdateRequest>,
+) -> Response {
+    if !is_valid_video_id(&video_id) {
+        return (StatusCode::BAD_REQUEST, "invalid video_id format").into_response();
+    }
+
+    let Some(session_id) = state.session_token_from_headers(&headers) else {
+        return (StatusCode::UNAUTHORIZED, "authentication required").into_response();
+    };
+
+    let completed = matches!(payload.event.as_deref(), Some("ended"));
+    let position_secs = if completed { 0 } else { payload.position_secs };
+
+    state.progress.upsert(
+        &session_id,
+        &video_id,
+        position_secs,
+        payload.duration_secs,
+        completed,
+    );
+
+    StatusCode::NO_CONTENT.into_response()
 }
 
 /// Get authenticated user's subscriptions

--- a/src/youtube_embed.rs
+++ b/src/youtube_embed.rs
@@ -225,6 +225,21 @@ fn inject_quality_indicator_script(html: &str, video_id: &str) -> String {
     format!("{html}{script}")
 }
 
+fn inject_watch_progress_script(html: &str, video_id: &str) -> String {
+    let mut script = r#"<script>(function(){const videoId='__VIDEO_ID__';const progressEndpoint=`/api/youtube/video/${encodeURIComponent(videoId)}/progress`;const saveEveryMs=10000;let lastSentAt=0;let pendingTick=null;let resumeApplied=false;function parseNumber(value){if(typeof value!=='number'||!Number.isFinite(value)){return null;}if(value<0){return 0;}return Math.floor(value);}function findVideo(){return document.querySelector('video');}async function loadProgressAndSeek(video){try{const res=await fetch(progressEndpoint,{credentials:'same-origin'});if(!res.ok){return;}const body=await res.json();if(!body||!body.has_progress||!body.should_resume){return;}const position=parseNumber(body.position_secs);if(position===null||position<=0){return;}const applySeek=()=>{if(resumeApplied){return;}if(video.readyState<1){return;}const maxSeek=Number.isFinite(video.duration)&&video.duration>0?Math.max(0,video.duration-2):position;if(position>maxSeek){video.currentTime=maxSeek;}else{video.currentTime=position;}resumeApplied=true;};if(video.readyState>=1){applySeek();}else{video.addEventListener('loadedmetadata',applySeek,{once:true});}}catch(_){}}async function sendProgress(video,eventName){const position=parseNumber(video.currentTime);if(position===null){return;}const duration=parseNumber(video.duration);const payload={position_secs:position,duration_secs:duration===null?undefined:duration,event:eventName};try{await fetch(progressEndpoint,{method:'POST',credentials:'same-origin',headers:{'content-type':'application/json'},body:JSON.stringify(payload),keepalive:eventName==='unload'});}catch(_){}}function scheduleTick(video){if(pendingTick!==null){return;}pendingTick=window.setTimeout(async()=>{pendingTick=null;await sendProgress(video,'tick');lastSentAt=Date.now();scheduleTick(video);},saveEveryMs);}function clearTick(){if(pendingTick!==null){window.clearTimeout(pendingTick);pendingTick=null;}}function wireVideo(video){loadProgressAndSeek(video);video.addEventListener('play',()=>{if(Date.now()-lastSentAt>=saveEveryMs){sendProgress(video,'tick').catch(()=>{});lastSentAt=Date.now();}scheduleTick(video);});video.addEventListener('pause',()=>{clearTick();sendProgress(video,'pause').catch(()=>{});});video.addEventListener('ended',()=>{clearTick();sendProgress(video,'ended').catch(()=>{});});window.addEventListener('pagehide',()=>{sendProgress(video,'unload').catch(()=>{});});window.addEventListener('beforeunload',()=>{sendProgress(video,'unload').catch(()=>{});});}function boot(){const video=findVideo();if(video){wireVideo(video);return;}const observer=new MutationObserver(()=>{const discovered=findVideo();if(!discovered){return;}observer.disconnect();wireVideo(discovered);});observer.observe(document.documentElement,{childList:true,subtree:true});}if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',boot,{once:true});}else{boot();}})();</script>"#.to_string();
+    script = script.replace("__VIDEO_ID__", video_id);
+
+    if let Some(idx) = html.rfind("</body>") {
+        let mut out = String::with_capacity(html.len() + script.len());
+        out.push_str(&html[..idx]);
+        out.push_str(&script);
+        out.push_str(&html[idx..]);
+        return out;
+    }
+
+    format!("{html}{script}")
+}
+
 /// Proxy embed requests to avoid basic auth popup in browser.
 /// Fetches the Invidious embed page with backend authentication.
 pub async fn get_embed(
@@ -359,6 +374,7 @@ pub async fn get_embed(
     // Rewrite root-relative URLs to absolute URLs
     let rewritten_html = rewrite_html_urls(&html, base_url);
     let rewritten_html = inject_quality_indicator_script(&rewritten_html, &video_id);
+    let rewritten_html = inject_watch_progress_script(&rewritten_html, &video_id);
     let rewritten_bytes = rewritten_html.into_bytes();
 
     // Build response with appropriate headers
@@ -566,6 +582,15 @@ mod tests {
         assert!(
             output.contains("/api/youtube/video/${encodeURIComponent(videoId)}/quality-observed")
         );
+        assert!(output.contains("</body></html>"));
+    }
+
+    #[test]
+    fn inject_watch_progress_script_inserts_progress_endpoints() {
+        let input = "<html><body><div>player</div></body></html>";
+        let output = inject_watch_progress_script(input, "vYy4em2fQ8Q");
+        assert!(output.contains("/api/youtube/video/${encodeURIComponent(videoId)}/progress"));
+        assert!(output.contains("saveEveryMs=10000"));
         assert!(output.contains("</body></html>"));
     }
 }

--- a/src/youtube_progress.rs
+++ b/src/youtube_progress.rs
@@ -67,6 +67,12 @@ impl YoutubeWatchProgressStore {
         })
     }
 
+    pub fn get_entry(&self, session_id: &str, video_id: &str) -> Option<YoutubeProgressEntry> {
+        let key = (session_id.to_string(), video_id.to_string());
+        let guard = self.entries.read().ok()?;
+        guard.get(&key).cloned()
+    }
+
     pub fn upsert(
         &self,
         session_id: &str,

--- a/src/youtube_progress.rs
+++ b/src/youtube_progress.rs
@@ -1,0 +1,165 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+
+use serde::{Deserialize, Serialize};
+
+use crate::storage;
+use crate::util::time::now_unix_secs;
+
+const RESUME_MIN_SECS: u32 = 30;
+const FRESHNESS_TTL_SECS: u64 = 90 * 24 * 60 * 60;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct YoutubeProgressEntry {
+    pub session_id: String,
+    pub video_id: String,
+    pub position_secs: u32,
+    pub duration_secs: Option<u32>,
+    pub updated_at_unix: u64,
+    pub completed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct YoutubeProgressFile {
+    entries: Vec<YoutubeProgressEntry>,
+}
+
+#[derive(Debug, Clone)]
+pub struct YoutubeWatchProgressStore {
+    path: Option<PathBuf>,
+    entries: Arc<RwLock<HashMap<(String, String), YoutubeProgressEntry>>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct YoutubeProgressSnapshot {
+    pub position_secs: u32,
+    pub duration_secs: Option<u32>,
+    pub should_resume: bool,
+}
+
+impl YoutubeWatchProgressStore {
+    pub fn new() -> Self {
+        let path = storage::paths::youtube_watch_progress_path();
+        let map = path
+            .as_ref()
+            .and_then(|p| load_file_entries(p).ok())
+            .unwrap_or_default();
+
+        Self {
+            path,
+            entries: Arc::new(RwLock::new(map)),
+        }
+    }
+
+    pub fn get(&self, session_id: &str, video_id: &str) -> Option<YoutubeProgressSnapshot> {
+        let key = (session_id.to_string(), video_id.to_string());
+        let guard = self.entries.read().ok()?;
+        let entry = guard.get(&key)?;
+        if entry.completed {
+            return None;
+        }
+
+        Some(YoutubeProgressSnapshot {
+            position_secs: entry.position_secs,
+            duration_secs: entry.duration_secs,
+            should_resume: should_resume(entry.position_secs, entry.duration_secs),
+        })
+    }
+
+    pub fn upsert(
+        &self,
+        session_id: &str,
+        video_id: &str,
+        position_secs: u32,
+        duration_secs: Option<u32>,
+        completed: bool,
+    ) {
+        let now = now_unix_secs();
+        if let Ok(mut guard) = self.entries.write() {
+            prune_stale(&mut guard, now);
+            let key = (session_id.to_string(), video_id.to_string());
+            guard.insert(
+                key,
+                YoutubeProgressEntry {
+                    session_id: session_id.to_string(),
+                    video_id: video_id.to_string(),
+                    position_secs,
+                    duration_secs,
+                    updated_at_unix: now,
+                    completed,
+                },
+            );
+            persist_entries(self.path.as_deref(), &guard);
+        }
+    }
+}
+
+fn load_file_entries(
+    path: &Path,
+) -> Result<HashMap<(String, String), YoutubeProgressEntry>, String> {
+    let file = storage::files::load_toml_optional::<YoutubeProgressFile>(path)?.unwrap_or_default();
+    let now = now_unix_secs();
+    let mut map = HashMap::new();
+    for entry in file.entries {
+        if now.saturating_sub(entry.updated_at_unix) > FRESHNESS_TTL_SECS {
+            continue;
+        }
+        map.insert((entry.session_id.clone(), entry.video_id.clone()), entry);
+    }
+    Ok(map)
+}
+
+fn persist_entries(path: Option<&Path>, entries: &HashMap<(String, String), YoutubeProgressEntry>) {
+    let Some(path) = path else {
+        return;
+    };
+
+    let mut values: Vec<YoutubeProgressEntry> = entries.values().cloned().collect();
+    values.sort_by(|a, b| {
+        a.session_id
+            .cmp(&b.session_id)
+            .then_with(|| a.video_id.cmp(&b.video_id))
+    });
+
+    let file = YoutubeProgressFile { entries: values };
+    let _ = storage::files::write_toml_pretty_atomic(path, &file);
+}
+
+fn prune_stale(entries: &mut HashMap<(String, String), YoutubeProgressEntry>, now: u64) {
+    entries.retain(|_, entry| now.saturating_sub(entry.updated_at_unix) <= FRESHNESS_TTL_SECS);
+}
+
+fn should_resume(position_secs: u32, duration_secs: Option<u32>) -> bool {
+    if position_secs <= RESUME_MIN_SECS {
+        return false;
+    }
+
+    if let Some(duration) = duration_secs {
+        if duration > position_secs {
+            return duration.saturating_sub(position_secs) > RESUME_MIN_SECS;
+        }
+        return false;
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_resume;
+
+    #[test]
+    fn resume_requires_meaningful_progress() {
+        assert!(!should_resume(0, None));
+        assert!(!should_resume(30, None));
+        assert!(should_resume(31, None));
+    }
+
+    #[test]
+    fn resume_rejects_near_end() {
+        assert!(should_resume(200, Some(400)));
+        assert!(!should_resume(370, Some(400)));
+        assert!(!should_resume(400, Some(400)));
+    }
+}


### PR DESCRIPTION
## Summary
- Add per-session YouTube watch progress persistence with GET/POST progress endpoints.
- Inject client-side progress tracking into YouTube embeds to resume playback and periodically save state.
- Sync completed and uncompleted watch state to authenticated Invidious history when configured.
- Document the new progress API and Invidious history behavior in the README and API contracts.

## Testing
- `cargo test`
- `cargo check`
- `cargo clippy --all-targets --all-features`
- `cargo fmt -- --check`