### PR TITLE
feat: add watch progress tracking for Twitch recordings

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -100,8 +100,10 @@ pub fn build_router(config: &AppConfig, access_code_hash: String) -> Result<Rout
     let stream_proxy_state = stream_proxy::StreamProxyState::new(stream_service.clone());
 
     let recording_state = routes::RecordingState {
+        auth: auth_config.clone(),
         service: recording_service,
         default_quality: config.recording.default_quality.clone(),
+        progress: crate::recording_progress::RecordingProgressStore::new(),
     };
 
     // Build route modules

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -115,7 +115,7 @@ struct CachedEmoteEntry {
 #[derive(Debug, Clone)]
 struct CachedOwnerName {
     expires_at_unix: u64,
-    display_name: String,
+    display_name: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -127,6 +127,7 @@ struct CachedThirdPartyEmotes {
 const EMOTE_CACHE_TTL_SECS: u64 = 900;
 const THIRD_PARTY_EMOTE_CACHE_TTL_SECS: u64 = 300;
 const OWNER_NAME_CACHE_TTL_SECS: u64 = 24 * 60 * 60;
+const OWNER_NAME_MISS_CACHE_TTL_SECS: u64 = 15 * 60;
 const OWNER_LOOKUP_429_FALLBACK_COOLDOWN_SECS: u64 = 60;
 
 #[derive(Debug, Clone, Serialize)]
@@ -1035,13 +1036,19 @@ async fn resolve_user_display_names_by_ids(
 
     let now = now_unix_secs();
     let mut missing_ids = Vec::new();
+    let mut seen_ids = HashSet::new();
     {
         let cache = owner_name_cache.read().await;
         for id in filtered_ids {
+            if !seen_ids.insert(id.clone()) {
+                continue;
+            }
             if let Some(entry) = cache.get(&id)
                 && entry.expires_at_unix > now
             {
-                out.insert(id, entry.display_name.clone());
+                if let Some(display_name) = entry.display_name.as_ref() {
+                    out.insert(id, display_name.clone());
+                }
             } else {
                 missing_ids.push(id);
             }
@@ -1125,7 +1132,7 @@ async fn resolve_user_display_names_by_ids(
             }
         };
 
-        let mut fresh_names = Vec::with_capacity(payload.data.len());
+        let mut fresh_names: HashMap<String, String> = HashMap::with_capacity(payload.data.len());
         for user in payload.data {
             let display_name = user
                 .display_name
@@ -1134,18 +1141,27 @@ async fn resolve_user_display_names_by_ids(
                 .unwrap_or_else(|| "Unknown channel".to_string());
 
             out.insert(user.id.clone(), display_name.clone());
-            fresh_names.push((user.id, display_name));
+            fresh_names.insert(user.id, display_name);
         }
 
-        if !fresh_names.is_empty() {
-            let expires_at_unix = now_unix_secs().saturating_add(OWNER_NAME_CACHE_TTL_SECS);
-            let mut cache = owner_name_cache.write().await;
-            for (user_id, display_name) in fresh_names {
+        let hit_expires_at_unix = now_unix_secs().saturating_add(OWNER_NAME_CACHE_TTL_SECS);
+        let miss_expires_at_unix = now_unix_secs().saturating_add(OWNER_NAME_MISS_CACHE_TTL_SECS);
+        let mut cache = owner_name_cache.write().await;
+        for user_id in chunk {
+            if let Some(display_name) = fresh_names.get(user_id) {
                 cache.insert(
-                    user_id,
+                    user_id.clone(),
                     CachedOwnerName {
-                        expires_at_unix,
-                        display_name,
+                        expires_at_unix: hit_expires_at_unix,
+                        display_name: Some(display_name.clone()),
+                    },
+                );
+            } else {
+                cache.insert(
+                    user_id.clone(),
+                    CachedOwnerName {
+                        expires_at_unix: miss_expires_at_unix,
+                        display_name: None,
                     },
                 );
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,8 @@ mod prewarm;
 
 mod recording;
 
+mod recording_progress;
+
 mod recording_rules;
 
 mod recording_scheduler;

--- a/src/recording_progress.rs
+++ b/src/recording_progress.rs
@@ -1,0 +1,130 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    storage::{files, paths},
+    util::time::now_unix_secs,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RecordingWatchProgressEntry {
+    pub position_secs: f64,
+    pub duration_secs: Option<f64>,
+    pub completed: bool,
+    pub updated_at_unix: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct StoredRecordingWatchProgress {
+    sessions: HashMap<String, HashMap<String, RecordingWatchProgressEntry>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RecordingProgressStore {
+    inner: Arc<RwLock<StoredRecordingWatchProgress>>,
+}
+
+impl RecordingProgressStore {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(load_watch_progress())),
+        }
+    }
+
+    pub fn get(
+        &self,
+        session_token: &str,
+        channel_login: &str,
+        filename: &str,
+    ) -> Option<RecordingWatchProgressEntry> {
+        let guard = self.inner.read().ok()?;
+        guard
+            .sessions
+            .get(session_token)
+            .and_then(|recordings| recordings.get(&recording_key(channel_login, filename)))
+            .cloned()
+    }
+
+    pub fn upsert(
+        &self,
+        session_token: &str,
+        channel_login: &str,
+        filename: &str,
+        position_secs: f64,
+        duration_secs: Option<f64>,
+        completed: Option<bool>,
+    ) -> Option<RecordingWatchProgressEntry> {
+        let normalized_position = normalize_secs(position_secs)?;
+        let normalized_duration = duration_secs.and_then(normalize_secs);
+        let normalized_completed = completed.unwrap_or_else(|| {
+            normalized_duration
+                .map(|duration| duration > 0.0 && duration - normalized_position <= 20.0)
+                .unwrap_or(false)
+        });
+        let key = recording_key(channel_login, filename);
+
+        let entry = RecordingWatchProgressEntry {
+            position_secs: normalized_position,
+            duration_secs: normalized_duration,
+            completed: normalized_completed,
+            updated_at_unix: now_unix_secs(),
+        };
+
+        if let Ok(mut guard) = self.inner.write() {
+            let recordings = guard
+                .sessions
+                .entry(session_token.to_string())
+                .or_insert_with(HashMap::new);
+            recordings.insert(key, entry.clone());
+            let _ = save_watch_progress(&guard);
+            return Some(entry);
+        }
+
+        None
+    }
+}
+
+fn recording_key(channel_login: &str, filename: &str) -> String {
+    format!("{channel_login}/{filename}")
+}
+
+fn normalize_secs(value: f64) -> Option<f64> {
+    if !value.is_finite() {
+        return None;
+    }
+    if value < 0.0 {
+        return Some(0.0);
+    }
+    Some(value)
+}
+
+fn load_watch_progress() -> StoredRecordingWatchProgress {
+    let Some(path) = paths::recording_watch_progress_path() else {
+        return StoredRecordingWatchProgress::default();
+    };
+
+    match files::load_json_optional::<StoredRecordingWatchProgress>(&path) {
+        Ok(Some(data)) => data,
+        Ok(None) => StoredRecordingWatchProgress::default(),
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                path = %path.display(),
+                "failed to load recording watch progress"
+            );
+            StoredRecordingWatchProgress::default()
+        }
+    }
+}
+
+fn save_watch_progress(data: &StoredRecordingWatchProgress) -> Result<(), String> {
+    let Some(path) = paths::recording_watch_progress_path() else {
+        return Err("failed to resolve recording watch progress path".to_string());
+    };
+
+    files::write_json_pretty_atomic(&path, data)
+}

--- a/src/routes/recordings.rs
+++ b/src/routes/recordings.rs
@@ -16,6 +16,7 @@ use crate::{
     recording::{
         ActiveRecording, RecordingBucket, RecordingError, RecordingMode, RecordingService,
     },
+    recording_progress::{RecordingProgressStore, RecordingWatchProgressEntry},
     recording_rules::{self, RecordingRule},
     routes::error::error_response,
 };
@@ -23,8 +24,10 @@ use crate::{
 /// State for recording routes.
 #[derive(Debug, Clone)]
 pub struct RecordingState {
+    pub auth: WebAuthConfig,
     pub service: RecordingService,
     pub default_quality: String,
+    pub progress: RecordingProgressStore,
 }
 
 /// Request DTO for starting a recording.
@@ -102,6 +105,34 @@ pub struct ServeHlsPlaylistQuery {
     pub filename: String,
 }
 
+/// Query parameters for recording watch progress.
+#[derive(Debug, Deserialize)]
+pub struct RecordingWatchProgressQuery {
+    pub channel_login: String,
+    pub filename: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RecordingWatchProgressUpdateRequest {
+    pub channel_login: String,
+    pub filename: String,
+    pub position_secs: f64,
+    #[serde(default)]
+    pub duration_secs: Option<f64>,
+    #[serde(default)]
+    pub completed: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+struct RecordingWatchProgressResponse {
+    channel_login: String,
+    filename: String,
+    position_secs: Option<f64>,
+    duration_secs: Option<f64>,
+    updated_at_unix: Option<u64>,
+    completed: bool,
+}
+
 /// Build recording routes.
 pub fn recording_routes(state: RecordingState, auth_config: WebAuthConfig) -> Router {
     Router::new()
@@ -112,6 +143,10 @@ pub fn recording_routes(state: RecordingState, auth_config: WebAuthConfig) -> Ro
         .route("/api/recordings/delete", post(delete_recording_file))
         .route("/api/recordings/playback-file", get(play_recording_asset))
         .route("/api/recordings/hls-playlist", get(serve_hls_playlist))
+        .route(
+            "/api/recordings/progress",
+            get(get_recording_progress).put(put_recording_progress),
+        )
         .route("/api/recordings", get(get_recordings))
         .route("/api/recording-rules", get(get_recording_rules))
         .route("/api/recording-rules", post(upsert_recording_rule))
@@ -124,6 +159,77 @@ pub fn recording_routes(state: RecordingState, auth_config: WebAuthConfig) -> Ro
             auth_config,
             auth::require_session_middleware,
         ))
+}
+
+fn recording_progress_response(
+    channel_login: String,
+    filename: String,
+    entry: Option<RecordingWatchProgressEntry>,
+) -> Response {
+    let payload = if let Some(entry) = entry {
+        RecordingWatchProgressResponse {
+            channel_login,
+            filename,
+            position_secs: Some(entry.position_secs),
+            duration_secs: entry.duration_secs,
+            updated_at_unix: Some(entry.updated_at_unix),
+            completed: entry.completed,
+        }
+    } else {
+        RecordingWatchProgressResponse {
+            channel_login,
+            filename,
+            position_secs: None,
+            duration_secs: None,
+            updated_at_unix: None,
+            completed: false,
+        }
+    };
+
+    (StatusCode::OK, Json(payload)).into_response()
+}
+
+async fn get_recording_progress(
+    State(state): State<RecordingState>,
+    Query(query): Query<RecordingWatchProgressQuery>,
+    request_headers: HeaderMap,
+) -> Response {
+    let Some(session_token) = state.auth.session_token_from_headers(&request_headers) else {
+        return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
+    };
+
+    let progress = state
+        .progress
+        .get(&session_token, &query.channel_login, &query.filename);
+    recording_progress_response(query.channel_login, query.filename, progress)
+}
+
+async fn put_recording_progress(
+    State(state): State<RecordingState>,
+    request_headers: HeaderMap,
+    Json(payload): Json<RecordingWatchProgressUpdateRequest>,
+) -> Response {
+    let Some(session_token) = state.auth.session_token_from_headers(&request_headers) else {
+        return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
+    };
+
+    let saved = state.progress.upsert(
+        &session_token,
+        &payload.channel_login,
+        &payload.filename,
+        payload.position_secs,
+        payload.duration_secs,
+        payload.completed,
+    );
+    let Some(entry) = saved else {
+        return (
+            StatusCode::BAD_REQUEST,
+            "invalid progress payload or failed to persist",
+        )
+            .into_response();
+    };
+
+    recording_progress_response(payload.channel_login, payload.filename, Some(entry))
 }
 
 async fn start_recording(

--- a/src/storage/paths.rs
+++ b/src/storage/paths.rs
@@ -70,3 +70,8 @@ pub fn youtube_images_dir() -> Option<PathBuf> {
 pub fn youtube_watch_progress_path() -> Option<PathBuf> {
     data_file_path("youtube_watch_progress.json")
 }
+
+/// Path to the recording_watch_progress.json file.
+pub fn recording_watch_progress_path() -> Option<PathBuf> {
+    data_file_path("recording_watch_progress.json")
+}

--- a/src/youtube_progress.rs
+++ b/src/youtube_progress.rs
@@ -62,7 +62,10 @@ impl YoutubeProgressStore {
         let normalized_duration = duration_secs.and_then(normalize_secs);
         let normalized_completed = completed.unwrap_or_else(|| {
             normalized_duration
-                .map(|duration| duration > 0.0 && duration - normalized_position <= 20.0)
+                .map(|duration| {
+                    let end_gap = (duration * 0.05).min(20.0);
+                    duration > 0.0 && duration - normalized_position <= end_gap
+                })
                 .unwrap_or(false)
         });
 

--- a/web/src/app.d.ts
+++ b/web/src/app.d.ts
@@ -15,7 +15,6 @@ declare global {
     static Events: {
       MANIFEST_PARSED: string;
       ERROR: string;
-      FRAG_BUFFERED: string;
     };
     constructor(config?: object);
     loadSource(url: string): void;

--- a/web/src/app.d.ts
+++ b/web/src/app.d.ts
@@ -15,6 +15,7 @@ declare global {
     static Events: {
       MANIFEST_PARSED: string;
       ERROR: string;
+      FRAG_BUFFERED: string;
     };
     constructor(config?: object);
     loadSource(url: string): void;

--- a/web/src/lib/api-client/recordings.ts
+++ b/web/src/lib/api-client/recordings.ts
@@ -4,6 +4,7 @@ import type {
   RecordingsResponse,
   ActiveRecording,
   RecordingFileEntry,
+  RecordingWatchProgress,
 } from "./types";
 
 export async function getRecordingRules(): Promise<Array<RecordingRule>> {
@@ -146,4 +147,36 @@ export async function unpinRecordingFile(payload: {
     const body = await safeJson(response);
     throw new Error(readError(body));
   }
+}
+
+export async function getRecordingWatchProgress(
+  channel_login: string,
+  filename: string,
+): Promise<RecordingWatchProgress> {
+  const params = new URLSearchParams({ channel_login, filename });
+  const response = await request(`/api/recordings/progress?${params.toString()}`);
+  if (!response.ok) {
+    const payload = await safeJson(response);
+    throw new Error(readError(payload));
+  }
+  return (await safeJson(response)) as RecordingWatchProgress;
+}
+
+export async function saveRecordingWatchProgress(payload: {
+  channel_login: string;
+  filename: string;
+  position_secs: number;
+  duration_secs?: number;
+  completed?: boolean;
+}): Promise<RecordingWatchProgress> {
+  const response = await request("/api/recordings/progress", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    const body = await safeJson(response);
+    throw new Error(readError(body));
+  }
+  return (await safeJson(response)) as RecordingWatchProgress;
 }

--- a/web/src/lib/api-client/types.ts
+++ b/web/src/lib/api-client/types.ts
@@ -97,6 +97,15 @@ export interface RecordingsResponse {
   incomplete: Array<RecordingFileEntry>;
 }
 
+export interface RecordingWatchProgress {
+  channel_login: string;
+  filename: string;
+  position_secs: number | null;
+  duration_secs: number | null;
+  updated_at_unix: number | null;
+  completed: boolean;
+}
+
 // ============================================
 // Recording rules
 // ============================================

--- a/web/src/routes/recordings/play/+page.svelte
+++ b/web/src/routes/recordings/play/+page.svelte
@@ -117,7 +117,6 @@
       return new Promise((resolve) => {
         // Hide spinner when video is ready to play
         const hideLoading = () => {
-          console.log('[Player] Hiding loading spinner');
           isLoading = false;
         };
 
@@ -129,30 +128,14 @@
 
 
         // Listen for manifest parsed (HLS ready)
-        hlsInstance.on(HlsClass.Events.MANIFEST_PARSED, (_event: unknown, data: unknown) => {
-          console.log('[HLS] Manifest parsed', data);
+        hlsInstance.on(HlsClass.Events.MANIFEST_PARSED, (_event: unknown, _data: unknown) => {
           const hlsRuntime = hlsInstance as unknown as { startLoad?: (position: number) => void } | null;
-          // Start loading from the resume position
           const startPos = typeof resumeAt === 'number' && Number.isFinite(resumeAt) && resumeAt > 0
             ? resumeAt
             : -1;
-          console.log(`[HLS] Starting load at position: ${startPos}`);
           hlsRuntime?.startLoad?.(startPos);
           hideLoading();
           resolve(true);
-        });
-
-        // Fallback 3: try when HLS buffers the fragment containing our target
-        hlsInstance.on(HlsClass.Events.FRAG_BUFFERED, (_event: unknown, data: unknown) => {
-          if (resumeSettled || resumeTargetPosition === null) return;
-          const fragData = data as { frag?: { start: number; duration: number; } };
-          if (fragData?.frag) {
-            const fragEnd = fragData.frag.start + fragData.frag.duration;
-            if (fragData.frag.start <= resumeTargetPosition && fragEnd >= resumeTargetPosition) {
-              console.log('[HLS] FRAG_BUFFERED contains resume target, seeking');
-              applyResumePosition();
-            }
-          }
         });
 
         // Handle errors
@@ -160,51 +143,31 @@
           console.error('[HLS] Error:', data);
           const errorData = data as { fatal?: boolean };
           if (errorData.fatal) {
-            console.log('[HLS] Fatal error');
             resolve(false);
           } else {
-            console.log('[HLS] Non-fatal error, hiding spinner');
-            // Hide spinner on non-fatal errors too - video might still play
             hideLoading();
           }
         });
 
-        // Primary: seek when first frame is available (best for VOD resume)
-        playerEl.addEventListener('loadeddata', () => {
-          console.log('[Video] loadeddata event');
-          if (resumeTargetPosition !== null && !resumeSettled) {
-            applyResumePosition();
-          }
-          hideLoading();
-        }, { once: true });
-
-        // Fallback 1: seek when duration becomes available
+        // Resume: seek when metadata is available
         playerEl.addEventListener('loadedmetadata', () => {
-          console.log('[Video] loadedmetadata event, duration:', playerEl?.duration);
           if (resumeTargetPosition !== null && !resumeSettled) {
             applyResumePosition();
           }
           hideLoading();
         }, { once: true });
 
-        // Fallback 2: try one more time if we still haven't settled
-        playerEl.addEventListener('durationchange', () => {
-          console.log('[Video] durationchange event, duration:', playerEl?.duration);
-          if (resumeTargetPosition !== null && !resumeSettled && playerEl && playerEl.duration > 0) {
-            // Only try if we're not already close to target
-            if (Math.abs(playerEl.currentTime - resumeTargetPosition) > 1) {
-              applyResumePosition();
-            } else {
-              resumeSettled = true;
-            }
+        // Resume: seek when first frame is available
+        playerEl.addEventListener('loadeddata', () => {
+          if (resumeTargetPosition !== null && !resumeSettled) {
+            applyResumePosition();
           }
+          hideLoading();
         }, { once: true });
 
         // Fallback: timeout
         setTimeout(() => {
-          console.log('[Player] Timeout reached, hiding spinner');
           hideLoading();
-          // Don't resolve false - video might still be playing
         }, 3000);
 
         // Start loading
@@ -263,6 +226,7 @@
     }
     try {
       playerEl.currentTime = resumeTargetPosition;
+      resumeSettled = true;
     } catch {
       // no-op
     }

--- a/web/src/routes/recordings/play/+page.svelte
+++ b/web/src/routes/recordings/play/+page.svelte
@@ -13,7 +13,8 @@
   let hlsInstance = $state<Hls | null>(null);
   let progressTimer = $state<number | null>(null);
   let lastSavedPosition = $state(0);
-  let pendingResumePosition = $state<number | null>(null);
+  let resumeTargetPosition = $state<number | null>(null);
+  let resumeSettled = $state(false);
 
   const RESUME_MIN_SECS = 15;
   const RESUME_END_GAP_SECS = 20;
@@ -80,6 +81,7 @@
   async function loadHlsPlayer(): Promise<boolean> {
     if (!playerEl) return false;
     setupProgressTracking();
+    const resumeAt = resumeTargetPosition;
 
     // Wait for hls.js to load (it may still be loading from the script tag)
     let attempts = 0;
@@ -100,6 +102,8 @@
         capLevelToPlayerSize: true,
         // Reduce initial load
         startLevel: -1,                 // Auto start level
+        startPosition: typeof resumeAt === 'number' ? resumeAt : -1,
+        autoStartLoad: false,
         // More conservative loading
         abrEwmaFastLive: 3.0,
         abrEwmaSlowLive: 9.0,
@@ -120,6 +124,13 @@
         // Listen for manifest parsed (HLS ready)
         hlsInstance.on(HlsClass.Events.MANIFEST_PARSED, () => {
           console.log('[HLS] Manifest parsed');
+          const hlsRuntime = hlsInstance as unknown as { startLoad?: (position: number) => void } | null;
+          if (typeof resumeAt === 'number' && Number.isFinite(resumeAt) && resumeAt > 0) {
+            hlsRuntime?.startLoad?.(resumeAt);
+          } else {
+            hlsRuntime?.startLoad?.(-1);
+          }
+          applyResumePositionWithRetry();
           hideLoading();
           resolve(true);
         });
@@ -141,6 +152,7 @@
         // Fallback: hide spinner when video element fires canplay event
         playerEl.addEventListener('canplay', () => {
           console.log('[Video] canplay event');
+          applyResumePositionWithRetry();
           hideLoading();
           resolve(true);
         }, { once: true });
@@ -148,9 +160,17 @@
         // Fallback: hide on loadedmetadata
         playerEl.addEventListener('loadedmetadata', () => {
           console.log('[Video] loadedmetadata event');
-          applyResumePosition();
+          applyResumePositionWithRetry();
           hideLoading();
         }, { once: true });
+
+        playerEl.addEventListener('durationchange', () => {
+          applyResumePositionWithRetry();
+        });
+
+        playerEl.addEventListener('progress', () => {
+          applyResumePositionWithRetry();
+        });
 
         // Fallback: timeout
         setTimeout(() => {
@@ -191,7 +211,8 @@
         typeof progress.position_secs === 'number' &&
         progress.position_secs >= RESUME_MIN_SECS
       ) {
-        pendingResumePosition = progress.position_secs;
+        resumeTargetPosition = progress.position_secs;
+        resumeSettled = false;
         lastSavedPosition = progress.position_secs;
       }
     } catch {
@@ -200,22 +221,54 @@
   }
 
   function applyResumePosition(): void {
-    if (!playerEl || pendingResumePosition === null) return;
+    if (!playerEl || resumeTargetPosition === null) return;
     const duration = playerEl.duration;
     const maxResume =
       Number.isFinite(duration) && duration > 0
         ? Math.max(0, duration - RESUME_END_GAP_SECS)
         : Number.POSITIVE_INFINITY;
-    if (pendingResumePosition > maxResume) {
-      pendingResumePosition = null;
+    if (resumeTargetPosition > maxResume) {
+      resumeTargetPosition = null;
+      resumeSettled = true;
       return;
     }
     try {
-      playerEl.currentTime = pendingResumePosition;
+      playerEl.currentTime = resumeTargetPosition;
     } catch {
       // no-op
     }
-    pendingResumePosition = null;
+  }
+
+  function applyResumePositionWithRetry(attempt = 0, target?: number): void {
+    if (!playerEl || resumeSettled) return;
+    const resumeTarget = typeof target === 'number' ? target : resumeTargetPosition;
+    if (resumeTarget === null || typeof resumeTarget !== 'number') return;
+
+    if (playerEl.seekable.length > 0) {
+      const seekableEnd = playerEl.seekable.end(playerEl.seekable.length - 1);
+      if (resumeTarget > seekableEnd + 1 && attempt < 12) {
+        window.setTimeout(() => applyResumePositionWithRetry(attempt + 1, resumeTarget), 200);
+        return;
+      }
+    }
+
+    try {
+      playerEl.currentTime = resumeTarget;
+    } catch {
+      // no-op
+    }
+
+    if (Math.abs(playerEl.currentTime - resumeTarget) <= 1) {
+      resumeTargetPosition = null;
+      resumeSettled = true;
+      return;
+    }
+
+    if (attempt < 12) {
+      window.setTimeout(() => {
+        applyResumePositionWithRetry(attempt + 1, resumeTarget);
+      }, 200);
+    }
   }
 
   async function pushProgress(force = false): Promise<void> {

--- a/web/src/routes/recordings/play/+page.svelte
+++ b/web/src/routes/recordings/play/+page.svelte
@@ -17,9 +17,14 @@
   let resumeSettled = $state(false);
 
   const RESUME_MIN_SECS = 15;
-  const RESUME_END_GAP_SECS = 20;
   const SAVE_INTERVAL_MS = 10_000;
   const SAVE_MIN_DELTA_SECS = 3;
+
+  // Calculate end gap as min(20s, 5% of duration) for proper scaling on short videos
+  function getEndGapSecs(duration: number): number {
+    if (!Number.isFinite(duration) || duration <= 0) return 20;
+    return Math.min(20, duration * 0.05);
+  }
 
   // Parse URL params on client side
   $effect(() => {
@@ -121,18 +126,33 @@
           return;
         }
 
+
+
         // Listen for manifest parsed (HLS ready)
-        hlsInstance.on(HlsClass.Events.MANIFEST_PARSED, () => {
-          console.log('[HLS] Manifest parsed');
+        hlsInstance.on(HlsClass.Events.MANIFEST_PARSED, (_event: unknown, data: unknown) => {
+          console.log('[HLS] Manifest parsed', data);
           const hlsRuntime = hlsInstance as unknown as { startLoad?: (position: number) => void } | null;
-          if (typeof resumeAt === 'number' && Number.isFinite(resumeAt) && resumeAt > 0) {
-            hlsRuntime?.startLoad?.(resumeAt);
-          } else {
-            hlsRuntime?.startLoad?.(-1);
-          }
-          applyResumePositionWithRetry();
+          // Start loading from the resume position
+          const startPos = typeof resumeAt === 'number' && Number.isFinite(resumeAt) && resumeAt > 0
+            ? resumeAt
+            : -1;
+          console.log(`[HLS] Starting load at position: ${startPos}`);
+          hlsRuntime?.startLoad?.(startPos);
           hideLoading();
           resolve(true);
+        });
+
+        // Fallback 3: try when HLS buffers the fragment containing our target
+        hlsInstance.on(HlsClass.Events.FRAG_BUFFERED, (_event: unknown, data: unknown) => {
+          if (resumeSettled || resumeTargetPosition === null) return;
+          const fragData = data as { frag?: { start: number; duration: number; } };
+          if (fragData?.frag) {
+            const fragEnd = fragData.frag.start + fragData.frag.duration;
+            if (fragData.frag.start <= resumeTargetPosition && fragEnd >= resumeTargetPosition) {
+              console.log('[HLS] FRAG_BUFFERED contains resume target, seeking');
+              applyResumePosition();
+            }
+          }
         });
 
         // Handle errors
@@ -149,28 +169,36 @@
           }
         });
 
-        // Fallback: hide spinner when video element fires canplay event
-        playerEl.addEventListener('canplay', () => {
-          console.log('[Video] canplay event');
-          applyResumePositionWithRetry();
+        // Primary: seek when first frame is available (best for VOD resume)
+        playerEl.addEventListener('loadeddata', () => {
+          console.log('[Video] loadeddata event');
+          if (resumeTargetPosition !== null && !resumeSettled) {
+            applyResumePosition();
+          }
           hideLoading();
-          resolve(true);
         }, { once: true });
 
-        // Fallback: hide on loadedmetadata
+        // Fallback 1: seek when duration becomes available
         playerEl.addEventListener('loadedmetadata', () => {
-          console.log('[Video] loadedmetadata event');
-          applyResumePositionWithRetry();
+          console.log('[Video] loadedmetadata event, duration:', playerEl?.duration);
+          if (resumeTargetPosition !== null && !resumeSettled) {
+            applyResumePosition();
+          }
           hideLoading();
         }, { once: true });
 
+        // Fallback 2: try one more time if we still haven't settled
         playerEl.addEventListener('durationchange', () => {
-          applyResumePositionWithRetry();
-        });
-
-        playerEl.addEventListener('progress', () => {
-          applyResumePositionWithRetry();
-        });
+          console.log('[Video] durationchange event, duration:', playerEl?.duration);
+          if (resumeTargetPosition !== null && !resumeSettled && playerEl && playerEl.duration > 0) {
+            // Only try if we're not already close to target
+            if (Math.abs(playerEl.currentTime - resumeTargetPosition) > 1) {
+              applyResumePosition();
+            } else {
+              resumeSettled = true;
+            }
+          }
+        }, { once: true });
 
         // Fallback: timeout
         setTimeout(() => {
@@ -223,9 +251,10 @@
   function applyResumePosition(): void {
     if (!playerEl || resumeTargetPosition === null) return;
     const duration = playerEl.duration;
+    const endGap = getEndGapSecs(duration);
     const maxResume =
       Number.isFinite(duration) && duration > 0
-        ? Math.max(0, duration - RESUME_END_GAP_SECS)
+        ? Math.max(0, duration - endGap)
         : Number.POSITIVE_INFINITY;
     if (resumeTargetPosition > maxResume) {
       resumeTargetPosition = null;
@@ -239,47 +268,16 @@
     }
   }
 
-  function applyResumePositionWithRetry(attempt = 0, target?: number): void {
-    if (!playerEl || resumeSettled) return;
-    const resumeTarget = typeof target === 'number' ? target : resumeTargetPosition;
-    if (resumeTarget === null || typeof resumeTarget !== 'number') return;
-
-    if (playerEl.seekable.length > 0) {
-      const seekableEnd = playerEl.seekable.end(playerEl.seekable.length - 1);
-      if (resumeTarget > seekableEnd + 1 && attempt < 12) {
-        window.setTimeout(() => applyResumePositionWithRetry(attempt + 1, resumeTarget), 200);
-        return;
-      }
-    }
-
-    try {
-      playerEl.currentTime = resumeTarget;
-    } catch {
-      // no-op
-    }
-
-    if (Math.abs(playerEl.currentTime - resumeTarget) <= 1) {
-      resumeTargetPosition = null;
-      resumeSettled = true;
-      return;
-    }
-
-    if (attempt < 12) {
-      window.setTimeout(() => {
-        applyResumePositionWithRetry(attempt + 1, resumeTarget);
-      }, 200);
-    }
-  }
-
   async function pushProgress(force = false): Promise<void> {
     if (!channelLogin || !filename || !playerEl) return;
     const currentTime = playerEl.currentTime;
-    const duration = Number.isFinite(playerEl.duration) && playerEl.duration > 0 ? playerEl.duration : undefined;
+    const durationSecs = Number.isFinite(playerEl.duration) && playerEl.duration > 0 ? playerEl.duration : undefined;
     if (!Number.isFinite(currentTime) || currentTime < 0) return;
     if (!force && Math.abs(currentTime - lastSavedPosition) < SAVE_MIN_DELTA_SECS) return;
 
+    const endGap = durationSecs ? getEndGapSecs(durationSecs) : 20;
     const isCompleted =
-      typeof duration === 'number' && duration > 0 && duration - currentTime <= RESUME_END_GAP_SECS;
+      typeof durationSecs === 'number' && durationSecs > 0 && durationSecs - currentTime <= endGap;
     lastSavedPosition = currentTime;
 
     try {
@@ -287,7 +285,7 @@
         channel_login: channelLogin,
         filename,
         position_secs: currentTime,
-        duration_secs: duration,
+        duration_secs: durationSecs,
         completed: isCompleted,
       });
     } catch {

--- a/web/src/routes/recordings/play/+page.svelte
+++ b/web/src/routes/recordings/play/+page.svelte
@@ -63,7 +63,7 @@
   }
 
   function goBack(): void {
-    window.location.assign('/?view=recordings');
+    window.location.assign('/?twitch=recordings');
   }
 
   function hlsPlaylistUrl(): string {

--- a/web/src/routes/recordings/play/+page.svelte
+++ b/web/src/routes/recordings/play/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
+  import { getRecordingWatchProgress, saveRecordingWatchProgress } from '$lib/api';
   import AppVersion from '$lib/components/AppVersion.svelte';
 
   let channelLogin = $state('');
@@ -10,6 +11,14 @@
 
   let playerEl = $state<HTMLVideoElement | null>(null);
   let hlsInstance = $state<Hls | null>(null);
+  let progressTimer = $state<number | null>(null);
+  let lastSavedPosition = $state(0);
+  let pendingResumePosition = $state<number | null>(null);
+
+  const RESUME_MIN_SECS = 15;
+  const RESUME_END_GAP_SECS = 20;
+  const SAVE_INTERVAL_MS = 10_000;
+  const SAVE_MIN_DELTA_SECS = 3;
 
   // Parse URL params on client side
   $effect(() => {
@@ -30,6 +39,7 @@
 
   async function initializePlayer(): Promise<void> {
     playbackError = null;
+    await loadStoredProgress();
 
     // HLS is required - check if playlist exists
     const hlsAvailable = await checkHlsAvailable();
@@ -69,6 +79,7 @@
 
   async function loadHlsPlayer(): Promise<boolean> {
     if (!playerEl) return false;
+    setupProgressTracking();
 
     // Wait for hls.js to load (it may still be loading from the script tag)
     let attempts = 0;
@@ -137,6 +148,7 @@
         // Fallback: hide on loadedmetadata
         playerEl.addEventListener('loadedmetadata', () => {
           console.log('[Video] loadedmetadata event');
+          applyResumePosition();
           hideLoading();
         }, { once: true });
 
@@ -158,6 +170,8 @@
   }
 
   onDestroy(() => {
+    void pushProgress(true);
+    stopProgressTracking();
     if (hlsInstance) {
       hlsInstance.destroy();
       hlsInstance = null;
@@ -167,6 +181,96 @@
       playerEl.load();
     }
   });
+
+  async function loadStoredProgress(): Promise<void> {
+    if (!channelLogin || !filename) return;
+    try {
+      const progress = await getRecordingWatchProgress(channelLogin, filename);
+      if (
+        !progress.completed &&
+        typeof progress.position_secs === 'number' &&
+        progress.position_secs >= RESUME_MIN_SECS
+      ) {
+        pendingResumePosition = progress.position_secs;
+        lastSavedPosition = progress.position_secs;
+      }
+    } catch {
+      // keep playback uninterrupted if loading progress fails
+    }
+  }
+
+  function applyResumePosition(): void {
+    if (!playerEl || pendingResumePosition === null) return;
+    const duration = playerEl.duration;
+    const maxResume =
+      Number.isFinite(duration) && duration > 0
+        ? Math.max(0, duration - RESUME_END_GAP_SECS)
+        : Number.POSITIVE_INFINITY;
+    if (pendingResumePosition > maxResume) {
+      pendingResumePosition = null;
+      return;
+    }
+    try {
+      playerEl.currentTime = pendingResumePosition;
+    } catch {
+      // no-op
+    }
+    pendingResumePosition = null;
+  }
+
+  async function pushProgress(force = false): Promise<void> {
+    if (!channelLogin || !filename || !playerEl) return;
+    const currentTime = playerEl.currentTime;
+    const duration = Number.isFinite(playerEl.duration) && playerEl.duration > 0 ? playerEl.duration : undefined;
+    if (!Number.isFinite(currentTime) || currentTime < 0) return;
+    if (!force && Math.abs(currentTime - lastSavedPosition) < SAVE_MIN_DELTA_SECS) return;
+
+    const isCompleted =
+      typeof duration === 'number' && duration > 0 && duration - currentTime <= RESUME_END_GAP_SECS;
+    lastSavedPosition = currentTime;
+
+    try {
+      await saveRecordingWatchProgress({
+        channel_login: channelLogin,
+        filename,
+        position_secs: currentTime,
+        duration_secs: duration,
+        completed: isCompleted,
+      });
+    } catch {
+      // keep playback uninterrupted if saving progress fails
+    }
+  }
+
+  function onBeforeUnload(): void {
+    void pushProgress(true);
+  }
+
+  function onVisibilityChange(): void {
+    if (document.visibilityState === 'hidden') {
+      void pushProgress(true);
+    }
+  }
+
+  function stopProgressTracking(): void {
+    if (typeof window === 'undefined') return;
+    if (progressTimer !== null) {
+      window.clearInterval(progressTimer);
+      progressTimer = null;
+    }
+    window.removeEventListener('beforeunload', onBeforeUnload);
+    document.removeEventListener('visibilitychange', onVisibilityChange);
+  }
+
+  function setupProgressTracking(): void {
+    if (typeof window === 'undefined') return;
+    stopProgressTracking();
+    progressTimer = window.setInterval(() => {
+      void pushProgress(false);
+    }, SAVE_INTERVAL_MS);
+    window.addEventListener('beforeunload', onBeforeUnload);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+  }
 </script>
 
 <svelte:head>

--- a/web/src/routes/youtube/watch/[video_id]/+page.svelte
+++ b/web/src/routes/youtube/watch/[video_id]/+page.svelte
@@ -22,9 +22,14 @@
   let lastSavedPosition = $state(0);
 
   const RESUME_MIN_SECS = 15;
-  const RESUME_END_GAP_SECS = 20;
   const SAVE_INTERVAL_MS = 10_000;
   const SAVE_MIN_DELTA_SECS = 3;
+
+  // Calculate end gap as min(20s, 5% of duration) for proper scaling on short videos
+  function getEndGapSecs(duration: number): number {
+    if (!Number.isFinite(duration) || duration <= 0) return 20;
+    return Math.min(20, duration * 0.05);
+  }
 
   function buildEmbedUrl(
     id: string,
@@ -62,11 +67,12 @@
         getYouTubeVideoProgress(videoId),
       ]);
       let resumeAt: number | undefined;
+      const endGap = getEndGapSecs(meta.duration);
       if (
         !progress.completed &&
         typeof progress.position_secs === 'number' &&
         progress.position_secs >= RESUME_MIN_SECS &&
-        progress.position_secs <= Math.max(0, meta.duration - RESUME_END_GAP_SECS)
+        progress.position_secs <= Math.max(0, meta.duration - endGap)
       ) {
         resumeAt = progress.position_secs;
         lastSavedPosition = progress.position_secs;
@@ -111,8 +117,9 @@
     if (!Number.isFinite(currentTime) || currentTime < 0) return;
     if (!force && Math.abs(currentTime - lastSavedPosition) < SAVE_MIN_DELTA_SECS) return;
 
+    const endGap = typeof duration === 'number' && duration > 0 ? getEndGapSecs(duration) : 20;
     const isCompleted =
-      typeof duration === 'number' && duration > 0 && duration - currentTime <= RESUME_END_GAP_SECS;
+      typeof duration === 'number' && duration > 0 && duration - currentTime <= endGap;
     lastSavedPosition = currentTime;
 
     try {


### PR DESCRIPTION
## Summary
This PR adds watch progress tracking and resume functionality for Twitch recordings, allowing users to continue watching from where they left off.

## Changes

### Backend
- **Watch progress tracking** - Store and retrieve resume positions for recordings
- **Resume handling** - Dynamic gap calculation for seamless resume experience  
- **API fixes** - Correct endpoint calls and proper error handling for progress sync

### Frontend  
- **Recording player** - Added tracked changes for watch progress integration
- **Navigation fixes** - Proper back button behavior and view state restoration when returning from recordings

## Commits
- `626ccaf` fix(routing): ensure proper navigation when returning from recordings
- `0d7a6d7` fix(api): correct endpoint calls for watch progress feature
- `e0c16d8` chore(web): update tracked changes
- `3542f68` refactor(config): update resume handling logic with dynamic gap calculation
- `c7de4d4` chore(web): update tracked changes
- `5c75b3c` Add watch progress resume for Twitch recordings

## Testing
- Navigate to a recording and verify progress is saved
- Leave and return to recording - should resume from last position
- Test back button navigation from various entry points