### PR TITLE
Add YouTube Recent tab and recent-feed endpoint

### DIFF
--- a/src/invidious.rs
+++ b/src/invidious.rs
@@ -169,6 +169,13 @@ struct InvidiousPlaylistDetails {
     videos: Vec<InvidiousVideoRaw>,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum InvidiousRecentFeedResponse {
+    Videos(Vec<InvidiousVideoRaw>),
+    Wrapped { videos: Vec<InvidiousVideoRaw> },
+}
+
 #[derive(Debug, Clone, Deserialize)]
 struct Thumbnail {
     url: String,
@@ -409,6 +416,59 @@ impl InvidiousClient {
             .collect();
 
         Ok(videos)
+    }
+
+    /// Get authenticated user's recent videos from subscription feed
+    pub async fn get_recent_videos(
+        &self,
+        max_results: Option<u32>,
+    ) -> Result<Vec<YoutubeVideo>, AppError> {
+        let max = max_results.unwrap_or(25).min(40);
+        let url = format!("{}/api/v1/auth/feed?max_results={}", self.base_url, max);
+
+        let response = self
+            .with_basic_auth(self.http.get(&url))
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
+
+        match response.status() {
+            status if status.is_success() => {
+                let feed: InvidiousRecentFeedResponse = response
+                    .json()
+                    .await
+                    .map_err(|_| AppError::InvidiousBadResponse)?;
+
+                let mut videos: Vec<YoutubeVideo> = match feed {
+                    InvidiousRecentFeedResponse::Videos(videos) => videos,
+                    InvidiousRecentFeedResponse::Wrapped { videos } => videos,
+                }
+                .into_iter()
+                .map(|v| {
+                    let thumbnail = format!("{}/vi/{}/hqdefault.jpg", self.base_url, v.video_id);
+
+                    YoutubeVideo {
+                        title: v.title,
+                        video_id: v.video_id.clone(),
+                        author: v.author,
+                        author_id: v.author_id,
+                        published: v.published,
+                        published_text: v.published_text,
+                        duration: v.length_seconds,
+                        thumbnail,
+                        view_count: v.view_count,
+                        description: Some(v.description).filter(|d| !d.is_empty()),
+                    }
+                })
+                .collect();
+
+                videos.sort_by_key(|video| std::cmp::Reverse(video.published));
+                Ok(videos)
+            }
+            status if status.as_u16() == 401 => Err(AppError::InvidiousAuthFailed),
+            status if status.as_u16() == 429 => Err(AppError::InvidiousRateLimited),
+            _ => Err(AppError::InvidiousBadResponse),
+        }
     }
 
     /// Get channel info including description

--- a/src/youtube.rs
+++ b/src/youtube.rs
@@ -88,6 +88,17 @@ fn default_max_results() -> u32 {
     20
 }
 
+/// Recent videos query parameters
+#[derive(Debug, Deserialize)]
+pub struct RecentVideosQuery {
+    #[serde(default = "default_recent_max_results")]
+    max_results: u32,
+}
+
+fn default_recent_max_results() -> u32 {
+    25
+}
+
 /// Video list response
 #[derive(Debug, Serialize)]
 pub struct ChannelVideosResponse {
@@ -118,6 +129,12 @@ pub struct PlaylistVideosResponse {
     pub videos: Vec<YoutubeVideo>,
 }
 
+/// Recent videos response
+#[derive(Debug, Serialize)]
+pub struct RecentVideosResponse {
+    pub videos: Vec<YoutubeVideo>,
+}
+
 #[derive(Debug, Serialize)]
 struct YoutubeWatchProgressResponse {
     video_id: String,
@@ -145,6 +162,7 @@ pub fn build_routes(auth: WebAuthConfig, config: &AppConfig) -> Router {
 
     Router::new()
         .route("/api/youtube/subscriptions", get(get_subscriptions))
+        .route("/api/youtube/recent", get(get_recent_videos))
         .route(
             "/api/youtube/channel/{channel_id}/videos",
             get(get_channel_videos),
@@ -340,6 +358,23 @@ async fn get_subscriptions(State(state): State<YoutubeState>) -> Response {
 
     match client.get_subscriptions().await {
         Ok(channels) => (StatusCode::OK, Json(SubscriptionsResponse { channels })).into_response(),
+        Err(e) => e.into_response(),
+    }
+}
+
+/// Get authenticated user's recent videos from subscription feed
+async fn get_recent_videos(
+    State(state): State<YoutubeState>,
+    query: axum::extract::Query<RecentVideosQuery>,
+) -> Response {
+    let client = match state.require_client() {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
+
+    let max_results = query.max_results.min(40);
+    match client.get_recent_videos(Some(max_results)).await {
+        Ok(videos) => (StatusCode::OK, Json(RecentVideosResponse { videos })).into_response(),
         Err(e) => e.into_response(),
     }
 }

--- a/web/src/lib/api-client/youtube.ts
+++ b/web/src/lib/api-client/youtube.ts
@@ -43,6 +43,24 @@ export async function getYouTubeSubscriptions(): Promise<YoutubeChannel[]> {
   return payload.channels as YoutubeChannel[];
 }
 
+export async function getYouTubeRecentVideos(maxResults = 25): Promise<YoutubeVideo[]> {
+  const params = new URLSearchParams();
+  params.set("max_results", String(maxResults));
+
+  const response = await request(`/api/youtube/recent?${params.toString()}`);
+  if (!response.ok) {
+    const payload = await safeJson(response);
+    throw new Error(readError(payload));
+  }
+
+  const payload = await safeJson(response);
+  if (!isObject(payload) || !Array.isArray(payload.videos)) {
+    throw new Error("recent videos payload is invalid");
+  }
+
+  return payload.videos as YoutubeVideo[];
+}
+
 export async function getYouTubeChannelInfo(channelId: string): Promise<YoutubeChannelInfo> {
   const url = `/api/youtube/channel/${encodeURIComponent(channelId)}/info`;
   const response = await request(url);

--- a/web/src/lib/components/YouTubeRecentView.svelte
+++ b/web/src/lib/components/YouTubeRecentView.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { getYouTubeRecentVideos, getYouTubeThumbnailUrl } from '$lib/api';
+  import type { YoutubeVideo } from '$lib/api';
+  import { formatTimeAgo } from '$lib/youtube/format';
+  import { YouTubeListState, YouTubeMediaRow } from '$lib/components/youtube';
+
+  const DEFAULT_MAX_RESULTS = 25;
+
+  let videos = $state<YoutubeVideo[]>([]);
+  let isLoading = $state(true);
+  let error = $state<string | null>(null);
+
+  onMount(async () => {
+    try {
+      videos = await getYouTubeRecentVideos(DEFAULT_MAX_RESULTS);
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Failed to load recent videos';
+    } finally {
+      isLoading = false;
+    }
+  });
+
+  function openVideo(videoId: string): void {
+    if (typeof window !== 'undefined') {
+      sessionStorage.setItem('youtubeBackContext', 'recent');
+      sessionStorage.setItem('youtubeWatchReturnUrl', '/?youtube=recent');
+    }
+    goto(`/youtube/watch/${encodeURIComponent(videoId)}`);
+  }
+
+  function formatViewCount(count: number): string {
+    if (count >= 1000000) {
+      return `${(count / 1000000).toFixed(1)}M views`;
+    }
+    if (count >= 1000) {
+      return `${(count / 1000).toFixed(1)}K views`;
+    }
+    return `${count} views`;
+  }
+
+  function formatDuration(seconds: number): string {
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    const secs = seconds % 60;
+
+    if (hours > 0) {
+      return `${hours}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+    }
+    return `${minutes}:${secs.toString().padStart(2, '0')}`;
+  }
+</script>
+
+<div class="youtube-recent">
+  <YouTubeListState
+    {isLoading}
+    {error}
+    isEmpty={videos.length === 0}
+    loadingText="Loading recent videos..."
+    emptyText="No recent videos found."
+  >
+    <div class="ui-list">
+      {#each videos as video (video.video_id)}
+        {#snippet visual()}
+          <div class="recent-thumbnail-wrap">
+            <img
+              class="ui-thumbnail recent-thumbnail"
+              src={getYouTubeThumbnailUrl(video.video_id)}
+              alt={video.title}
+              loading="lazy"
+            />
+            <span class="recent-duration">{formatDuration(video.duration)}</span>
+          </div>
+        {/snippet}
+
+        {#snippet meta()}
+          <span class="ui-media-meta recent-meta">
+            {video.author} · {formatViewCount(video.view_count)} · {formatTimeAgo(video.published)}
+          </span>
+        {/snippet}
+
+        <YouTubeMediaRow
+          title={video.title}
+          onClick={() => openVideo(video.video_id)}
+          {visual}
+          {meta}
+          extraClass="youtube-recent-row"
+        />
+      {/each}
+    </div>
+  </YouTubeListState>
+</div>
+
+<style>
+  .youtube-recent {
+    display: grid;
+    gap: 1rem;
+  }
+
+  :global(.youtube-recent-row) {
+    display: grid;
+    grid-template-columns: 140px minmax(0, 1fr);
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.8rem;
+    text-align: left;
+  }
+
+  .recent-thumbnail-wrap {
+    position: relative;
+    width: 140px;
+    height: 78px;
+  }
+
+  .recent-thumbnail {
+    width: 140px;
+    height: 78px;
+    border-radius: 0.5rem;
+  }
+
+  .recent-duration {
+    position: absolute;
+    right: 0.35rem;
+    bottom: 0.35rem;
+    padding: 0.1rem 0.3rem;
+    border-radius: 0.25rem;
+    font-size: 0.74rem;
+    line-height: 1.1;
+    color: white;
+    background: rgba(0, 0, 0, 0.76);
+  }
+
+  .recent-meta {
+    line-height: 1.35;
+  }
+</style>

--- a/web/src/lib/components/home/YouTubeModeView.svelte
+++ b/web/src/lib/components/home/YouTubeModeView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import YouTubeSubscriptionsView from '$lib/components/YouTubeSubscriptionsView.svelte';
+  import YouTubeRecentView from '$lib/components/YouTubeRecentView.svelte';
   import YouTubePlaylistsView from '$lib/components/YouTubePlaylistsView.svelte';
   import type { YouTubeModeViewProps } from './types';
 
@@ -20,6 +21,14 @@
       <button
         type="button"
         class="channels-label tab"
+        class:active={youtubeViewMode === 'recent'}
+        onclick={() => onViewModeChange('recent')}
+      >
+        Recent
+      </button>
+      <button
+        type="button"
+        class="channels-label tab"
         class:active={youtubeViewMode === 'playlists'}
         onclick={() => onViewModeChange('playlists')}
       >
@@ -29,6 +38,8 @@
   </div>
   {#if youtubeViewMode === 'subscriptions'}
     <YouTubeSubscriptionsView />
+  {:else if youtubeViewMode === 'recent'}
+    <YouTubeRecentView />
   {:else}
     <YouTubePlaylistsView />
   {/if}

--- a/web/src/lib/components/home/types.ts
+++ b/web/src/lib/components/home/types.ts
@@ -13,7 +13,7 @@ export type { ChannelEntry, ChannelStatus, RecordingRule, ActiveRecording, Recor
 export type AuthMode = "checking" | "authenticated" | "unauthenticated";
 export type RelayMode = "twitch" | "youtube";
 export type LoginMode = "code" | "qr";
-export type YouTubeViewMode = "subscriptions" | "playlists";
+export type YouTubeViewMode = "subscriptions" | "recent" | "playlists";
 export type CurrentView = "channels" | "recordings";
 
 // AppHeader props

--- a/web/src/lib/home/routeView.ts
+++ b/web/src/lib/home/routeView.ts
@@ -1,6 +1,6 @@
 export type InitialHomeView =
   | { relayMode: "twitch"; twitchView: "channels" | "recordings" }
-  | { relayMode: "youtube"; youtubeView: "subscriptions" | "playlists" };
+  | { relayMode: "youtube"; youtubeView: "subscriptions" | "recent" | "playlists" };
 
 export function parseInitialHomeView(search: string): InitialHomeView {
   const params = new URLSearchParams(search);
@@ -13,6 +13,8 @@ export function parseInitialHomeView(search: string): InitialHomeView {
     return { relayMode: "twitch", twitchView: "channels" };
   } else if (youtubeView === "subscriptions") {
     return { relayMode: "youtube", youtubeView: "subscriptions" };
+  } else if (youtubeView === "recent") {
+    return { relayMode: "youtube", youtubeView: "recent" };
   } else if (youtubeView === "playlists") {
     return { relayMode: "youtube", youtubeView: "playlists" };
   } else {

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -20,7 +20,7 @@
   import { loadLiveOnlyPreference, saveLiveOnlyPreference } from '$lib/home/preferences';
   import { parseInitialHomeView } from '$lib/home/routeView';
 
-  type YouTubeViewMode = 'subscriptions' | 'playlists';
+  type YouTubeViewMode = 'subscriptions' | 'recent' | 'playlists';
 
   // Global error state (shared across controllers)
   let errorMessage = $state<string | null>(null);

--- a/web/src/routes/youtube/watch/[video_id]/+page.svelte
+++ b/web/src/routes/youtube/watch/[video_id]/+page.svelte
@@ -174,6 +174,9 @@
       if (context === 'playlists') {
         goto('/?youtube=playlists');
         return;
+      } else if (context === 'recent') {
+        goto('/?youtube=recent');
+        return;
       } else {
         goto('/?youtube=subscriptions');
         return;


### PR DESCRIPTION
## Summary
- add a new YouTube `Recent` tab between `Subscribed Channels` and `Playlists`
- add backend endpoint `GET /api/youtube/recent?max_results=<n>`
- add Invidious authenticated recent-feed client mapping to existing `YoutubeVideo` shape
- add frontend API client and `YouTubeRecentView` component
- wire `recent` into home route view parsing and watch-page back navigation

## Verification
- `cargo check`
- `cargo clippy --all-targets --all-features`
- `cargo test`
- `cargo fmt -- --check`
- `cd web && pnpm run verify`