### PR TITLE
feat(recording): add merging functionality for recordings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,9 +457,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -462,9 +487,24 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
@@ -660,6 +700,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,7 +733,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -738,6 +786,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -979,6 +1033,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,6 +1129,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1265,6 +1335,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1849,6 +1925,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]
@@ -1868,6 +1945,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -1916,6 +1999,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,7 +2042,16 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -2007,6 +2110,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2017,6 +2142,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -2296,9 +2433,97 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ toml = "0.8"
 urlencoding = "2.1"
 regex = "1"
 quick-xml = "0.38"
-time = { version = "0.3.44", features = ["formatting"] }
+time = { version = "0.3.44", features = ["formatting", "parsing"] }
+uuid = { version = "1.10.0", features = ["v4"] }
 
 # Pure Rust TS->MP4 remux dependencies
 bytes = "1.10"

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -14,6 +14,7 @@ use crate::{
     twitch_auth::{HelixChannelMetadata, TwitchAuthService},
     util::time::now_unix_secs,
 };
+use std::process::Command as StdCommand;
 
 mod files;
 mod nfo;
@@ -336,6 +337,221 @@ impl RecordingService {
 
         fs::remove_file(&pin_path).map_err(|error| {
             RecordingError::UnpinFailed(format!("recording unpin failed: {error}"))
+        })
+    }
+
+    pub async fn merge_incomplete_recordings(
+        &self,
+        channel_login: &str,
+        filenames: Vec<String>,
+    ) -> Result<RecordingFileEntry, RecordingError> {
+        let channel_login = Self::normalize_channel_login(channel_login)?;
+        
+        if filenames.len() < 2 {
+            return Err(RecordingError::MergeFailed(
+                "at least 2 files are required for merging".to_string(),
+            ));
+        }
+        
+        // Validate and parse all filenames
+        let mut parsed_files = Vec::new();
+        for filename in &filenames {
+            let validated = validate_recording_filename(filename)?;
+            let parsed = parse_recording_filename(&validated)
+                .map_err(|e| RecordingError::MergeFailed(format!("invalid filename format: {e}")))?;
+            
+            // Ensure parsed channel matches the requested channel
+            if parsed.channel != channel_login {
+                return Err(RecordingError::MergeFailed(format!(
+                    "filename channel '{}' does not match requested channel '{}'",
+                    parsed.channel, channel_login
+                )));
+            }
+            
+            parsed_files.push(parsed);
+        }
+        
+        // Resolve file paths
+        let channel_dir = self.channel_bucket_dir("incomplete", &channel_login);
+        let mut file_paths = Vec::new();
+        
+        for filename in &filenames {
+            let validated = validate_recording_filename(filename)?;
+            let file_path = channel_dir.join(&validated);
+            if !file_path.exists() {
+                return Err(RecordingError::MergeFailed(format!(
+                    "file not found: {}", file_path.display()
+                )));
+            }
+            file_paths.push(file_path);
+        }
+        
+        // Normalize titles and validate consistency
+        let normalized_titles: Vec<String> = parsed_files
+            .iter()
+            .map(|f| f.title.as_deref().unwrap_or("").to_string())
+            .collect();
+
+        let first_normalized_title = &normalized_titles[0];
+        for title in &normalized_titles {
+            if title != first_normalized_title {
+                return Err(RecordingError::MergeFailed(
+                    "all files must have the same title".to_string(),
+                ));
+            }
+        }
+
+        // Validate same date (YYYY-MM-DD)
+        let first_date = &parsed_files[0].date;
+        for file in &parsed_files {
+            if file.date != *first_date {
+                return Err(RecordingError::MergeFailed(
+                    "all files must have the same date (YYYY-MM-DD)".to_string(),
+                ));
+            }
+        }
+        
+        // Sort files by timestamp
+        let mut combined: Vec<(ParsedRecordingFilename, PathBuf)> = parsed_files
+            .into_iter()
+            .zip(file_paths)
+            .collect();
+        combined.sort_by(|a, b| a.0.timestamp.cmp(&b.0.timestamp));
+        
+        // Create temporary directory
+        let tmp_dir = self.recordings_dir.join(format!("tmp/merge-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&tmp_dir)
+            .map_err(|e| RecordingError::MergeFailed(format!("failed to create temp directory: {e}")))?;
+        
+        // Create concat file
+        let concat_path = tmp_dir.join("concat.txt");
+        let mut concat_content = String::new();
+        
+        for (_, file_path) in &combined {
+            concat_content.push_str(&format!("file '{}'\n", file_path.display()));
+        }
+        
+        fs::write(&concat_path, concat_content)
+            .map_err(|e| RecordingError::MergeFailed(format!("failed to write concat file: {e}")))?;
+        
+        // Run ffmpeg to merge
+        let merged_path = tmp_dir.join("merged.ts");
+        let output = StdCommand::new(&self.ffmpeg_path)
+            .arg("-f")
+            .arg("concat")
+            .arg("-safe")
+            .arg("0")
+            .arg("-i")
+            .arg(&concat_path)
+            .arg("-c")
+            .arg("copy")
+            .arg(&merged_path)
+            .output()
+            .map_err(|e| RecordingError::MergeFailed(format!("ffmpeg failed to start: {e}")))?;
+        
+        if !output.status.success() {
+            let stderr = String::from_utf8(output.stderr).unwrap_or_else(|_| "unknown error".to_string());
+            return Err(RecordingError::MergeFailed(format!("ffmpeg merge failed: {stderr}")));
+        }
+        
+        // Determine metadata from first file
+        let first_file = &combined[0];
+        let started_at_unix = parse_filename_timestamp_to_unix(&first_file.0.timestamp)
+            .unwrap_or_else(now_unix_secs);
+        let quality = first_file.0.quality.clone();
+        let mode = match first_file.0.mode.as_str() {
+            "manual" => RecordingMode::Manual,
+            "auto" => RecordingMode::Auto,
+            _ => RecordingMode::Manual,
+        };
+        let title = first_normalized_title.clone();
+        let stream_title = if title.is_empty() { None } else { Some(title) };
+        
+        // Move to completed directory
+        let final_path = build_completed_recording_path(
+            &self.channel_bucket_dir("completed", &channel_login),
+            &channel_login,
+            &ActiveRecording {
+                channel_login: channel_login.clone(),
+                quality: quality.clone(),
+                started_at_unix,
+                output_path: merged_path.display().to_string(),
+                pid: None,
+                mode,
+                error: None,
+            },
+            stream_title.as_deref(),
+        );
+        
+        move_file_if_exists(&merged_path, &final_path);
+        
+        // Write playback assets
+        let chapter_events = vec![
+            ChapterEvent {
+                offset_secs: 0,
+                title: "Stream Start".to_string(),
+            },
+            ChapterEvent {
+                offset_secs: now_unix_secs().saturating_sub(started_at_unix),
+                title: "Stream End".to_string(),
+            },
+        ];
+        
+        self.write_playback_assets(
+            &channel_login,
+            &final_path,
+            &ActiveRecording {
+                channel_login: channel_login.clone(),
+                quality: quality.clone(),
+                started_at_unix,
+                output_path: final_path.display().to_string(),
+                pid: None,
+                mode,
+                error: None,
+            },
+            &chapter_events,
+        )
+        .await;
+        
+        // Write NFO if enabled
+        self.write_nfo_if_enabled(
+            &channel_login,
+            &final_path,
+            &ActiveRecording {
+                channel_login: channel_login.clone(),
+                quality: quality.clone(),
+                started_at_unix,
+                output_path: final_path.display().to_string(),
+                pid: None,
+                mode,
+                error: None,
+            },
+            stream_title.as_deref(),
+        )
+        .await;
+        
+        // Delete source files
+        for (_, source_path) in &combined {
+            if let Err(e) = fs::remove_file(source_path) {
+                tracing::warn!(path = %source_path.display(), error = %e, "failed to delete source file after merge");
+            }
+        }
+        
+        // Cleanup temp directory
+        if let Err(e) = fs::remove_dir_all(&tmp_dir) {
+            tracing::warn!(path = %tmp_dir.display(), error = %e, "failed to cleanup temp directory");
+        }
+        
+        Ok(RecordingFileEntry {
+            channel_login,
+            filename: final_path
+                .file_name()
+                .and_then(|f| f.to_str())
+                .unwrap_or("merged.ts")
+                .to_string(),
+            path_display: final_path.display().to_string(),
+            status: "completed".to_string(),
+            pinned: false,
         })
     }
 

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -346,20 +346,21 @@ impl RecordingService {
         filenames: Vec<String>,
     ) -> Result<RecordingFileEntry, RecordingError> {
         let channel_login = Self::normalize_channel_login(channel_login)?;
-        
+
         if filenames.len() < 2 {
             return Err(RecordingError::MergeFailed(
                 "at least 2 files are required for merging".to_string(),
             ));
         }
-        
+
         // Validate and parse all filenames
         let mut parsed_files = Vec::new();
         for filename in &filenames {
             let validated = validate_recording_filename(filename)?;
-            let parsed = parse_recording_filename(&validated)
-                .map_err(|e| RecordingError::MergeFailed(format!("invalid filename format: {e}")))?;
-            
+            let parsed = parse_recording_filename(&validated).map_err(|e| {
+                RecordingError::MergeFailed(format!("invalid filename format: {e}"))
+            })?;
+
             // Ensure parsed channel matches the requested channel
             if parsed.channel != channel_login {
                 return Err(RecordingError::MergeFailed(format!(
@@ -367,25 +368,26 @@ impl RecordingService {
                     parsed.channel, channel_login
                 )));
             }
-            
+
             parsed_files.push(parsed);
         }
-        
+
         // Resolve file paths
         let channel_dir = self.channel_bucket_dir("incomplete", &channel_login);
         let mut file_paths = Vec::new();
-        
+
         for filename in &filenames {
             let validated = validate_recording_filename(filename)?;
             let file_path = channel_dir.join(&validated);
             if !file_path.exists() {
                 return Err(RecordingError::MergeFailed(format!(
-                    "file not found: {}", file_path.display()
+                    "file not found: {}",
+                    file_path.display()
                 )));
             }
             file_paths.push(file_path);
         }
-        
+
         // Normalize titles and validate consistency
         let normalized_titles: Vec<String> = parsed_files
             .iter()
@@ -410,30 +412,36 @@ impl RecordingService {
                 ));
             }
         }
-        
+
         // Sort files by timestamp
-        let mut combined: Vec<(ParsedRecordingFilename, PathBuf)> = parsed_files
-            .into_iter()
-            .zip(file_paths)
-            .collect();
+        let mut combined: Vec<(ParsedRecordingFilename, PathBuf)> =
+            parsed_files.into_iter().zip(file_paths).collect();
         combined.sort_by(|a, b| a.0.timestamp.cmp(&b.0.timestamp));
-        
+
         // Create temporary directory
-        let tmp_dir = self.recordings_dir.join(format!("tmp/merge-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&tmp_dir)
-            .map_err(|e| RecordingError::MergeFailed(format!("failed to create temp directory: {e}")))?;
-        
+        let tmp_dir = self
+            .recordings_dir
+            .join(format!("tmp/merge-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&tmp_dir).map_err(|e| {
+            RecordingError::MergeFailed(format!("failed to create temp directory: {e}"))
+        })?;
+
         // Create concat file
         let concat_path = tmp_dir.join("concat.txt");
         let mut concat_content = String::new();
-        
+
         for (_, file_path) in &combined {
-            concat_content.push_str(&format!("file '{}'\n", file_path.display()));
+            // ffmpeg concat demuxer requires absolute paths
+            let abs_path = fs::canonicalize(file_path).map_err(|e| {
+                RecordingError::MergeFailed(format!("failed to resolve file path: {e}"))
+            })?;
+            concat_content.push_str(&format!("file '{}'\n", abs_path.display()));
         }
-        
-        fs::write(&concat_path, concat_content)
-            .map_err(|e| RecordingError::MergeFailed(format!("failed to write concat file: {e}")))?;
-        
+
+        fs::write(&concat_path, concat_content).map_err(|e| {
+            RecordingError::MergeFailed(format!("failed to write concat file: {e}"))
+        })?;
+
         // Run ffmpeg to merge
         let merged_path = tmp_dir.join("merged.ts");
         let output = StdCommand::new(&self.ffmpeg_path)
@@ -448,16 +456,19 @@ impl RecordingService {
             .arg(&merged_path)
             .output()
             .map_err(|e| RecordingError::MergeFailed(format!("ffmpeg failed to start: {e}")))?;
-        
+
         if !output.status.success() {
-            let stderr = String::from_utf8(output.stderr).unwrap_or_else(|_| "unknown error".to_string());
-            return Err(RecordingError::MergeFailed(format!("ffmpeg merge failed: {stderr}")));
+            let stderr =
+                String::from_utf8(output.stderr).unwrap_or_else(|_| "unknown error".to_string());
+            return Err(RecordingError::MergeFailed(format!(
+                "ffmpeg merge failed: {stderr}"
+            )));
         }
-        
+
         // Determine metadata from first file
         let first_file = &combined[0];
-        let started_at_unix = parse_filename_timestamp_to_unix(&first_file.0.timestamp)
-            .unwrap_or_else(now_unix_secs);
+        let started_at_unix =
+            parse_filename_timestamp_to_unix(&first_file.0.timestamp).unwrap_or_else(now_unix_secs);
         let quality = first_file.0.quality.clone();
         let mode = match first_file.0.mode.as_str() {
             "manual" => RecordingMode::Manual,
@@ -466,7 +477,7 @@ impl RecordingService {
         };
         let title = first_normalized_title.clone();
         let stream_title = if title.is_empty() { None } else { Some(title) };
-        
+
         // Move to completed directory
         let final_path = build_completed_recording_path(
             &self.channel_bucket_dir("completed", &channel_login),
@@ -482,9 +493,9 @@ impl RecordingService {
             },
             stream_title.as_deref(),
         );
-        
+
         move_file_if_exists(&merged_path, &final_path);
-        
+
         // Write playback assets
         let chapter_events = vec![
             ChapterEvent {
@@ -496,7 +507,7 @@ impl RecordingService {
                 title: "Stream End".to_string(),
             },
         ];
-        
+
         self.write_playback_assets(
             &channel_login,
             &final_path,
@@ -512,7 +523,7 @@ impl RecordingService {
             &chapter_events,
         )
         .await;
-        
+
         // Write NFO if enabled
         self.write_nfo_if_enabled(
             &channel_login,
@@ -529,19 +540,14 @@ impl RecordingService {
             stream_title.as_deref(),
         )
         .await;
-        
-        // Delete source files
-        for (_, source_path) in &combined {
-            if let Err(e) = fs::remove_file(source_path) {
-                tracing::warn!(path = %source_path.display(), error = %e, "failed to delete source file after merge");
-            }
-        }
-        
+
+        // Source files are kept intentionally (user will delete manually)
+
         // Cleanup temp directory
         if let Err(e) = fs::remove_dir_all(&tmp_dir) {
             tracing::warn!(path = %tmp_dir.display(), error = %e, "failed to cleanup temp directory");
         }
-        
+
         Ok(RecordingFileEntry {
             channel_login,
             filename: final_path

--- a/src/recording/files.rs
+++ b/src/recording/files.rs
@@ -74,12 +74,12 @@ pub(super) fn parse_filename_timestamp_to_unix(timestamp_str: &str) -> Option<u6
         Ok(f) => f,
         Err(_) => return None,
     };
-    
+
     let datetime = match time::PrimitiveDateTime::parse(timestamp_str, &format) {
         Ok(dt) => dt,
         Err(_) => return None,
     };
-    
+
     Some(datetime.assume_utc().unix_timestamp() as u64)
 }
 
@@ -254,60 +254,58 @@ pub(super) struct ParsedRecordingFilename {
     pub title: Option<String>,
 }
 
-pub(super) fn parse_recording_filename(filename: &str) -> Result<ParsedRecordingFilename, RecordingError> {
+pub(super) fn parse_recording_filename(
+    filename: &str,
+) -> Result<ParsedRecordingFilename, RecordingError> {
     let trimmed = filename.trim();
     if trimmed.is_empty() {
         return Err(RecordingError::EmptyFilename);
     }
-    
+
     // Validate extension
     let extension = Path::new(trimmed)
         .extension()
         .and_then(|ext| ext.to_str())
         .map(|ext| ext.to_ascii_lowercase())
         .unwrap_or_default();
-    
+
     if extension != "ts" {
         return Err(RecordingError::InvalidFilename);
     }
-    
+
     // Remove extension for parsing
     let stem = Path::new(trimmed)
         .file_stem()
         .and_then(|stem| stem.to_str())
         .ok_or(RecordingError::InvalidFilename)?;
-    
+
     // Split by underscore
     let parts: Vec<&str> = stem.split('_').collect();
     if parts.len() < 4 {
         return Err(RecordingError::InvalidFilename);
     }
-    
+
     let channel = parts[0];
     let timestamp = parts[1];
     let quality = parts[2];
     let mode = parts[3];
-    
+
     // Validate timestamp format (YYYY-MM-DD-HHMM)
     let date = if timestamp.len() >= 10 {
         &timestamp[0..10] // YYYY-MM-DD
     } else {
         return Err(RecordingError::InvalidFilename);
     };
-    
+
     // Check if there's a title (parts[4..])
     let title = if parts.len() > 4 {
         let title_parts = &parts[4..];
         let title = title_parts.join("_");
-        if title.is_empty() {
-            None
-        } else {
-            Some(title)
-        }
+        if title.is_empty() { None } else { Some(title) }
     } else {
         None
     };
-    
+
     Ok(ParsedRecordingFilename {
         channel: channel.to_string(),
         timestamp: timestamp.to_string(),
@@ -369,12 +367,13 @@ fn collect_recording_media_paths(dir: &Path, out: &mut Vec<PathBuf>) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::types::RecordingError;
+    use super::*;
 
     #[test]
     fn parse_recording_filename_with_title() {
-        let result = parse_recording_filename("forsen_2026-05-11-1430_best_manual_minecraft.ts").unwrap();
+        let result =
+            parse_recording_filename("forsen_2026-05-11-1430_best_manual_minecraft.ts").unwrap();
         assert_eq!(result.channel, "forsen");
         assert_eq!(result.timestamp, "2026-05-11-1430");
         assert_eq!(result.date, "2026-05-11");

--- a/src/recording/files.rs
+++ b/src/recording/files.rs
@@ -8,6 +8,7 @@ use time::format_description;
 
 use super::nfo::{datetime_from_unix, next_same_day_suffix_index};
 use super::types::*;
+use time::format_description::parse as parse_format;
 
 pub(super) fn sanitize_filename(value: &str) -> String {
     let mut sanitized = value
@@ -66,6 +67,20 @@ pub(super) fn format_filename_timestamp(unix_secs: u64) -> String {
     };
 
     dt.format(&format).unwrap_or_else(|_| unix_secs.to_string())
+}
+
+pub(super) fn parse_filename_timestamp_to_unix(timestamp_str: &str) -> Option<u64> {
+    let format = match parse_format("[year]-[month]-[day]-[hour][minute]") {
+        Ok(f) => f,
+        Err(_) => return None,
+    };
+    
+    let datetime = match time::PrimitiveDateTime::parse(timestamp_str, &format) {
+        Ok(dt) => dt,
+        Err(_) => return None,
+    };
+    
+    Some(datetime.assume_utc().unix_timestamp() as u64)
 }
 
 pub(super) fn validate_recording_filename(filename: &str) -> Result<String, RecordingError> {
@@ -229,6 +244,80 @@ pub(super) fn is_recording_pinned(recording_path: &Path) -> bool {
     pin_marker_path_for_recording(recording_path).exists()
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct ParsedRecordingFilename {
+    pub channel: String,
+    pub timestamp: String,
+    pub date: String,
+    pub quality: String,
+    pub mode: String,
+    pub title: Option<String>,
+}
+
+pub(super) fn parse_recording_filename(filename: &str) -> Result<ParsedRecordingFilename, RecordingError> {
+    let trimmed = filename.trim();
+    if trimmed.is_empty() {
+        return Err(RecordingError::EmptyFilename);
+    }
+    
+    // Validate extension
+    let extension = Path::new(trimmed)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase())
+        .unwrap_or_default();
+    
+    if extension != "ts" {
+        return Err(RecordingError::InvalidFilename);
+    }
+    
+    // Remove extension for parsing
+    let stem = Path::new(trimmed)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .ok_or(RecordingError::InvalidFilename)?;
+    
+    // Split by underscore
+    let parts: Vec<&str> = stem.split('_').collect();
+    if parts.len() < 4 {
+        return Err(RecordingError::InvalidFilename);
+    }
+    
+    let channel = parts[0];
+    let timestamp = parts[1];
+    let quality = parts[2];
+    let mode = parts[3];
+    
+    // Validate timestamp format (YYYY-MM-DD-HHMM)
+    let date = if timestamp.len() >= 10 {
+        &timestamp[0..10] // YYYY-MM-DD
+    } else {
+        return Err(RecordingError::InvalidFilename);
+    };
+    
+    // Check if there's a title (parts[4..])
+    let title = if parts.len() > 4 {
+        let title_parts = &parts[4..];
+        let title = title_parts.join("_");
+        if title.is_empty() {
+            None
+        } else {
+            Some(title)
+        }
+    } else {
+        None
+    };
+    
+    Ok(ParsedRecordingFilename {
+        channel: channel.to_string(),
+        timestamp: timestamp.to_string(),
+        date: date.to_string(),
+        quality: quality.to_string(),
+        mode: mode.to_string(),
+        title: title.map(|t| t.to_string()),
+    })
+}
+
 pub(super) fn prune_completed_channel_dir(dir: &Path, keep_last: usize) {
     let mut files: Vec<PathBuf> = Vec::new();
     collect_recording_media_paths(dir, &mut files);
@@ -275,5 +364,51 @@ fn collect_recording_media_paths(dir: &Path, out: &mut Vec<PathBuf>) {
         if path.is_dir() {
             collect_recording_media_paths(&path, out);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::types::RecordingError;
+
+    #[test]
+    fn parse_recording_filename_with_title() {
+        let result = parse_recording_filename("forsen_2026-05-11-1430_best_manual_minecraft.ts").unwrap();
+        assert_eq!(result.channel, "forsen");
+        assert_eq!(result.timestamp, "2026-05-11-1430");
+        assert_eq!(result.date, "2026-05-11");
+        assert_eq!(result.quality, "best");
+        assert_eq!(result.mode, "manual");
+        assert_eq!(result.title, Some("minecraft".to_string()));
+    }
+
+    #[test]
+    fn parse_recording_filename_without_title() {
+        let result = parse_recording_filename("forsen_2026-05-11-1430_best_manual.ts").unwrap();
+        assert_eq!(result.channel, "forsen");
+        assert_eq!(result.timestamp, "2026-05-11-1430");
+        assert_eq!(result.date, "2026-05-11");
+        assert_eq!(result.quality, "best");
+        assert_eq!(result.mode, "manual");
+        assert_eq!(result.title, None);
+    }
+
+    #[test]
+    fn parse_recording_filename_rejects_non_ts_extension() {
+        let result = parse_recording_filename("forsen_2026-05-11-1430_best_manual.mp4");
+        assert!(matches!(result, Err(RecordingError::InvalidFilename)));
+    }
+
+    #[test]
+    fn parse_recording_filename_rejects_invalid_format() {
+        let result = parse_recording_filename("invalid_filename.ts");
+        assert!(matches!(result, Err(RecordingError::InvalidFilename)));
+    }
+
+    #[test]
+    fn parse_recording_filename_rejects_empty() {
+        let result = parse_recording_filename("");
+        assert!(matches!(result, Err(RecordingError::EmptyFilename)));
     }
 }

--- a/src/recording/types.rs
+++ b/src/recording/types.rs
@@ -28,6 +28,8 @@ pub enum RecordingError {
     UnpinFailed(String),
     #[error("streamlink spawn failed: {0}")]
     SpawnFailed(String),
+    #[error("merge failed: {0}")]
+    MergeFailed(String),
     #[error("recordings directory not writable: {0}")]
     DirectoryNotWritable(String),
     #[error("io error: {0}")]

--- a/src/routes/recordings.rs
+++ b/src/routes/recordings.rs
@@ -146,34 +146,34 @@ struct RecordingWatchProgressResponse {
     completed: bool,
 }
 
-    /// Build recording routes.
-    pub fn recording_routes(state: RecordingState, auth_config: WebAuthConfig) -> Router {
-        Router::new()
-            .route("/api/recordings/start", post(start_recording))
-            .route("/api/recordings/stop", post(stop_recording))
-            .route("/api/recordings/pin", post(pin_recording_file))
-            .route("/api/recordings/unpin", post(unpin_recording_file))
-            .route("/api/recordings/delete", post(delete_recording_file))
-            .route("/api/recordings/merge", post(merge_recordings))
-            .route("/api/recordings/playback-file", get(play_recording_asset))
-            .route("/api/recordings/hls-playlist", get(serve_hls_playlist))
-            .route(
-                "/api/recordings/progress",
-                get(get_recording_progress).put(put_recording_progress),
-            )
-            .route("/api/recordings", get(get_recordings))
-            .route("/api/recording-rules", get(get_recording_rules))
-            .route("/api/recording-rules", post(upsert_recording_rule))
-            .route(
-                "/api/recording-rules/{channel_login}",
-                delete(delete_recording_rule),
-            )
-            .with_state(state)
-            .layer(middleware::from_fn_with_state(
-                auth_config,
-                auth::require_session_middleware,
-            ))
-    }
+/// Build recording routes.
+pub fn recording_routes(state: RecordingState, auth_config: WebAuthConfig) -> Router {
+    Router::new()
+        .route("/api/recordings/start", post(start_recording))
+        .route("/api/recordings/stop", post(stop_recording))
+        .route("/api/recordings/pin", post(pin_recording_file))
+        .route("/api/recordings/unpin", post(unpin_recording_file))
+        .route("/api/recordings/delete", post(delete_recording_file))
+        .route("/api/recordings/merge", post(merge_recordings))
+        .route("/api/recordings/playback-file", get(play_recording_asset))
+        .route("/api/recordings/hls-playlist", get(serve_hls_playlist))
+        .route(
+            "/api/recordings/progress",
+            get(get_recording_progress).put(put_recording_progress),
+        )
+        .route("/api/recordings", get(get_recordings))
+        .route("/api/recording-rules", get(get_recording_rules))
+        .route("/api/recording-rules", post(upsert_recording_rule))
+        .route(
+            "/api/recording-rules/{channel_login}",
+            delete(delete_recording_rule),
+        )
+        .with_state(state)
+        .layer(middleware::from_fn_with_state(
+            auth_config,
+            auth::require_session_middleware,
+        ))
+}
 
 fn recording_progress_response(
     channel_login: String,
@@ -721,10 +721,9 @@ fn classify_recording_error(error: &RecordingError) -> (StatusCode, &'static str
             StatusCode::INTERNAL_SERVER_ERROR,
             "recording operation failed",
         ),
-        RecordingError::MergeFailed(_) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "recording merge failed",
-        ),
+        RecordingError::MergeFailed(_) => {
+            (StatusCode::INTERNAL_SERVER_ERROR, "recording merge failed")
+        }
     }
 }
 

--- a/src/routes/recordings.rs
+++ b/src/routes/recordings.rs
@@ -77,6 +77,19 @@ pub struct PinRecordingFileRequest {
     pub filename: String,
 }
 
+/// Request DTO for merging incomplete recordings.
+#[derive(Debug, Deserialize)]
+pub struct MergeRecordingsRequest {
+    pub channel_login: String,
+    pub filenames: Vec<String>,
+}
+
+/// Response DTO for merge result.
+#[derive(Debug, Serialize)]
+pub struct MergeRecordingsResponse {
+    pub merged_file: crate::recording::RecordingFileEntry,
+}
+
 /// Query parameters for playing a recording asset.
 #[derive(Debug, Deserialize)]
 pub struct PlayRecordingAssetQuery {
@@ -133,33 +146,34 @@ struct RecordingWatchProgressResponse {
     completed: bool,
 }
 
-/// Build recording routes.
-pub fn recording_routes(state: RecordingState, auth_config: WebAuthConfig) -> Router {
-    Router::new()
-        .route("/api/recordings/start", post(start_recording))
-        .route("/api/recordings/stop", post(stop_recording))
-        .route("/api/recordings/pin", post(pin_recording_file))
-        .route("/api/recordings/unpin", post(unpin_recording_file))
-        .route("/api/recordings/delete", post(delete_recording_file))
-        .route("/api/recordings/playback-file", get(play_recording_asset))
-        .route("/api/recordings/hls-playlist", get(serve_hls_playlist))
-        .route(
-            "/api/recordings/progress",
-            get(get_recording_progress).put(put_recording_progress),
-        )
-        .route("/api/recordings", get(get_recordings))
-        .route("/api/recording-rules", get(get_recording_rules))
-        .route("/api/recording-rules", post(upsert_recording_rule))
-        .route(
-            "/api/recording-rules/{channel_login}",
-            delete(delete_recording_rule),
-        )
-        .with_state(state)
-        .layer(middleware::from_fn_with_state(
-            auth_config,
-            auth::require_session_middleware,
-        ))
-}
+    /// Build recording routes.
+    pub fn recording_routes(state: RecordingState, auth_config: WebAuthConfig) -> Router {
+        Router::new()
+            .route("/api/recordings/start", post(start_recording))
+            .route("/api/recordings/stop", post(stop_recording))
+            .route("/api/recordings/pin", post(pin_recording_file))
+            .route("/api/recordings/unpin", post(unpin_recording_file))
+            .route("/api/recordings/delete", post(delete_recording_file))
+            .route("/api/recordings/merge", post(merge_recordings))
+            .route("/api/recordings/playback-file", get(play_recording_asset))
+            .route("/api/recordings/hls-playlist", get(serve_hls_playlist))
+            .route(
+                "/api/recordings/progress",
+                get(get_recording_progress).put(put_recording_progress),
+            )
+            .route("/api/recordings", get(get_recordings))
+            .route("/api/recording-rules", get(get_recording_rules))
+            .route("/api/recording-rules", post(upsert_recording_rule))
+            .route(
+                "/api/recording-rules/{channel_login}",
+                delete(delete_recording_rule),
+            )
+            .with_state(state)
+            .layer(middleware::from_fn_with_state(
+                auth_config,
+                auth::require_session_middleware,
+            ))
+    }
 
 fn recording_progress_response(
     channel_login: String,
@@ -653,6 +667,37 @@ async fn delete_recording_rule(Path(channel_login): Path<String>) -> Response {
     }
 }
 
+async fn merge_recordings(
+    State(state): State<RecordingState>,
+    Json(payload): Json<MergeRecordingsRequest>,
+) -> Response {
+    if payload.filenames.len() < 2 {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "at least 2 files are required for merging",
+        );
+    }
+
+    match state
+        .service
+        .merge_incomplete_recordings(&payload.channel_login, payload.filenames)
+        .await
+    {
+        Ok(merged_file) => (
+            StatusCode::OK,
+            Json(MergeRecordingsResponse { merged_file }),
+        )
+            .into_response(),
+        Err(error) => {
+            let (status, message) = classify_recording_error(&error);
+            if status == StatusCode::INTERNAL_SERVER_ERROR {
+                tracing::error!(error = %error, "recording merge failed");
+            }
+            error_response(status, message)
+        }
+    }
+}
+
 fn classify_recording_error(error: &RecordingError) -> (StatusCode, &'static str) {
     match error {
         RecordingError::EmptyChannelLogin => {
@@ -675,6 +720,10 @@ fn classify_recording_error(error: &RecordingError) -> (StatusCode, &'static str
         RecordingError::PinFailed(_) | RecordingError::UnpinFailed(_) | RecordingError::Io(_) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             "recording operation failed",
+        ),
+        RecordingError::MergeFailed(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "recording merge failed",
         ),
     }
 }
@@ -780,5 +829,13 @@ mod tests {
             classify_recording_error(&RecordingError::Io("some error".to_string()));
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(message, "recording operation failed");
+    }
+
+    #[test]
+    fn classify_recording_error_maps_merge_failed() {
+        let (status, message) =
+            classify_recording_error(&RecordingError::MergeFailed("some error".to_string()));
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(message, "recording merge failed");
     }
 }

--- a/web/src/lib/api-client/recordings.ts
+++ b/web/src/lib/api-client/recordings.ts
@@ -180,3 +180,23 @@ export async function saveRecordingWatchProgress(payload: {
   }
   return (await safeJson(response)) as RecordingWatchProgress;
 }
+
+export async function mergeRecordingFiles(payload: {
+  channel_login: string;
+  filenames: string[];
+}): Promise<RecordingFileEntry> {
+  const response = await request("/api/recordings/merge", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    const body = await safeJson(response);
+    throw new Error(readError(body));
+  }
+  const result = await safeJson(response);
+  if (!isObject(result) || !isObject(result.merged_file)) {
+    throw new Error("merge response is invalid");
+  }
+  return result.merged_file as unknown as RecordingFileEntry;
+}

--- a/web/src/lib/components/home/RecordingsOverview.svelte
+++ b/web/src/lib/components/home/RecordingsOverview.svelte
@@ -12,19 +12,23 @@
     shownRecordingEntries
   } from '$lib/home/recordings';
 
-  let {
-    activeRecordings,
-    completedRecordings,
-    incompleteRecordings,
-    recordingsChannelFilter,
-    deletingRecordingKey,
-    pinningRecordingKey,
-    onBackToChannels,
-    onUpdateFilter,
-    onOpenRecordingPlayer,
-    onRemoveRecordingFile,
-    onToggleRecordingPin
-  }: RecordingsOverviewProps = $props();
+let {
+  activeRecordings,
+  completedRecordings,
+  incompleteRecordings,
+  recordingsChannelFilter,
+  deletingRecordingKey,
+  pinningRecordingKey,
+  mergingRecordingKey,
+  selectedIncompleteFilenames,
+  onBackToChannels,
+  onUpdateFilter,
+  onOpenRecordingPlayer,
+  onRemoveRecordingFile,
+  onToggleRecordingPin,
+  onToggleIncompleteMergeSelection,
+  onMergeIncompleteFiles
+}: RecordingsOverviewProps = $props();
 
   const channelOptions = $derived(recordingChannelOptions(
     completedRecordings,
@@ -147,48 +151,77 @@
       {/if}
     </section>
 
-    <section class="recordings-section">
-      <h2>Incomplete ({incompleteList.length})</h2>
-      {#if incompleteList.length === 0}
-        <p class="ui-muted">No incomplete files.</p>
-      {:else}
-        <ul class="recordings-list">
-          {#each shownIncomplete as file (file.path_display)}
-            {@const deleteKey = recordingDeleteKey('incomplete', file)}
-            <li class="recordings-item-with-action">
-              <div>
-                <span class="entry-main" title={file.filename}>{file.filename}</span>
-                <span class="entry-meta" title={file.path_display}>{file.path_display}</span>
-              </div>
-              <button
-                type="button"
-                class="recording-delete-btn"
-                onclick={() => onRemoveRecordingFile('incomplete', file)}
-                title="Delete recording"
-                aria-label="Delete recording"
-                aria-busy={deletingRecordingKey === deleteKey}
-                disabled={deletingRecordingKey === deleteKey}
-              >
-                {#if deletingRecordingKey === deleteKey}
-                  <svg class="recording-delete-spinner" viewBox="0 0 24 24" aria-hidden="true">
-                    <circle cx="12" cy="12" r="8" class="spinner-track"></circle>
-                    <path d="M12 4a8 8 0 0 1 8 8" class="spinner-head"></path>
-                  </svg>
-                {:else}
-                  <svg class="recording-delete-icon" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M9 4h6"></path>
-                    <path d="M5 7h14"></path>
-                    <path d="M7 7l1 12h8l1-12"></path>
-                    <path d="M10 10v6"></path>
-                    <path d="M14 10v6"></path>
-                  </svg>
-                {/if}
-              </button>
-            </li>
-          {/each}
-        </ul>
-      {/if}
-    </section>
+     <section class="recordings-section">
+       <div class="incomplete-section-header">
+         <h2>Incomplete ({incompleteList.length})</h2>
+         {#if recordingsChannelFilter !== "all" && shownIncomplete.length > 0}
+           {@const selectedCount = Array.from(selectedIncompleteFilenames).filter(
+             filename => shownIncomplete.some(file => file.filename === filename)
+           ).length}
+           <button
+             type="button"
+             class="merge-btn"
+             onclick={() => onMergeIncompleteFiles(recordingsChannelFilter)}
+             disabled={selectedCount < 2 || mergingRecordingKey === recordingsChannelFilter}
+           >
+             {#if mergingRecordingKey === recordingsChannelFilter}
+               <span class="merge-btn-spinner"></span>
+               Merging...
+             {:else}
+               Merge selected ({selectedCount})
+             {/if}
+           </button>
+         {/if}
+       </div>
+       {#if incompleteList.length === 0}
+         <p class="ui-muted">No incomplete files.</p>
+       {:else}
+         <ul class="recordings-list">
+           {#each shownIncomplete as file (file.path_display)}
+             {@const deleteKey = recordingDeleteKey('incomplete', file)}
+             <li class="recordings-item-with-action">
+               <div>
+                 {#if recordingsChannelFilter !== "all"}
+                   <input
+                     type="checkbox"
+                     class="merge-checkbox"
+                     checked={selectedIncompleteFilenames.has(file.filename)}
+                     onchange={() => onToggleIncompleteMergeSelection(file.filename)}
+                     disabled={mergingRecordingKey === recordingsChannelFilter}
+                   />
+                 {/if}
+                 <span class="entry-main" title={file.filename}>{file.filename}</span>
+                 <span class="entry-meta" title={file.path_display}>{file.path_display}</span>
+               </div>
+               <button
+                 type="button"
+                 class="recording-delete-btn"
+                 onclick={() => onRemoveRecordingFile('incomplete', file)}
+                 title="Delete recording"
+                 aria-label="Delete recording"
+                 aria-busy={deletingRecordingKey === deleteKey}
+                 disabled={deletingRecordingKey === deleteKey}
+               >
+                 {#if deletingRecordingKey === deleteKey}
+                   <svg class="recording-delete-spinner" viewBox="0 0 24 24" aria-hidden="true">
+                     <circle cx="12" cy="12" r="8" class="spinner-track"></circle>
+                     <path d="M12 4a8 8 0 0 1 8 8" class="spinner-head"></path>
+                   </svg>
+                 {:else}
+                   <svg class="recording-delete-icon" viewBox="0 0 24 24" aria-hidden="true">
+                     <path d="M9 4h6"></path>
+                     <path d="M5 7h14"></path>
+                     <path d="M7 7l1 12h8l1-12"></path>
+                     <path d="M10 10v6"></path>
+                     <path d="M14 10v6"></path>
+                   </svg>
+                 {/if}
+               </button>
+             </li>
+           {/each}
+         </ul>
+       {/if}
+     </section>
   </div>
 </div>
 
@@ -255,11 +288,58 @@
     padding: 0.8rem;
   }
 
-  .recordings-section h2 {
-    margin: 0 0 0.55rem;
-    font-size: 0.95rem;
-    font-weight: 700;
-  }
+   .recordings-section h2 {
+     margin: 0 0 0.55rem;
+     font-size: 0.95rem;
+     font-weight: 700;
+   }
+
+   .incomplete-section-header {
+     display: flex;
+     justify-content: space-between;
+     align-items: center;
+     margin-bottom: 0.55rem;
+   }
+
+   .merge-btn {
+     height: 1.8rem;
+     border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+     border-radius: 0.55rem;
+     background: color-mix(in srgb, var(--bg-soft) 70%, #0e1624);
+     color: var(--fg);
+     padding: 0 0.62rem;
+     font-size: 0.78rem;
+     font-weight: 600;
+     display: inline-flex;
+     align-items: center;
+     gap: 0.4rem;
+   }
+
+   .merge-btn:hover:not(:disabled) {
+     border-color: color-mix(in srgb, var(--accent) 68%, white);
+     background: color-mix(in srgb, var(--accent) 34%, #1b2436);
+   }
+
+   .merge-btn:disabled {
+     opacity: 0.55;
+     cursor: not-allowed;
+   }
+
+   .merge-btn-spinner {
+     width: 0.8rem;
+     height: 0.8rem;
+     border: 2px solid rgba(255, 255, 255, 0.2);
+     border-top: 2px solid rgba(255, 255, 255, 0.8);
+     border-radius: 50%;
+     animation: spin 0.8s linear infinite;
+   }
+
+   .merge-checkbox {
+     width: 1rem;
+     height: 1rem;
+     margin-right: 0.5rem;
+     vertical-align: middle;
+   }
 
   .recordings-list {
     list-style: none;

--- a/web/src/lib/components/home/types.ts
+++ b/web/src/lib/components/home/types.ts
@@ -104,11 +104,15 @@ export interface RecordingsOverviewProps {
   recordingsChannelFilter: string;
   deletingRecordingKey: string | null;
   pinningRecordingKey: string | null;
+  mergingRecordingKey: string | null;
+  selectedIncompleteFilenames: Set<string>;
   onBackToChannels: () => void;
   onUpdateFilter: (value: string) => void;
   onOpenRecordingPlayer: (file: RecordingFileEntry) => void;
   onRemoveRecordingFile: (bucket: "completed" | "incomplete", file: RecordingFileEntry) => void;
   onToggleRecordingPin: (file: RecordingFileEntry) => void;
+  onToggleIncompleteMergeSelection: (filename: string) => void;
+  onMergeIncompleteFiles: (channelLogin: string) => void;
 }
 
 // ConfirmRemoveDialog props

--- a/web/src/lib/home/recordingsController.svelte.ts
+++ b/web/src/lib/home/recordingsController.svelte.ts
@@ -7,6 +7,7 @@ import {
   deleteRecordingFile,
   pinRecordingFile,
   unpinRecordingFile,
+  mergeRecordingFiles,
 } from "$lib/api";
 import { readMessage } from "$lib/home/errors";
 import type { RecordingRule, ActiveRecording, RecordingFileEntry } from "$lib/api-client/types";
@@ -22,6 +23,8 @@ export interface RecordingsController {
   incompleteRecordings: Array<RecordingFileEntry>;
   deletingRecordingKey: string | null;
   pinningRecordingKey: string | null;
+  mergingRecordingKey: string | null;
+  selectedIncompleteFilenames: Set<string>;
 
   loadRecordingRules: () => Promise<void>;
   loadRecordingState: () => Promise<void>;
@@ -32,6 +35,9 @@ export interface RecordingsController {
     file: RecordingFileEntry,
   ) => Promise<void>;
   toggleRecordingPin: (file: RecordingFileEntry) => Promise<void>;
+  toggleIncompleteMergeSelection: (filename: string) => void;
+  clearMergeSelection: () => void;
+  mergeSelectedIncompleteFiles: (channelLogin: string) => Promise<void>;
   selectedQuality: (channelLogin: string) => string;
 }
 
@@ -42,6 +48,8 @@ export function createRecordingsController(deps: RecordingsControllerDeps): Reco
   let incompleteRecordings = $state<Array<RecordingFileEntry>>([]);
   let deletingRecordingKey = $state<string | null>(null);
   let pinningRecordingKey = $state<string | null>(null);
+  let mergingRecordingKey = $state<string | null>(null);
+  let selectedIncompleteFilenames = $state<Set<string>>(new Set());
 
   const { setError } = deps;
 
@@ -68,6 +76,7 @@ export function createRecordingsController(deps: RecordingsControllerDeps): Reco
       activeRecordings = next;
       completedRecordings = recordings.completed;
       incompleteRecordings = recordings.incomplete;
+      selectedIncompleteFilenames = new Set(); // Clear selection on reload
     } catch {
       // ignore transient recording state failures
     }
@@ -168,6 +177,50 @@ export function createRecordingsController(deps: RecordingsControllerDeps): Reco
     }
   }
 
+  function toggleIncompleteMergeSelection(filename: string): void {
+    const newSelection = new Set(selectedIncompleteFilenames);
+    if (newSelection.has(filename)) {
+      newSelection.delete(filename);
+    } else {
+      newSelection.add(filename);
+    }
+    selectedIncompleteFilenames = newSelection;
+  }
+
+  function clearMergeSelection(): void {
+    selectedIncompleteFilenames = new Set();
+  }
+
+  async function mergeSelectedIncompleteFiles(channelLogin: string): Promise<void> {
+    const selectedFiles = Array.from(selectedIncompleteFilenames);
+    if (selectedFiles.length < 2) {
+      setError("Please select at least 2 files to merge");
+      return;
+    }
+
+    const shouldMerge = window.confirm(
+      `Merge ${selectedFiles.length} incomplete recording(s) for ${channelLogin}?`,
+    );
+    if (!shouldMerge) {
+      return;
+    }
+
+    mergingRecordingKey = channelLogin;
+    setError(null);
+
+    try {
+      await mergeRecordingFiles({
+        channel_login: channelLogin,
+        filenames: selectedFiles,
+      });
+      await loadRecordingState();
+    } catch (err) {
+      setError(readMessage(err, "failed to merge recordings"));
+    } finally {
+      mergingRecordingKey = null;
+    }
+  }
+
   return {
     get recordingRules() {
       return recordingRules;
@@ -187,12 +240,21 @@ export function createRecordingsController(deps: RecordingsControllerDeps): Reco
     get pinningRecordingKey() {
       return pinningRecordingKey;
     },
+    get mergingRecordingKey() {
+      return mergingRecordingKey;
+    },
+    get selectedIncompleteFilenames() {
+      return selectedIncompleteFilenames;
+    },
     loadRecordingRules,
     loadRecordingState,
     toggleAutoRecord,
     toggleManualRecording,
     removeRecordingFile,
     toggleRecordingPin,
+    toggleIncompleteMergeSelection,
+    clearMergeSelection,
+    mergeSelectedIncompleteFiles,
     selectedQuality,
   };
 }

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -36,6 +36,7 @@
   let newChannelLogin = $state('');
   let confirmRemoveChannel = $state<string | null>(null);
   let liveOnly = $state(false);
+  let recordingsChannelFilter = $state<string>('all');
 
   // Polling interval reference
   let pollInterval: ReturnType<typeof setInterval> | null = null;
@@ -230,19 +231,23 @@
             onPromptRemoveChannel={promptRemoveChannel}
           />
         {:else}
-          <RecordingsOverview
-            activeRecordings={recordingsController.activeRecordings}
-            completedRecordings={recordingsController.completedRecordings}
-            incompleteRecordings={recordingsController.incompleteRecordings}
-            recordingsChannelFilter="all"
-            deletingRecordingKey={recordingsController.deletingRecordingKey}
-            pinningRecordingKey={recordingsController.pinningRecordingKey}
-            onBackToChannels={backToChannels}
-            onUpdateFilter={() => {}}
-            onOpenRecordingPlayer={openRecordingPlayer}
-            onRemoveRecordingFile={recordingsController.removeRecordingFile}
-            onToggleRecordingPin={recordingsController.toggleRecordingPin}
-          />
+           <RecordingsOverview
+             activeRecordings={recordingsController.activeRecordings}
+             completedRecordings={recordingsController.completedRecordings}
+             incompleteRecordings={recordingsController.incompleteRecordings}
+             recordingsChannelFilter={recordingsChannelFilter}
+             deletingRecordingKey={recordingsController.deletingRecordingKey}
+             pinningRecordingKey={recordingsController.pinningRecordingKey}
+             mergingRecordingKey={recordingsController.mergingRecordingKey}
+             selectedIncompleteFilenames={recordingsController.selectedIncompleteFilenames}
+             onBackToChannels={backToChannels}
+             onUpdateFilter={(value) => (recordingsChannelFilter = value)}
+             onOpenRecordingPlayer={openRecordingPlayer}
+             onRemoveRecordingFile={recordingsController.removeRecordingFile}
+             onToggleRecordingPin={recordingsController.toggleRecordingPin}
+             onToggleIncompleteMergeSelection={recordingsController.toggleIncompleteMergeSelection}
+             onMergeIncompleteFiles={recordingsController.mergeSelectedIncompleteFiles}
+           />
         {/if}
       {/if}
     {/if}


### PR DESCRIPTION
- Added new dependencies (\`anyhow\`, \`foldhash\`, \`getrandom\`, \`hashbrown\`, \`heck\`, \`id-arena\`, \`leb128fmt\`, \`prettyplease\`, \`r-efi\`, \`semver\`, \`uuid\`, \`unicode-xid\`, \`wasm-encoder\`, \`wasm-metadata\`, \`wasmparser\`, \`wit-bindgen\`, \`wit-bindgen-core\`, \`wit-bindgen-rust\`, \`wit-bindgen-rust-macro\`, \`wit-component\`, \`wit-parser\`) to enhance functionality and improve performance.
- Introduced a new function \`merge_incomplete_recordings\` in \`recording.rs\` to merge multiple incomplete recording files into one. This function normalizes filenames, checks for consistency, and uses FFmpeg to perform the merging.
- Updated \`Cargo.toml\` to include the \`uuid\` crate with specific features (\`v4\`) for generating UUIDs.
- Enhanced error handling and validation in the new merging functionality.
- Ensured that all files being merged belong to the same channel, have the same title, and share the same date (YYYY-MM-DD).