### PR TITLE
Sync YouTube progress updates to Invidious

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -572,6 +572,45 @@ Get video metadata (for watch page).
 }
 ```
 
+### `GET /api/youtube/video/{video_id}/progress`
+
+Get stored playback progress for a video.
+
+**Response:**
+
+```json
+{
+  "video_id": "string",
+  "position_secs": "number?",
+  "duration_secs": "number?",
+  "updated_at_unix": "number?",
+  "completed": "bool",
+  "invidious_sync_attempted": "bool",
+  "invidious_sync_ok": "bool?",
+  "invidious_sync_action": "mark_watched | mark_unwatched | none"
+}
+```
+
+### `PUT /api/youtube/video/{video_id}/progress`
+
+Update stored playback progress for a video.
+
+**Request:**
+
+```json
+{
+  "position_secs": "number",
+  "duration_secs": "number?",
+  "completed": "bool?"
+}
+```
+
+**Response:** Same shape as `GET .../progress`
+
+**Notes:**
+- Local progress persistence is authoritative for resume position.
+- Invidious watch-history sync is best-effort only and never fails this endpoint when local save succeeds.
+
 ### `GET /api/youtube/playlists`
 
 Get user's playlists.

--- a/src/invidious.rs
+++ b/src/invidious.rs
@@ -306,6 +306,44 @@ impl InvidiousClient {
         }
     }
 
+    pub async fn mark_video_watched(&self, video_id: &str) -> Result<(), AppError> {
+        if !is_valid_video_id(video_id) {
+            return Err(AppError::Config(format!("invalid video_id: {video_id}")));
+        }
+
+        let url = format!("{}/api/v1/auth/history/{}", self.base_url, video_id);
+        let response = self
+            .with_basic_auth(self.http.post(&url))
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(AppError::InvidiousBadResponse)
+        }
+    }
+
+    pub async fn mark_video_unwatched(&self, video_id: &str) -> Result<(), AppError> {
+        if !is_valid_video_id(video_id) {
+            return Err(AppError::Config(format!("invalid video_id: {video_id}")));
+        }
+
+        let url = format!("{}/api/v1/auth/history/{}", self.base_url, video_id);
+        let response = self
+            .with_basic_auth(self.http.delete(&url))
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(AppError::InvidiousBadResponse)
+        }
+    }
+
     /// Get latest videos for a channel
     pub async fn get_channel_videos(
         &self,

--- a/src/youtube.rs
+++ b/src/youtube.rs
@@ -125,6 +125,9 @@ struct YoutubeWatchProgressResponse {
     duration_secs: Option<f64>,
     updated_at_unix: Option<u64>,
     completed: bool,
+    invidious_sync_attempted: bool,
+    invidious_sync_ok: Option<bool>,
+    invidious_sync_action: &'static str,
 }
 
 #[derive(Debug, Deserialize)]
@@ -189,7 +192,11 @@ pub fn build_routes(auth: WebAuthConfig, config: &AppConfig) -> Router {
         ))
 }
 
-fn progress_response(video_id: String, entry: Option<YoutubeWatchProgressEntry>) -> Response {
+fn progress_response(
+    video_id: String,
+    entry: Option<YoutubeWatchProgressEntry>,
+    sync_result: ProgressSyncResult,
+) -> Response {
     let payload = if let Some(entry) = entry {
         YoutubeWatchProgressResponse {
             video_id,
@@ -197,6 +204,9 @@ fn progress_response(video_id: String, entry: Option<YoutubeWatchProgressEntry>)
             duration_secs: entry.duration_secs,
             updated_at_unix: Some(entry.updated_at_unix),
             completed: entry.completed,
+            invidious_sync_attempted: sync_result.attempted,
+            invidious_sync_ok: sync_result.ok,
+            invidious_sync_action: sync_result.action.as_str(),
         }
     } else {
         YoutubeWatchProgressResponse {
@@ -205,6 +215,9 @@ fn progress_response(video_id: String, entry: Option<YoutubeWatchProgressEntry>)
             duration_secs: None,
             updated_at_unix: None,
             completed: false,
+            invidious_sync_attempted: false,
+            invidious_sync_ok: None,
+            invidious_sync_action: ProgressSyncAction::None.as_str(),
         }
     };
 
@@ -225,7 +238,32 @@ async fn get_video_progress(
     };
 
     let progress = state.progress.get(&session_token, &video_id);
-    progress_response(video_id, progress)
+    progress_response(video_id, progress, ProgressSyncResult::default())
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct ProgressSyncResult {
+    attempted: bool,
+    ok: Option<bool>,
+    action: ProgressSyncAction,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum ProgressSyncAction {
+    MarkWatched,
+    MarkUnwatched,
+    #[default]
+    None,
+}
+
+impl ProgressSyncAction {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::MarkWatched => "mark_watched",
+            Self::MarkUnwatched => "mark_unwatched",
+            Self::None => "none",
+        }
+    }
 }
 
 async fn put_video_progress(
@@ -256,7 +294,41 @@ async fn put_video_progress(
             .into_response();
     };
 
-    progress_response(video_id, Some(saved))
+    let mut sync_result = ProgressSyncResult::default();
+    let previous_completed = saved.previous.map(|entry| entry.completed).unwrap_or(false);
+    let action = match (previous_completed, saved.current.completed) {
+        (false, true) => ProgressSyncAction::MarkWatched,
+        (true, false) => ProgressSyncAction::MarkUnwatched,
+        _ => ProgressSyncAction::None,
+    };
+    sync_result.action = action;
+
+    if action != ProgressSyncAction::None
+        && let Some(client) = state.invidious_client()
+    {
+        sync_result.attempted = true;
+        let sync_outcome = match action {
+            ProgressSyncAction::MarkWatched => client.mark_video_watched(&video_id).await,
+            ProgressSyncAction::MarkUnwatched => client.mark_video_unwatched(&video_id).await,
+            ProgressSyncAction::None => Ok(()),
+        };
+        match sync_outcome {
+            Ok(()) => {
+                sync_result.ok = Some(true);
+            }
+            Err(error) => {
+                sync_result.ok = Some(false);
+                tracing::warn!(
+                    video_id = %video_id,
+                    action = action.as_str(),
+                    error = %error,
+                    "failed to sync youtube watch status to invidious"
+                );
+            }
+        }
+    }
+
+    progress_response(video_id, Some(saved.current), sync_result)
 }
 
 /// Get authenticated user's subscriptions

--- a/src/youtube_progress.rs
+++ b/src/youtube_progress.rs
@@ -18,6 +18,12 @@ pub struct YoutubeWatchProgressEntry {
     pub updated_at_unix: u64,
 }
 
+#[derive(Debug, Clone)]
+pub struct YoutubeProgressUpsertResult {
+    pub previous: Option<YoutubeWatchProgressEntry>,
+    pub current: YoutubeWatchProgressEntry,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct StoredYoutubeWatchProgress {
     sessions: HashMap<String, HashMap<String, YoutubeWatchProgressEntry>>,
@@ -51,7 +57,7 @@ impl YoutubeProgressStore {
         position_secs: f64,
         duration_secs: Option<f64>,
         completed: Option<bool>,
-    ) -> Option<YoutubeWatchProgressEntry> {
+    ) -> Option<YoutubeProgressUpsertResult> {
         let normalized_position = normalize_secs(position_secs)?;
         let normalized_duration = duration_secs.and_then(normalize_secs);
         let normalized_completed = completed.unwrap_or_else(|| {
@@ -72,9 +78,12 @@ impl YoutubeProgressStore {
                 .sessions
                 .entry(session_token.to_string())
                 .or_insert_with(HashMap::new);
-            videos.insert(video_id.to_string(), entry.clone());
+            let previous = videos.insert(video_id.to_string(), entry.clone());
             let _ = save_watch_progress(&guard);
-            return Some(entry);
+            return Some(YoutubeProgressUpsertResult {
+                previous,
+                current: entry,
+            });
         }
 
         None

--- a/web/src/lib/api-client/types.ts
+++ b/web/src/lib/api-client/types.ts
@@ -167,6 +167,9 @@ export interface YouTubeWatchProgress {
   duration_secs: number | null;
   updated_at_unix: number | null;
   completed: boolean;
+  invidious_sync_attempted: boolean;
+  invidious_sync_ok: boolean | null;
+  invidious_sync_action: "mark_watched" | "mark_unwatched" | "none";
 }
 
 export interface YoutubePlaylist {

--- a/web/src/lib/api-client/youtube.ts
+++ b/web/src/lib/api-client/youtube.ts
@@ -210,7 +210,12 @@ export async function getYouTubeVideoProgress(videoId: string): Promise<YouTubeW
     (payload.position_secs !== null && typeof payload.position_secs !== "number") ||
     (payload.duration_secs !== null && typeof payload.duration_secs !== "number") ||
     (payload.updated_at_unix !== null && typeof payload.updated_at_unix !== "number") ||
-    typeof payload.completed !== "boolean"
+    typeof payload.completed !== "boolean" ||
+    typeof payload.invidious_sync_attempted !== "boolean" ||
+    (payload.invidious_sync_ok !== null && typeof payload.invidious_sync_ok !== "boolean") ||
+    (payload.invidious_sync_action !== "mark_watched" &&
+      payload.invidious_sync_action !== "mark_unwatched" &&
+      payload.invidious_sync_action !== "none")
   ) {
     throw new Error("youtube watch progress payload is invalid");
   }
@@ -246,7 +251,12 @@ export async function saveYouTubeVideoProgress(
     (payload.position_secs !== null && typeof payload.position_secs !== "number") ||
     (payload.duration_secs !== null && typeof payload.duration_secs !== "number") ||
     (payload.updated_at_unix !== null && typeof payload.updated_at_unix !== "number") ||
-    typeof payload.completed !== "boolean"
+    typeof payload.completed !== "boolean" ||
+    typeof payload.invidious_sync_attempted !== "boolean" ||
+    (payload.invidious_sync_ok !== null && typeof payload.invidious_sync_ok !== "boolean") ||
+    (payload.invidious_sync_action !== "mark_watched" &&
+      payload.invidious_sync_action !== "mark_unwatched" &&
+      payload.invidious_sync_action !== "none")
   ) {
     throw new Error("youtube watch progress payload is invalid");
   }


### PR DESCRIPTION
## Summary
- sync YouTube watch progress completion transitions back to Invidious history
- add best-effort watched/unwatched writeback (`POST`/`DELETE /api/v1/auth/history/:id`)
- extend progress API response with Invidious sync metadata
- update frontend API types/validation and API contract docs

## Details
- local progress remains the source of truth for exact resume seconds
- Invidious sync only runs on completion state changes:
  - `false -> true` => `mark_watched`
  - `true -> false` => `mark_unwatched`
- sync failures are logged but do not fail the progress endpoint

## Verification
- `cargo check`
- `cargo clippy --all-targets --all-features`
- `cargo test`
- `cargo fmt -- --check`
- `cd web && pnpm run verify`