### PR TITLE
Persist YouTube watch progress and resume playback

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -572,6 +572,45 @@ Get video metadata (for watch page).
 }
 ```
 
+### `GET /api/youtube/video/{video_id}/progress`
+
+Get stored playback progress for a video.
+
+**Response:**
+
+```json
+{
+  "video_id": "string",
+  "position_secs": "number?",
+  "duration_secs": "number?",
+  "updated_at_unix": "number?",
+  "completed": "bool",
+  "invidious_sync_attempted": "bool",
+  "invidious_sync_ok": "bool?",
+  "invidious_sync_action": "mark_watched | mark_unwatched | none"
+}
+```
+
+### `PUT /api/youtube/video/{video_id}/progress`
+
+Update stored playback progress for a video.
+
+**Request:**
+
+```json
+{
+  "position_secs": "number",
+  "duration_secs": "number?",
+  "completed": "bool?"
+}
+```
+
+**Response:** Same shape as `GET .../progress`
+
+**Notes:**
+- Local progress persistence is authoritative for resume position.
+- Invidious watch-history sync is best-effort only and never fails this endpoint when local save succeeds.
+
 ### `GET /api/youtube/playlists`
 
 Get user's playlists.

--- a/src/invidious.rs
+++ b/src/invidious.rs
@@ -169,6 +169,13 @@ struct InvidiousPlaylistDetails {
     videos: Vec<InvidiousVideoRaw>,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum InvidiousRecentFeedResponse {
+    Videos(Vec<InvidiousVideoRaw>),
+    Wrapped { videos: Vec<InvidiousVideoRaw> },
+}
+
 #[derive(Debug, Clone, Deserialize)]
 struct Thumbnail {
     url: String,
@@ -409,6 +416,59 @@ impl InvidiousClient {
             .collect();
 
         Ok(videos)
+    }
+
+    /// Get authenticated user's recent videos from subscription feed
+    pub async fn get_recent_videos(
+        &self,
+        max_results: Option<u32>,
+    ) -> Result<Vec<YoutubeVideo>, AppError> {
+        let max = max_results.unwrap_or(25).min(40);
+        let url = format!("{}/api/v1/auth/feed?max_results={}", self.base_url, max);
+
+        let response = self
+            .with_basic_auth(self.http.get(&url))
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
+
+        match response.status() {
+            status if status.is_success() => {
+                let feed: InvidiousRecentFeedResponse = response
+                    .json()
+                    .await
+                    .map_err(|_| AppError::InvidiousBadResponse)?;
+
+                let mut videos: Vec<YoutubeVideo> = match feed {
+                    InvidiousRecentFeedResponse::Videos(videos) => videos,
+                    InvidiousRecentFeedResponse::Wrapped { videos } => videos,
+                }
+                .into_iter()
+                .map(|v| {
+                    let thumbnail = format!("{}/vi/{}/hqdefault.jpg", self.base_url, v.video_id);
+
+                    YoutubeVideo {
+                        title: v.title,
+                        video_id: v.video_id.clone(),
+                        author: v.author,
+                        author_id: v.author_id,
+                        published: v.published,
+                        published_text: v.published_text,
+                        duration: v.length_seconds,
+                        thumbnail,
+                        view_count: v.view_count,
+                        description: Some(v.description).filter(|d| !d.is_empty()),
+                    }
+                })
+                .collect();
+
+                videos.sort_by_key(|video| std::cmp::Reverse(video.published));
+                Ok(videos)
+            }
+            status if status.as_u16() == 401 => Err(AppError::InvidiousAuthFailed),
+            status if status.as_u16() == 429 => Err(AppError::InvidiousRateLimited),
+            _ => Err(AppError::InvidiousBadResponse),
+        }
     }
 
     /// Get channel info including description

--- a/src/invidious.rs
+++ b/src/invidious.rs
@@ -306,6 +306,44 @@ impl InvidiousClient {
         }
     }
 
+    pub async fn mark_video_watched(&self, video_id: &str) -> Result<(), AppError> {
+        if !is_valid_video_id(video_id) {
+            return Err(AppError::Config(format!("invalid video_id: {video_id}")));
+        }
+
+        let url = format!("{}/api/v1/auth/history/{}", self.base_url, video_id);
+        let response = self
+            .with_basic_auth(self.http.post(&url))
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(AppError::InvidiousBadResponse)
+        }
+    }
+
+    pub async fn mark_video_unwatched(&self, video_id: &str) -> Result<(), AppError> {
+        if !is_valid_video_id(video_id) {
+            return Err(AppError::Config(format!("invalid video_id: {video_id}")));
+        }
+
+        let url = format!("{}/api/v1/auth/history/{}", self.base_url, video_id);
+        let response = self
+            .with_basic_auth(self.http.delete(&url))
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(AppError::InvidiousBadResponse)
+        }
+    }
+
     /// Get latest videos for a channel
     pub async fn get_channel_videos(
         &self,

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ mod youtube_channels;
 mod youtube_quality;
 
 mod youtube_embed;
+mod youtube_progress;
 
 use std::process::ExitCode;
 

--- a/src/storage/paths.rs
+++ b/src/storage/paths.rs
@@ -65,3 +65,8 @@ pub fn images_dir() -> Option<PathBuf> {
 pub fn youtube_images_dir() -> Option<PathBuf> {
     data_file_path("youtube_images")
 }
+
+/// Path to the youtube_watch_progress.json file.
+pub fn youtube_watch_progress_path() -> Option<PathBuf> {
+    data_file_path("youtube_watch_progress.json")
+}

--- a/src/youtube.rs
+++ b/src/youtube.rs
@@ -125,6 +125,9 @@ struct YoutubeWatchProgressResponse {
     duration_secs: Option<f64>,
     updated_at_unix: Option<u64>,
     completed: bool,
+    invidious_sync_attempted: bool,
+    invidious_sync_ok: Option<bool>,
+    invidious_sync_action: &'static str,
 }
 
 #[derive(Debug, Deserialize)]
@@ -189,7 +192,11 @@ pub fn build_routes(auth: WebAuthConfig, config: &AppConfig) -> Router {
         ))
 }
 
-fn progress_response(video_id: String, entry: Option<YoutubeWatchProgressEntry>) -> Response {
+fn progress_response(
+    video_id: String,
+    entry: Option<YoutubeWatchProgressEntry>,
+    sync_result: ProgressSyncResult,
+) -> Response {
     let payload = if let Some(entry) = entry {
         YoutubeWatchProgressResponse {
             video_id,
@@ -197,6 +204,9 @@ fn progress_response(video_id: String, entry: Option<YoutubeWatchProgressEntry>)
             duration_secs: entry.duration_secs,
             updated_at_unix: Some(entry.updated_at_unix),
             completed: entry.completed,
+            invidious_sync_attempted: sync_result.attempted,
+            invidious_sync_ok: sync_result.ok,
+            invidious_sync_action: sync_result.action.as_str(),
         }
     } else {
         YoutubeWatchProgressResponse {
@@ -205,6 +215,9 @@ fn progress_response(video_id: String, entry: Option<YoutubeWatchProgressEntry>)
             duration_secs: None,
             updated_at_unix: None,
             completed: false,
+            invidious_sync_attempted: false,
+            invidious_sync_ok: None,
+            invidious_sync_action: ProgressSyncAction::None.as_str(),
         }
     };
 
@@ -225,7 +238,32 @@ async fn get_video_progress(
     };
 
     let progress = state.progress.get(&session_token, &video_id);
-    progress_response(video_id, progress)
+    progress_response(video_id, progress, ProgressSyncResult::default())
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct ProgressSyncResult {
+    attempted: bool,
+    ok: Option<bool>,
+    action: ProgressSyncAction,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum ProgressSyncAction {
+    MarkWatched,
+    MarkUnwatched,
+    #[default]
+    None,
+}
+
+impl ProgressSyncAction {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::MarkWatched => "mark_watched",
+            Self::MarkUnwatched => "mark_unwatched",
+            Self::None => "none",
+        }
+    }
 }
 
 async fn put_video_progress(
@@ -256,7 +294,41 @@ async fn put_video_progress(
             .into_response();
     };
 
-    progress_response(video_id, Some(saved))
+    let mut sync_result = ProgressSyncResult::default();
+    let previous_completed = saved.previous.map(|entry| entry.completed).unwrap_or(false);
+    let action = match (previous_completed, saved.current.completed) {
+        (false, true) => ProgressSyncAction::MarkWatched,
+        (true, false) => ProgressSyncAction::MarkUnwatched,
+        _ => ProgressSyncAction::None,
+    };
+    sync_result.action = action;
+
+    if action != ProgressSyncAction::None
+        && let Some(client) = state.invidious_client()
+    {
+        sync_result.attempted = true;
+        let sync_outcome = match action {
+            ProgressSyncAction::MarkWatched => client.mark_video_watched(&video_id).await,
+            ProgressSyncAction::MarkUnwatched => client.mark_video_unwatched(&video_id).await,
+            ProgressSyncAction::None => Ok(()),
+        };
+        match sync_outcome {
+            Ok(()) => {
+                sync_result.ok = Some(true);
+            }
+            Err(error) => {
+                sync_result.ok = Some(false);
+                tracing::warn!(
+                    video_id = %video_id,
+                    action = action.as_str(),
+                    error = %error,
+                    "failed to sync youtube watch status to invidious"
+                );
+            }
+        }
+    }
+
+    progress_response(video_id, Some(saved.current), sync_result)
 }
 
 /// Get authenticated user's subscriptions

--- a/src/youtube.rs
+++ b/src/youtube.rs
@@ -88,6 +88,17 @@ fn default_max_results() -> u32 {
     20
 }
 
+/// Recent videos query parameters
+#[derive(Debug, Deserialize)]
+pub struct RecentVideosQuery {
+    #[serde(default = "default_recent_max_results")]
+    max_results: u32,
+}
+
+fn default_recent_max_results() -> u32 {
+    25
+}
+
 /// Video list response
 #[derive(Debug, Serialize)]
 pub struct ChannelVideosResponse {
@@ -118,6 +129,12 @@ pub struct PlaylistVideosResponse {
     pub videos: Vec<YoutubeVideo>,
 }
 
+/// Recent videos response
+#[derive(Debug, Serialize)]
+pub struct RecentVideosResponse {
+    pub videos: Vec<YoutubeVideo>,
+}
+
 #[derive(Debug, Serialize)]
 struct YoutubeWatchProgressResponse {
     video_id: String,
@@ -145,6 +162,7 @@ pub fn build_routes(auth: WebAuthConfig, config: &AppConfig) -> Router {
 
     Router::new()
         .route("/api/youtube/subscriptions", get(get_subscriptions))
+        .route("/api/youtube/recent", get(get_recent_videos))
         .route(
             "/api/youtube/channel/{channel_id}/videos",
             get(get_channel_videos),
@@ -340,6 +358,23 @@ async fn get_subscriptions(State(state): State<YoutubeState>) -> Response {
 
     match client.get_subscriptions().await {
         Ok(channels) => (StatusCode::OK, Json(SubscriptionsResponse { channels })).into_response(),
+        Err(e) => e.into_response(),
+    }
+}
+
+/// Get authenticated user's recent videos from subscription feed
+async fn get_recent_videos(
+    State(state): State<YoutubeState>,
+    query: axum::extract::Query<RecentVideosQuery>,
+) -> Response {
+    let client = match state.require_client() {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
+
+    let max_results = query.max_results.min(40);
+    match client.get_recent_videos(Some(max_results)).await {
+        Ok(videos) => (StatusCode::OK, Json(RecentVideosResponse { videos })).into_response(),
         Err(e) => e.into_response(),
     }
 }

--- a/src/youtube.rs
+++ b/src/youtube.rs
@@ -23,6 +23,7 @@ use crate::{
         YoutubeVideoMeta, is_valid_video_id,
     },
     youtube_embed::{get_embed, get_embed_config, rewrite_dash_manifest},
+    youtube_progress::{YoutubeProgressStore, YoutubeWatchProgressEntry},
     youtube_quality::{
         QualityObservation, QualityObservedResponse, get_video_quality_observed,
         get_video_quality_stream, observe_quality_from_request,
@@ -32,20 +33,24 @@ use crate::{
 /// State for YouTube routes
 #[derive(Debug, Clone)]
 pub struct YoutubeState {
+    auth: WebAuthConfig,
     invidious: Option<InvidiousClient>,
     invidious_base_url: Option<String>,
+    progress: YoutubeProgressStore,
     pub(crate) quality_observations: Arc<Mutex<HashMap<String, QualityObservation>>>,
     pub(crate) quality_streams:
         Arc<Mutex<HashMap<String, broadcast::Sender<QualityObservedResponse>>>>,
 }
 
 impl YoutubeState {
-    pub fn new(_auth: WebAuthConfig, config: &AppConfig) -> Self {
+    pub fn new(auth: WebAuthConfig, config: &AppConfig) -> Self {
         let invidious = config.invidious.as_ref().map(InvidiousClient::new);
         let invidious_base_url = config.invidious.as_ref().map(|c| c.base_url.clone());
         Self {
+            auth,
             invidious,
             invidious_base_url,
+            progress: YoutubeProgressStore::new(),
             quality_observations: Arc::new(Mutex::new(HashMap::new())),
             quality_streams: Arc::new(Mutex::new(HashMap::new())),
         }
@@ -113,6 +118,24 @@ pub struct PlaylistVideosResponse {
     pub videos: Vec<YoutubeVideo>,
 }
 
+#[derive(Debug, Serialize)]
+struct YoutubeWatchProgressResponse {
+    video_id: String,
+    position_secs: Option<f64>,
+    duration_secs: Option<f64>,
+    updated_at_unix: Option<u64>,
+    completed: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct YoutubeWatchProgressUpdateRequest {
+    position_secs: f64,
+    #[serde(default)]
+    duration_secs: Option<f64>,
+    #[serde(default)]
+    completed: Option<bool>,
+}
+
 /// Build YouTube API routes
 pub fn build_routes(auth: WebAuthConfig, config: &AppConfig) -> Router {
     let state = YoutubeState::new(auth.clone(), config);
@@ -128,6 +151,10 @@ pub fn build_routes(auth: WebAuthConfig, config: &AppConfig) -> Router {
             get(get_channel_info),
         )
         .route("/api/youtube/video/{video_id}/meta", get(get_video_meta))
+        .route(
+            "/api/youtube/video/{video_id}/progress",
+            get(get_video_progress).put(put_video_progress),
+        )
         .route(
             "/api/youtube/video/{video_id}/quality-observed",
             get(get_video_quality_observed),
@@ -160,6 +187,76 @@ pub fn build_routes(auth: WebAuthConfig, config: &AppConfig) -> Router {
             auth,
             auth::require_session_middleware,
         ))
+}
+
+fn progress_response(video_id: String, entry: Option<YoutubeWatchProgressEntry>) -> Response {
+    let payload = if let Some(entry) = entry {
+        YoutubeWatchProgressResponse {
+            video_id,
+            position_secs: Some(entry.position_secs),
+            duration_secs: entry.duration_secs,
+            updated_at_unix: Some(entry.updated_at_unix),
+            completed: entry.completed,
+        }
+    } else {
+        YoutubeWatchProgressResponse {
+            video_id,
+            position_secs: None,
+            duration_secs: None,
+            updated_at_unix: None,
+            completed: false,
+        }
+    };
+
+    (StatusCode::OK, Json(payload)).into_response()
+}
+
+async fn get_video_progress(
+    State(state): State<YoutubeState>,
+    Path(video_id): Path<String>,
+    request_headers: HeaderMap,
+) -> Response {
+    if !is_valid_video_id(&video_id) {
+        return (StatusCode::BAD_REQUEST, "invalid video_id format").into_response();
+    }
+
+    let Some(session_token) = state.auth.session_token_from_headers(&request_headers) else {
+        return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
+    };
+
+    let progress = state.progress.get(&session_token, &video_id);
+    progress_response(video_id, progress)
+}
+
+async fn put_video_progress(
+    State(state): State<YoutubeState>,
+    Path(video_id): Path<String>,
+    request_headers: HeaderMap,
+    Json(payload): Json<YoutubeWatchProgressUpdateRequest>,
+) -> Response {
+    if !is_valid_video_id(&video_id) {
+        return (StatusCode::BAD_REQUEST, "invalid video_id format").into_response();
+    }
+
+    let Some(session_token) = state.auth.session_token_from_headers(&request_headers) else {
+        return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
+    };
+
+    let Some(saved) = state.progress.upsert(
+        &session_token,
+        &video_id,
+        payload.position_secs,
+        payload.duration_secs,
+        payload.completed,
+    ) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            "invalid progress payload or failed to persist",
+        )
+            .into_response();
+    };
+
+    progress_response(video_id, Some(saved))
 }
 
 /// Get authenticated user's subscriptions

--- a/src/youtube_embed.rs
+++ b/src/youtube_embed.rs
@@ -57,6 +57,8 @@ pub(crate) struct EmbedQuery {
     autoplay: Option<String>,
     quality: Option<String>,
     quality_dash: Option<String>,
+    start: Option<String>,
+    t: Option<String>,
 }
 
 static HTML_ATTR_DOUBLE_RE: OnceLock<Regex> = OnceLock::new();
@@ -260,6 +262,12 @@ pub async fn get_embed(
             "quality_dash={}",
             urlencoding::encode(quality_dash)
         ));
+    }
+    if let Some(start) = &query.start {
+        params.push(format!("start={}", urlencoding::encode(start)));
+    }
+    if let Some(t) = &query.t {
+        params.push(format!("t={}", urlencoding::encode(t)));
     }
 
     if !params.is_empty() {

--- a/src/youtube_progress.rs
+++ b/src/youtube_progress.rs
@@ -1,0 +1,115 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    storage::{files, paths},
+    util::time::now_unix_secs,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct YoutubeWatchProgressEntry {
+    pub position_secs: f64,
+    pub duration_secs: Option<f64>,
+    pub completed: bool,
+    pub updated_at_unix: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct StoredYoutubeWatchProgress {
+    sessions: HashMap<String, HashMap<String, YoutubeWatchProgressEntry>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct YoutubeProgressStore {
+    inner: Arc<RwLock<StoredYoutubeWatchProgress>>,
+}
+
+impl YoutubeProgressStore {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(load_watch_progress())),
+        }
+    }
+
+    pub fn get(&self, session_token: &str, video_id: &str) -> Option<YoutubeWatchProgressEntry> {
+        let guard = self.inner.read().ok()?;
+        guard
+            .sessions
+            .get(session_token)
+            .and_then(|videos| videos.get(video_id))
+            .cloned()
+    }
+
+    pub fn upsert(
+        &self,
+        session_token: &str,
+        video_id: &str,
+        position_secs: f64,
+        duration_secs: Option<f64>,
+        completed: Option<bool>,
+    ) -> Option<YoutubeWatchProgressEntry> {
+        let normalized_position = normalize_secs(position_secs)?;
+        let normalized_duration = duration_secs.and_then(normalize_secs);
+        let normalized_completed = completed.unwrap_or_else(|| {
+            normalized_duration
+                .map(|duration| duration > 0.0 && duration - normalized_position <= 20.0)
+                .unwrap_or(false)
+        });
+
+        let entry = YoutubeWatchProgressEntry {
+            position_secs: normalized_position,
+            duration_secs: normalized_duration,
+            completed: normalized_completed,
+            updated_at_unix: now_unix_secs(),
+        };
+
+        if let Ok(mut guard) = self.inner.write() {
+            let videos = guard
+                .sessions
+                .entry(session_token.to_string())
+                .or_insert_with(HashMap::new);
+            videos.insert(video_id.to_string(), entry.clone());
+            let _ = save_watch_progress(&guard);
+            return Some(entry);
+        }
+
+        None
+    }
+}
+
+fn normalize_secs(value: f64) -> Option<f64> {
+    if !value.is_finite() {
+        return None;
+    }
+    if value < 0.0 {
+        return Some(0.0);
+    }
+    Some(value)
+}
+
+fn load_watch_progress() -> StoredYoutubeWatchProgress {
+    let Some(path) = paths::youtube_watch_progress_path() else {
+        return StoredYoutubeWatchProgress::default();
+    };
+
+    match files::load_json_optional::<StoredYoutubeWatchProgress>(&path) {
+        Ok(Some(data)) => data,
+        Ok(None) => StoredYoutubeWatchProgress::default(),
+        Err(error) => {
+            tracing::warn!(error = %error, path = %path.display(), "failed to load youtube watch progress");
+            StoredYoutubeWatchProgress::default()
+        }
+    }
+}
+
+fn save_watch_progress(data: &StoredYoutubeWatchProgress) -> Result<(), String> {
+    let Some(path) = paths::youtube_watch_progress_path() else {
+        return Err("failed to resolve youtube watch progress path".to_string());
+    };
+
+    files::write_json_pretty_atomic(&path, data)
+}

--- a/src/youtube_progress.rs
+++ b/src/youtube_progress.rs
@@ -18,6 +18,12 @@ pub struct YoutubeWatchProgressEntry {
     pub updated_at_unix: u64,
 }
 
+#[derive(Debug, Clone)]
+pub struct YoutubeProgressUpsertResult {
+    pub previous: Option<YoutubeWatchProgressEntry>,
+    pub current: YoutubeWatchProgressEntry,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct StoredYoutubeWatchProgress {
     sessions: HashMap<String, HashMap<String, YoutubeWatchProgressEntry>>,
@@ -51,7 +57,7 @@ impl YoutubeProgressStore {
         position_secs: f64,
         duration_secs: Option<f64>,
         completed: Option<bool>,
-    ) -> Option<YoutubeWatchProgressEntry> {
+    ) -> Option<YoutubeProgressUpsertResult> {
         let normalized_position = normalize_secs(position_secs)?;
         let normalized_duration = duration_secs.and_then(normalize_secs);
         let normalized_completed = completed.unwrap_or_else(|| {
@@ -72,9 +78,12 @@ impl YoutubeProgressStore {
                 .sessions
                 .entry(session_token.to_string())
                 .or_insert_with(HashMap::new);
-            videos.insert(video_id.to_string(), entry.clone());
+            let previous = videos.insert(video_id.to_string(), entry.clone());
             let _ = save_watch_progress(&guard);
-            return Some(entry);
+            return Some(YoutubeProgressUpsertResult {
+                previous,
+                current: entry,
+            });
         }
 
         None

--- a/web/src/lib/api-client/types.ts
+++ b/web/src/lib/api-client/types.ts
@@ -161,6 +161,14 @@ export interface YouTubeVideoMeta {
   duration: number;
 }
 
+export interface YouTubeWatchProgress {
+  video_id: string;
+  position_secs: number | null;
+  duration_secs: number | null;
+  updated_at_unix: number | null;
+  completed: boolean;
+}
+
 export interface YoutubePlaylist {
   title: string;
   playlist_id: string;

--- a/web/src/lib/api-client/types.ts
+++ b/web/src/lib/api-client/types.ts
@@ -167,6 +167,9 @@ export interface YouTubeWatchProgress {
   duration_secs: number | null;
   updated_at_unix: number | null;
   completed: boolean;
+  invidious_sync_attempted: boolean;
+  invidious_sync_ok: boolean | null;
+  invidious_sync_action: "mark_watched" | "mark_unwatched" | "none";
 }
 
 export interface YoutubePlaylist {

--- a/web/src/lib/api-client/youtube.ts
+++ b/web/src/lib/api-client/youtube.ts
@@ -210,7 +210,12 @@ export async function getYouTubeVideoProgress(videoId: string): Promise<YouTubeW
     (payload.position_secs !== null && typeof payload.position_secs !== "number") ||
     (payload.duration_secs !== null && typeof payload.duration_secs !== "number") ||
     (payload.updated_at_unix !== null && typeof payload.updated_at_unix !== "number") ||
-    typeof payload.completed !== "boolean"
+    typeof payload.completed !== "boolean" ||
+    typeof payload.invidious_sync_attempted !== "boolean" ||
+    (payload.invidious_sync_ok !== null && typeof payload.invidious_sync_ok !== "boolean") ||
+    (payload.invidious_sync_action !== "mark_watched" &&
+      payload.invidious_sync_action !== "mark_unwatched" &&
+      payload.invidious_sync_action !== "none")
   ) {
     throw new Error("youtube watch progress payload is invalid");
   }
@@ -246,7 +251,12 @@ export async function saveYouTubeVideoProgress(
     (payload.position_secs !== null && typeof payload.position_secs !== "number") ||
     (payload.duration_secs !== null && typeof payload.duration_secs !== "number") ||
     (payload.updated_at_unix !== null && typeof payload.updated_at_unix !== "number") ||
-    typeof payload.completed !== "boolean"
+    typeof payload.completed !== "boolean" ||
+    typeof payload.invidious_sync_attempted !== "boolean" ||
+    (payload.invidious_sync_ok !== null && typeof payload.invidious_sync_ok !== "boolean") ||
+    (payload.invidious_sync_action !== "mark_watched" &&
+      payload.invidious_sync_action !== "mark_unwatched" &&
+      payload.invidious_sync_action !== "none")
   ) {
     throw new Error("youtube watch progress payload is invalid");
   }

--- a/web/src/lib/api-client/youtube.ts
+++ b/web/src/lib/api-client/youtube.ts
@@ -43,6 +43,24 @@ export async function getYouTubeSubscriptions(): Promise<YoutubeChannel[]> {
   return payload.channels as YoutubeChannel[];
 }
 
+export async function getYouTubeRecentVideos(maxResults = 25): Promise<YoutubeVideo[]> {
+  const params = new URLSearchParams();
+  params.set("max_results", String(maxResults));
+
+  const response = await request(`/api/youtube/recent?${params.toString()}`);
+  if (!response.ok) {
+    const payload = await safeJson(response);
+    throw new Error(readError(payload));
+  }
+
+  const payload = await safeJson(response);
+  if (!isObject(payload) || !Array.isArray(payload.videos)) {
+    throw new Error("recent videos payload is invalid");
+  }
+
+  return payload.videos as YoutubeVideo[];
+}
+
 export async function getYouTubeChannelInfo(channelId: string): Promise<YoutubeChannelInfo> {
   const url = `/api/youtube/channel/${encodeURIComponent(channelId)}/info`;
   const response = await request(url);

--- a/web/src/lib/api-client/youtube.ts
+++ b/web/src/lib/api-client/youtube.ts
@@ -5,6 +5,7 @@ import type {
   YoutubeVideo,
   YouTubeEmbedConfig,
   YouTubeVideoMeta,
+  YouTubeWatchProgress,
   YoutubePlaylist,
 } from "./types";
 
@@ -193,6 +194,64 @@ export async function getYouTubeVideoMeta(videoId: string): Promise<YouTubeVideo
     title: payload.video.title,
     duration: payload.video.duration,
   };
+}
+
+export async function getYouTubeVideoProgress(videoId: string): Promise<YouTubeWatchProgress> {
+  const response = await request(`/api/youtube/video/${encodeURIComponent(videoId)}/progress`);
+  if (!response.ok) {
+    const payload = await safeJson(response);
+    throw new Error(readError(payload));
+  }
+
+  const payload = await safeJson(response);
+  if (
+    !isObject(payload) ||
+    typeof payload.video_id !== "string" ||
+    (payload.position_secs !== null && typeof payload.position_secs !== "number") ||
+    (payload.duration_secs !== null && typeof payload.duration_secs !== "number") ||
+    (payload.updated_at_unix !== null && typeof payload.updated_at_unix !== "number") ||
+    typeof payload.completed !== "boolean"
+  ) {
+    throw new Error("youtube watch progress payload is invalid");
+  }
+
+  return payload as unknown as YouTubeWatchProgress;
+}
+
+export async function saveYouTubeVideoProgress(
+  videoId: string,
+  progress: {
+    position_secs: number;
+    duration_secs?: number | null;
+    completed?: boolean;
+  },
+): Promise<YouTubeWatchProgress> {
+  const response = await request(`/api/youtube/video/${encodeURIComponent(videoId)}/progress`, {
+    method: "PUT",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(progress),
+  });
+
+  if (!response.ok) {
+    const payload = await safeJson(response);
+    throw new Error(readError(payload));
+  }
+
+  const payload = await safeJson(response);
+  if (
+    !isObject(payload) ||
+    typeof payload.video_id !== "string" ||
+    (payload.position_secs !== null && typeof payload.position_secs !== "number") ||
+    (payload.duration_secs !== null && typeof payload.duration_secs !== "number") ||
+    (payload.updated_at_unix !== null && typeof payload.updated_at_unix !== "number") ||
+    typeof payload.completed !== "boolean"
+  ) {
+    throw new Error("youtube watch progress payload is invalid");
+  }
+
+  return payload as unknown as YouTubeWatchProgress;
 }
 
 export function getCachedPlaylistVideos(playlistId: string): YoutubeVideo[] | undefined {

--- a/web/src/lib/components/YouTubeRecentView.svelte
+++ b/web/src/lib/components/YouTubeRecentView.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { getYouTubeRecentVideos, getYouTubeThumbnailUrl } from '$lib/api';
+  import type { YoutubeVideo } from '$lib/api';
+  import { formatTimeAgo } from '$lib/youtube/format';
+  import { YouTubeListState, YouTubeMediaRow } from '$lib/components/youtube';
+
+  const DEFAULT_MAX_RESULTS = 25;
+
+  let videos = $state<YoutubeVideo[]>([]);
+  let isLoading = $state(true);
+  let error = $state<string | null>(null);
+
+  onMount(async () => {
+    try {
+      videos = await getYouTubeRecentVideos(DEFAULT_MAX_RESULTS);
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Failed to load recent videos';
+    } finally {
+      isLoading = false;
+    }
+  });
+
+  function openVideo(videoId: string): void {
+    if (typeof window !== 'undefined') {
+      sessionStorage.setItem('youtubeBackContext', 'recent');
+      sessionStorage.setItem('youtubeWatchReturnUrl', '/?youtube=recent');
+    }
+    goto(`/youtube/watch/${encodeURIComponent(videoId)}`);
+  }
+
+  function formatViewCount(count: number): string {
+    if (count >= 1000000) {
+      return `${(count / 1000000).toFixed(1)}M views`;
+    }
+    if (count >= 1000) {
+      return `${(count / 1000).toFixed(1)}K views`;
+    }
+    return `${count} views`;
+  }
+
+  function formatDuration(seconds: number): string {
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    const secs = seconds % 60;
+
+    if (hours > 0) {
+      return `${hours}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+    }
+    return `${minutes}:${secs.toString().padStart(2, '0')}`;
+  }
+</script>
+
+<div class="youtube-recent">
+  <YouTubeListState
+    {isLoading}
+    {error}
+    isEmpty={videos.length === 0}
+    loadingText="Loading recent videos..."
+    emptyText="No recent videos found."
+  >
+    <div class="ui-list">
+      {#each videos as video (video.video_id)}
+        {#snippet visual()}
+          <div class="recent-thumbnail-wrap">
+            <img
+              class="ui-thumbnail recent-thumbnail"
+              src={getYouTubeThumbnailUrl(video.video_id)}
+              alt={video.title}
+              loading="lazy"
+            />
+            <span class="recent-duration">{formatDuration(video.duration)}</span>
+          </div>
+        {/snippet}
+
+        {#snippet meta()}
+          <span class="ui-media-meta recent-meta">
+            {video.author} · {formatViewCount(video.view_count)} · {formatTimeAgo(video.published)}
+          </span>
+        {/snippet}
+
+        <YouTubeMediaRow
+          title={video.title}
+          onClick={() => openVideo(video.video_id)}
+          {visual}
+          {meta}
+          extraClass="youtube-recent-row"
+        />
+      {/each}
+    </div>
+  </YouTubeListState>
+</div>
+
+<style>
+  .youtube-recent {
+    display: grid;
+    gap: 1rem;
+  }
+
+  :global(.youtube-recent-row) {
+    display: grid;
+    grid-template-columns: 140px minmax(0, 1fr);
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.8rem;
+    text-align: left;
+  }
+
+  .recent-thumbnail-wrap {
+    position: relative;
+    width: 140px;
+    height: 78px;
+  }
+
+  .recent-thumbnail {
+    width: 140px;
+    height: 78px;
+    border-radius: 0.5rem;
+  }
+
+  .recent-duration {
+    position: absolute;
+    right: 0.35rem;
+    bottom: 0.35rem;
+    padding: 0.1rem 0.3rem;
+    border-radius: 0.25rem;
+    font-size: 0.74rem;
+    line-height: 1.1;
+    color: white;
+    background: rgba(0, 0, 0, 0.76);
+  }
+
+  .recent-meta {
+    line-height: 1.35;
+  }
+</style>

--- a/web/src/lib/components/home/YouTubeModeView.svelte
+++ b/web/src/lib/components/home/YouTubeModeView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import YouTubeSubscriptionsView from '$lib/components/YouTubeSubscriptionsView.svelte';
+  import YouTubeRecentView from '$lib/components/YouTubeRecentView.svelte';
   import YouTubePlaylistsView from '$lib/components/YouTubePlaylistsView.svelte';
   import type { YouTubeModeViewProps } from './types';
 
@@ -20,6 +21,14 @@
       <button
         type="button"
         class="channels-label tab"
+        class:active={youtubeViewMode === 'recent'}
+        onclick={() => onViewModeChange('recent')}
+      >
+        Recent
+      </button>
+      <button
+        type="button"
+        class="channels-label tab"
         class:active={youtubeViewMode === 'playlists'}
         onclick={() => onViewModeChange('playlists')}
       >
@@ -29,6 +38,8 @@
   </div>
   {#if youtubeViewMode === 'subscriptions'}
     <YouTubeSubscriptionsView />
+  {:else if youtubeViewMode === 'recent'}
+    <YouTubeRecentView />
   {:else}
     <YouTubePlaylistsView />
   {/if}

--- a/web/src/lib/components/home/types.ts
+++ b/web/src/lib/components/home/types.ts
@@ -13,7 +13,7 @@ export type { ChannelEntry, ChannelStatus, RecordingRule, ActiveRecording, Recor
 export type AuthMode = "checking" | "authenticated" | "unauthenticated";
 export type RelayMode = "twitch" | "youtube";
 export type LoginMode = "code" | "qr";
-export type YouTubeViewMode = "subscriptions" | "playlists";
+export type YouTubeViewMode = "subscriptions" | "recent" | "playlists";
 export type CurrentView = "channels" | "recordings";
 
 // AppHeader props

--- a/web/src/lib/home/routeView.ts
+++ b/web/src/lib/home/routeView.ts
@@ -1,6 +1,6 @@
 export type InitialHomeView =
   | { relayMode: "twitch"; twitchView: "channels" | "recordings" }
-  | { relayMode: "youtube"; youtubeView: "subscriptions" | "playlists" };
+  | { relayMode: "youtube"; youtubeView: "subscriptions" | "recent" | "playlists" };
 
 export function parseInitialHomeView(search: string): InitialHomeView {
   const params = new URLSearchParams(search);
@@ -13,6 +13,8 @@ export function parseInitialHomeView(search: string): InitialHomeView {
     return { relayMode: "twitch", twitchView: "channels" };
   } else if (youtubeView === "subscriptions") {
     return { relayMode: "youtube", youtubeView: "subscriptions" };
+  } else if (youtubeView === "recent") {
+    return { relayMode: "youtube", youtubeView: "recent" };
   } else if (youtubeView === "playlists") {
     return { relayMode: "youtube", youtubeView: "playlists" };
   } else {

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -20,7 +20,7 @@
   import { loadLiveOnlyPreference, saveLiveOnlyPreference } from '$lib/home/preferences';
   import { parseInitialHomeView } from '$lib/home/routeView';
 
-  type YouTubeViewMode = 'subscriptions' | 'playlists';
+  type YouTubeViewMode = 'subscriptions' | 'recent' | 'playlists';
 
   // Global error state (shared across controllers)
   let errorMessage = $state<string | null>(null);

--- a/web/src/routes/youtube/watch/[video_id]/+page.svelte
+++ b/web/src/routes/youtube/watch/[video_id]/+page.svelte
@@ -174,6 +174,9 @@
       if (context === 'playlists') {
         goto('/?youtube=playlists');
         return;
+      } else if (context === 'recent') {
+        goto('/?youtube=recent');
+        return;
       } else {
         goto('/?youtube=subscriptions');
         return;

--- a/web/src/routes/youtube/watch/[video_id]/+page.svelte
+++ b/web/src/routes/youtube/watch/[video_id]/+page.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
-  import { getYouTubeEmbedConfig, getYouTubeVideoMeta } from '$lib/api';
+  import {
+    getYouTubeEmbedConfig,
+    getYouTubeVideoMeta,
+    getYouTubeVideoProgress,
+    saveYouTubeVideoProgress,
+  } from '$lib/api';
   import AppVersion from '$lib/components/AppVersion.svelte';
 
   const videoId = $derived($page.params.video_id ?? '');
@@ -12,16 +17,30 @@
   let error = $state<string | null>(null);
   let videoTitle = $state('YouTube video');
   let videoDuration = $state<number | null>(null);
+  let playerFrame = $state<HTMLIFrameElement | null>(null);
+  let progressTimer = $state<number | null>(null);
+  let lastSavedPosition = $state(0);
+
+  const RESUME_MIN_SECS = 15;
+  const RESUME_END_GAP_SECS = 20;
+  const SAVE_INTERVAL_MS = 10_000;
+  const SAVE_MIN_DELTA_SECS = 3;
 
   function buildEmbedUrl(
     id: string,
     defaults: { autoplay: number; quality: string; quality_dash: string },
+    resumeAtSecs?: number,
   ): string {
     const params = new URLSearchParams({
       autoplay: String(defaults.autoplay),
       quality: defaults.quality,
       quality_dash: defaults.quality_dash,
     });
+    if (resumeAtSecs && resumeAtSecs >= RESUME_MIN_SECS) {
+      const resumeSeconds = String(Math.floor(resumeAtSecs));
+      params.set('start', resumeSeconds);
+      params.set('t', `${resumeSeconds}s`);
+    }
 
     // Use backend proxy endpoint to avoid Basic auth popup
     return `/api/youtube/embed/${encodeURIComponent(id)}?${params.toString()}`;
@@ -37,20 +56,105 @@
     error = null;
 
     try {
-      const [config, meta] = await Promise.all([getYouTubeEmbedConfig(), getYouTubeVideoMeta(videoId)]);
-      embedUrl = buildEmbedUrl(videoId, config.defaults);
+      const [config, meta, progress] = await Promise.all([
+        getYouTubeEmbedConfig(),
+        getYouTubeVideoMeta(videoId),
+        getYouTubeVideoProgress(videoId),
+      ]);
+      let resumeAt: number | undefined;
+      if (
+        !progress.completed &&
+        typeof progress.position_secs === 'number' &&
+        progress.position_secs >= RESUME_MIN_SECS &&
+        progress.position_secs <= Math.max(0, meta.duration - RESUME_END_GAP_SECS)
+      ) {
+        resumeAt = progress.position_secs;
+        lastSavedPosition = progress.position_secs;
+      }
+      embedUrl = buildEmbedUrl(videoId, config.defaults, resumeAt);
       videoTitle = meta.title;
       videoDuration = meta.duration;
       referrerPolicy =
         config.referrer_policy === 'strict-origin-when-cross-origin'
           ? 'strict-origin-when-cross-origin'
           : 'no-referrer';
+      startProgressTracking();
     } catch (e) {
       error = e instanceof Error ? e.message : 'Failed to load embed configuration.';
     } finally {
       isLoading = false;
     }
   });
+
+  onDestroy(() => {
+    stopProgressTracking();
+  });
+
+  function getEmbeddedVideoElement(): HTMLVideoElement | null {
+    if (!playerFrame) return null;
+    try {
+      const doc = playerFrame.contentWindow?.document;
+      if (!doc) return null;
+      return doc.querySelector('video');
+    } catch {
+      return null;
+    }
+  }
+
+  async function pushProgress(force = false): Promise<void> {
+    if (!videoId) return;
+    const video = getEmbeddedVideoElement();
+    if (!video) return;
+    const currentTime = video.currentTime;
+    const duration =
+      Number.isFinite(video.duration) && video.duration > 0 ? video.duration : videoDuration;
+    if (!Number.isFinite(currentTime) || currentTime < 0) return;
+    if (!force && Math.abs(currentTime - lastSavedPosition) < SAVE_MIN_DELTA_SECS) return;
+
+    const isCompleted =
+      typeof duration === 'number' && duration > 0 && duration - currentTime <= RESUME_END_GAP_SECS;
+    lastSavedPosition = currentTime;
+
+    try {
+      await saveYouTubeVideoProgress(videoId, {
+        position_secs: currentTime,
+        duration_secs: duration ?? undefined,
+        completed: isCompleted,
+      });
+    } catch {
+      // keep playback uninterrupted if saving progress fails
+    }
+  }
+
+  function stopProgressTracking(): void {
+    if (typeof window === 'undefined') return;
+    if (progressTimer !== null) {
+      window.clearInterval(progressTimer);
+      progressTimer = null;
+    }
+    window.removeEventListener('beforeunload', onBeforeUnload);
+    document.removeEventListener('visibilitychange', onVisibilityChange);
+  }
+
+  function onBeforeUnload(): void {
+    void pushProgress(true);
+  }
+
+  function onVisibilityChange(): void {
+    if (document.visibilityState === 'hidden') {
+      void pushProgress(true);
+    }
+  }
+
+  function startProgressTracking(): void {
+    if (typeof window === 'undefined') return;
+    stopProgressTracking();
+    progressTimer = window.setInterval(() => {
+      void pushProgress(false);
+    }, SAVE_INTERVAL_MS);
+    window.addEventListener('beforeunload', onBeforeUnload);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+  }
 
   function goBack() {
     // Check if we have a stored return URL from sessionStorage
@@ -127,6 +231,7 @@
     {:else if videoId && embedUrl}
       <div class="player-wrapper">
         <iframe
+          bind:this={playerFrame}
           class="player"
           src={embedUrl}
           title="Invidious video player"


### PR DESCRIPTION
## Summary
- Add backend storage and API endpoints for per-session YouTube watch progress.
- Resume playback from saved progress when reopening a video, with guards to avoid resuming near the end.
- Persist progress updates from the watch page and save them on interval, tab hide, and unload.
- Extend the embed proxy and web API client/types to support resume parameters and progress payloads.

## Testing
- Not run (PR content only).
- Recommended: `cargo check`
- Recommended: `cargo clippy --all-targets --all-features`
- Recommended: `cargo test`
- Recommended: `cargo fmt -- --check`
- Recommended: `cd web && pnpm run verify`