### PR TITLE
refactor(recordings): async job-based finalize and merge flow

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -109,8 +109,8 @@ pub fn build_router(config: &AppConfig, access_code_hash: String) -> Result<Rout
         service: recording_service,
         default_quality: config.recording.default_quality.clone(),
         progress: crate::recording_progress::RecordingProgressStore::new(),
-        active_merge_guard: Arc::new(RwLock::new(HashSet::new())),
-        merge_jobs: Arc::new(RwLock::new(HashMap::new())),
+        active_processing_guard: Arc::new(RwLock::new(HashSet::new())),
+        recording_jobs: Arc::new(RwLock::new(HashMap::new())),
     };
 
     // Build route modules

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,11 @@
 use std::path::PathBuf;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use axum::Router;
+use tokio::sync::RwLock;
 use tower_http::services::{ServeDir, ServeFile};
 
 use crate::{
@@ -104,6 +109,8 @@ pub fn build_router(config: &AppConfig, access_code_hash: String) -> Result<Rout
         service: recording_service,
         default_quality: config.recording.default_quality.clone(),
         progress: crate::recording_progress::RecordingProgressStore::new(),
+        active_merge_guard: Arc::new(RwLock::new(HashSet::new())),
+        merge_jobs: Arc::new(RwLock::new(HashMap::new())),
     };
 
     // Build route modules

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -563,6 +563,94 @@ impl RecordingService {
         })
     }
 
+    pub async fn repair_completed_recording(
+        &self,
+        channel_login: &str,
+        filename: &str,
+    ) -> Result<RecordingFileEntry, RecordingError> {
+        let channel_login = Self::normalize_channel_login(channel_login)?;
+        let target_path = self.resolve_completed_file_path(&channel_login, filename)?;
+        if !target_path.exists() {
+            return Err(RecordingError::FileNotFound);
+        }
+
+        let extension = target_path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| ext.to_ascii_lowercase())
+            .unwrap_or_default();
+
+        match extension.as_str() {
+            "mp4" => {
+                self.rebuild_hls_playlist(&channel_login, &target_path)
+                    .map_err(RecordingError::RepairFailed)?;
+                let marker = processing_marker_path_for_recording(&target_path);
+                let _ = fs::remove_file(marker);
+                Ok(self.completed_entry_from_path(&channel_login, &target_path))
+            }
+            "ts" => {
+                let tmp_output = self
+                    .tmp_dir()
+                    .join(format!("repair-{}.mp4", uuid::Uuid::new_v4()));
+                if let Some(parent) = tmp_output.parent() {
+                    fs::create_dir_all(parent).map_err(|e| {
+                        RecordingError::RepairFailed(format!(
+                            "failed to create temp directory: {e}"
+                        ))
+                    })?;
+                }
+
+                let status = StdCommand::new(&self.ffmpeg_path)
+                    .arg("-y")
+                    .arg("-i")
+                    .arg(&target_path)
+                    .arg("-c")
+                    .arg("copy")
+                    .arg("-bsf:a")
+                    .arg("aac_adtstoasc")
+                    .arg("-movflags")
+                    .arg("frag_keyframe+empty_moov+delay_moov+default_base_moof")
+                    .arg("-frag_duration")
+                    .arg("10000000")
+                    .arg(&tmp_output)
+                    .status()
+                    .map_err(|e| {
+                        RecordingError::RepairFailed(format!("ffmpeg failed to start: {e}"))
+                    })?;
+
+                if !status.success() {
+                    let _ = fs::remove_file(&tmp_output);
+                    return Err(RecordingError::RepairFailed(
+                        "ffmpeg remux failed".to_string(),
+                    ));
+                }
+
+                let final_mp4 = target_path.with_extension("mp4");
+                if let Some(parent) = final_mp4.parent() {
+                    fs::create_dir_all(parent).map_err(|e| {
+                        RecordingError::RepairFailed(format!(
+                            "failed to create destination directory: {e}"
+                        ))
+                    })?;
+                }
+                fs::rename(&tmp_output, &final_mp4).map_err(|e| {
+                    RecordingError::RepairFailed(format!("failed to move repaired file: {e}"))
+                })?;
+                let _ = fs::remove_file(&target_path);
+
+                self.rebuild_hls_playlist(&channel_login, &final_mp4)
+                    .map_err(RecordingError::RepairFailed)?;
+                let marker = processing_marker_path_for_recording(&final_mp4);
+                let _ = fs::remove_file(marker);
+
+                Ok(self.completed_entry_from_path(&channel_login, &final_mp4))
+            }
+            _ => Err(RecordingError::RepairFailed(
+                "unsupported recording extension".to_string(),
+            )),
+        }
+    }
+
     pub fn resolve_completed_file_path(
         &self,
         channel_login: &str,
@@ -900,6 +988,8 @@ impl RecordingService {
         }
 
         let mp4_path = recording_path.with_extension("mp4");
+        let processing_marker = processing_marker_path_for_recording(&mp4_path);
+        let _ = fs::write(&processing_marker, b"processing\n");
         // Generate fragmented MP4 (fMP4) for proper HLS byte-range playback
         // Creates moof+mdat fragments aligned with keyframes, ~10 seconds each
         let remux_ok = match Command::new(&self.ffmpeg_path)
@@ -932,6 +1022,7 @@ impl RecordingService {
             tracing::warn!(channel = %channel_login, path = %recording_path.display(), "ffmpeg mp4 remux failed");
             let _ = fs::remove_file(recording_path);
             let _ = fs::remove_file(&chapter_file);
+            let _ = fs::remove_file(&processing_marker);
             return;
         }
 
@@ -950,12 +1041,48 @@ impl RecordingService {
                     tracing::warn!(channel = %channel_login, error = %e, "failed to write hls playlist file");
                 } else {
                     tracing::info!(channel = %channel_login, path = %playlist_path.display(), "hls playlist generated");
+                    let _ = fs::remove_file(&processing_marker);
                 }
             }
             Err(error) => {
                 tracing::warn!(channel = %channel_login, path = %mp4_path.display(), error = %error, "failed to generate hls playlist");
                 // Non-fatal: MP4 still works for direct playback
+                let _ = fs::remove_file(&processing_marker);
             }
+        }
+    }
+
+    fn rebuild_hls_playlist(&self, channel_login: &str, mp4_path: &Path) -> Result<(), String> {
+        let mp4_filename = mp4_path
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or("recording.mp4");
+        let playlist_content =
+            crate::hls_generator::generate_hls_playlist(mp4_path, channel_login, mp4_filename)
+                .map_err(|e| format!("failed to generate hls playlist: {e}"))?;
+        let playlist_path = mp4_path.with_extension("m3u8");
+        fs::write(&playlist_path, playlist_content)
+            .map_err(|e| format!("failed to write hls playlist: {e}"))
+    }
+
+    fn completed_entry_from_path(&self, channel_login: &str, path: &Path) -> RecordingFileEntry {
+        let filename = path
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or("unknown.mp4")
+            .to_string();
+        RecordingFileEntry {
+            channel_login: channel_login.to_string(),
+            filename,
+            path_display: path.display().to_string(),
+            status: "completed".to_string(),
+            pinned: is_recording_pinned(path),
+            has_hls: path.with_extension("m3u8").exists(),
+            processing_state: if processing_marker_path_for_recording(path).exists() {
+                RecordingProcessingState::Processing
+            } else {
+                RecordingProcessingState::Ready
+            },
         }
     }
 }

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -21,8 +21,9 @@ mod nfo;
 mod types;
 
 pub use types::{
-    ActiveRecording, MergeJob, MergeJobStatus, RecordingBucket, RecordingError, RecordingFileEntry,
-    RecordingMode, RecordingProcessingConfig, RecordingProcessingState, RecordingsOverview,
+    ActiveRecording, RecordingBucket, RecordingError, RecordingFileEntry, RecordingJob,
+    RecordingJobKind, RecordingJobStatus, RecordingMode, RecordingProcessingConfig,
+    RecordingProcessingState, RecordingsOverview,
 };
 
 use files::*;
@@ -493,36 +494,166 @@ impl RecordingService {
     ) -> Result<(String, String), RecordingError> {
         let normalized = Self::normalize_channel_login(channel_login)?;
         let (combined, stream_title) = self.validate_merge_sources(&normalized, filenames)?;
-        let first_file = &combined[0];
+        let expected_name = self.expected_completed_mp4_filename(
+            &normalized,
+            &combined[0].0,
+            stream_title.as_deref(),
+        );
+        Ok((normalized, expected_name))
+    }
+
+    pub fn validate_finalize_request(
+        &self,
+        channel_login: &str,
+        filename: &str,
+    ) -> Result<(String, String), RecordingError> {
+        let normalized = Self::normalize_channel_login(channel_login)?;
+        let validated = validate_recording_filename(filename)?;
+        let parsed = parse_recording_filename(&validated)
+            .map_err(|e| RecordingError::MergeFailed(format!("invalid filename format: {e}")))?;
+        if parsed.channel != normalized {
+            return Err(RecordingError::MergeFailed(format!(
+                "filename channel '{}' does not match requested channel '{}'",
+                parsed.channel, normalized
+            )));
+        }
+
+        let source_path = self
+            .channel_bucket_dir("incomplete", &normalized)
+            .join(&validated);
+        if !source_path.exists() {
+            return Err(RecordingError::MergeFailed(format!(
+                "file not found: {}",
+                source_path.display()
+            )));
+        }
+
+        let expected_name =
+            self.expected_completed_mp4_filename(&normalized, &parsed, parsed.title.as_deref());
+        Ok((normalized, expected_name))
+    }
+
+    pub async fn finalize_incomplete_recording(
+        &self,
+        channel_login: &str,
+        filename: &str,
+        expected_filename: &str,
+    ) -> Result<RecordingFileEntry, RecordingError> {
+        let normalized = Self::normalize_channel_login(channel_login)?;
+        let validated = validate_recording_filename(filename)?;
+        let parsed = parse_recording_filename(&validated)
+            .map_err(|e| RecordingError::MergeFailed(format!("invalid filename format: {e}")))?;
+        if parsed.channel != normalized {
+            return Err(RecordingError::MergeFailed(format!(
+                "filename channel '{}' does not match requested channel '{}'",
+                parsed.channel, normalized
+            )));
+        }
+
+        let source_path = self
+            .channel_bucket_dir("incomplete", &normalized)
+            .join(&validated);
+        if !source_path.exists() {
+            return Err(RecordingError::MergeFailed(format!(
+                "file not found: {}",
+                source_path.display()
+            )));
+        }
+
+        let final_name = Path::new(&validate_recording_filename(expected_filename)?)
+            .with_extension("mp4")
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or("recording.mp4")
+            .to_string();
+
+        let tmp_dir = self
+            .recordings_dir
+            .join(format!("tmp/finalize-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&tmp_dir).map_err(|e| {
+            RecordingError::MergeFailed(format!("failed to create temp directory: {e}"))
+        })?;
+        let tmp_output = tmp_dir.join("finalized.mp4");
+
+        let output = StdCommand::new(&self.ffmpeg_path)
+            .arg("-y")
+            .arg("-i")
+            .arg(&source_path)
+            .arg("-c")
+            .arg("copy")
+            .arg("-bsf:a")
+            .arg("aac_adtstoasc")
+            .arg("-movflags")
+            .arg("frag_keyframe+empty_moov+delay_moov+default_base_moof")
+            .arg("-frag_duration")
+            .arg("10000000")
+            .arg(&tmp_output)
+            .output()
+            .map_err(|e| RecordingError::MergeFailed(format!("ffmpeg failed to start: {e}")))?;
+        if !output.status.success() {
+            let stderr =
+                String::from_utf8(output.stderr).unwrap_or_else(|_| "unknown error".to_string());
+            let _ = fs::remove_dir_all(&tmp_dir);
+            return Err(RecordingError::MergeFailed(format!(
+                "ffmpeg finalize failed: {stderr}"
+            )));
+        }
+
+        let final_path = self
+            .channel_bucket_dir("completed", &normalized)
+            .join(final_name);
+        if let Some(parent) = final_path.parent() {
+            fs::create_dir_all(parent).map_err(|e| {
+                RecordingError::MergeFailed(format!("failed to create destination directory: {e}"))
+            })?;
+        }
+
+        let processing_marker = processing_marker_path_for_recording(&final_path);
+        let _ = fs::write(&processing_marker, b"processing\n");
+
+        if let Err(error) = fs::rename(&tmp_output, &final_path) {
+            let _ = fs::remove_file(&processing_marker);
+            let _ = fs::remove_dir_all(&tmp_dir);
+            return Err(RecordingError::MergeFailed(format!(
+                "failed to finalize output: {error}"
+            )));
+        }
+
+        if let Err(error) = self.rebuild_hls_playlist(&normalized, &final_path) {
+            let _ = fs::remove_file(&processing_marker);
+            let _ = fs::remove_dir_all(&tmp_dir);
+            return Err(RecordingError::MergeFailed(error));
+        }
+
         let started_at_unix =
-            parse_filename_timestamp_to_unix(&first_file.0.timestamp).unwrap_or_else(now_unix_secs);
-        let quality = first_file.0.quality.clone();
-        let mode = match first_file.0.mode.as_str() {
+            parse_filename_timestamp_to_unix(&parsed.timestamp).unwrap_or_else(now_unix_secs);
+        let quality = parsed.quality.clone();
+        let mode = match parsed.mode.as_str() {
             "manual" => RecordingMode::Manual,
             "auto" => RecordingMode::Auto,
             _ => RecordingMode::Manual,
         };
-        let expected = build_completed_recording_path(
-            &self.channel_bucket_dir("completed", &normalized),
+        self.write_nfo_if_enabled(
             &normalized,
+            &final_path,
             &ActiveRecording {
                 channel_login: normalized.clone(),
                 quality,
                 started_at_unix,
-                output_path: String::new(),
+                output_path: final_path.display().to_string(),
                 pid: None,
                 mode,
                 error: None,
             },
-            stream_title.as_deref(),
-        );
-        let expected_name = expected
-            .with_extension("mp4")
-            .file_name()
-            .and_then(|f| f.to_str())
-            .unwrap_or("merged.mp4")
-            .to_string();
-        Ok((normalized, expected_name))
+            parsed.title.as_deref(),
+        )
+        .await;
+
+        let _ = fs::remove_file(&source_path);
+        let _ = fs::remove_file(&processing_marker);
+        let _ = fs::remove_dir_all(&tmp_dir);
+
+        Ok(self.completed_entry_from_path(&normalized, &final_path))
     }
 
     pub async fn repair_completed_recording(
@@ -679,6 +810,42 @@ impl RecordingService {
             Some(first_title)
         };
         Ok((combined, stream_title))
+    }
+
+    fn expected_completed_mp4_filename(
+        &self,
+        channel_login: &str,
+        parsed: &ParsedRecordingFilename,
+        stream_title: Option<&str>,
+    ) -> String {
+        let started_at_unix =
+            parse_filename_timestamp_to_unix(&parsed.timestamp).unwrap_or_else(now_unix_secs);
+        let quality = parsed.quality.clone();
+        let mode = match parsed.mode.as_str() {
+            "manual" => RecordingMode::Manual,
+            "auto" => RecordingMode::Auto,
+            _ => RecordingMode::Manual,
+        };
+        let expected = build_completed_recording_path(
+            &self.channel_bucket_dir("completed", channel_login),
+            channel_login,
+            &ActiveRecording {
+                channel_login: channel_login.to_string(),
+                quality,
+                started_at_unix,
+                output_path: String::new(),
+                pid: None,
+                mode,
+                error: None,
+            },
+            stream_title,
+        );
+        expected
+            .with_extension("mp4")
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or("merged.mp4")
+            .to_string()
     }
 
     pub async fn note_game_observation(

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -29,6 +29,8 @@ use files::*;
 use nfo::*;
 use types::*;
 
+type MergeSourceItem = (ParsedRecordingFilename, PathBuf);
+
 #[derive(Debug, Clone)]
 pub struct RecordingService {
     streamlink_path: String,
@@ -344,78 +346,12 @@ impl RecordingService {
         &self,
         channel_login: &str,
         filenames: Vec<String>,
+        expected_filename: &str,
     ) -> Result<RecordingFileEntry, RecordingError> {
         let channel_login = Self::normalize_channel_login(channel_login)?;
-
-        if filenames.len() < 2 {
-            return Err(RecordingError::MergeFailed(
-                "at least 2 files are required for merging".to_string(),
-            ));
-        }
-
-        // Validate and parse all filenames
-        let mut parsed_files = Vec::new();
-        for filename in &filenames {
-            let validated = validate_recording_filename(filename)?;
-            let parsed = parse_recording_filename(&validated).map_err(|e| {
-                RecordingError::MergeFailed(format!("invalid filename format: {e}"))
-            })?;
-
-            // Ensure parsed channel matches the requested channel
-            if parsed.channel != channel_login {
-                return Err(RecordingError::MergeFailed(format!(
-                    "filename channel '{}' does not match requested channel '{}'",
-                    parsed.channel, channel_login
-                )));
-            }
-
-            parsed_files.push(parsed);
-        }
-
-        // Resolve file paths
-        let channel_dir = self.channel_bucket_dir("incomplete", &channel_login);
-        let mut file_paths = Vec::new();
-
-        for filename in &filenames {
-            let validated = validate_recording_filename(filename)?;
-            let file_path = channel_dir.join(&validated);
-            if !file_path.exists() {
-                return Err(RecordingError::MergeFailed(format!(
-                    "file not found: {}",
-                    file_path.display()
-                )));
-            }
-            file_paths.push(file_path);
-        }
-
-        // Normalize titles and validate consistency
-        let normalized_titles: Vec<String> = parsed_files
-            .iter()
-            .map(|f| f.title.as_deref().unwrap_or("").to_string())
-            .collect();
-
-        let first_normalized_title = &normalized_titles[0];
-        for title in &normalized_titles {
-            if title != first_normalized_title {
-                return Err(RecordingError::MergeFailed(
-                    "all files must have the same title".to_string(),
-                ));
-            }
-        }
-
-        // Validate same date (YYYY-MM-DD)
-        let first_date = &parsed_files[0].date;
-        for file in &parsed_files {
-            if file.date != *first_date {
-                return Err(RecordingError::MergeFailed(
-                    "all files must have the same date (YYYY-MM-DD)".to_string(),
-                ));
-            }
-        }
-
-        // Sort files by timestamp
-        let mut combined: Vec<(ParsedRecordingFilename, PathBuf)> =
-            parsed_files.into_iter().zip(file_paths).collect();
+        let filename = validate_recording_filename(expected_filename)?;
+        let (mut combined, stream_title) =
+            self.validate_merge_sources(&channel_login, &filenames)?;
         combined.sort_by(|a, b| a.0.timestamp.cmp(&b.0.timestamp));
 
         // Create temporary directory
@@ -442,9 +378,10 @@ impl RecordingService {
             RecordingError::MergeFailed(format!("failed to write concat file: {e}"))
         })?;
 
-        // Run ffmpeg to merge
-        let merged_path = tmp_dir.join("merged.ts");
+        // Merge directly to fragmented MP4 in temporary storage
+        let merged_path = tmp_dir.join("merged.mp4");
         let output = StdCommand::new(&self.ffmpeg_path)
+            .arg("-y")
             .arg("-f")
             .arg("concat")
             .arg("-safe")
@@ -453,6 +390,12 @@ impl RecordingService {
             .arg(&concat_path)
             .arg("-c")
             .arg("copy")
+            .arg("-bsf:a")
+            .arg("aac_adtstoasc")
+            .arg("-movflags")
+            .arg("frag_keyframe+empty_moov+delay_moov+default_base_moof")
+            .arg("-frag_duration")
+            .arg("10000000")
             .arg(&merged_path)
             .output()
             .map_err(|e| RecordingError::MergeFailed(format!("ffmpeg failed to start: {e}")))?;
@@ -475,54 +418,34 @@ impl RecordingService {
             "auto" => RecordingMode::Auto,
             _ => RecordingMode::Manual,
         };
-        let title = first_normalized_title.clone();
-        let stream_title = if title.is_empty() { None } else { Some(title) };
+        let stream_title = stream_title.as_deref();
 
-        // Move to completed directory
-        let final_path = build_completed_recording_path(
-            &self.channel_bucket_dir("completed", &channel_login),
-            &channel_login,
-            &ActiveRecording {
-                channel_login: channel_login.clone(),
-                quality: quality.clone(),
-                started_at_unix,
-                output_path: merged_path.display().to_string(),
-                pid: None,
-                mode,
-                error: None,
-            },
-            stream_title.as_deref(),
-        );
+        let final_name = Path::new(&filename)
+            .with_extension("mp4")
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or("merged.mp4")
+            .to_string();
+        let final_path = self
+            .channel_bucket_dir("completed", &channel_login)
+            .join(final_name);
+        if let Some(parent) = final_path.parent() {
+            fs::create_dir_all(parent).map_err(|e| {
+                RecordingError::MergeFailed(format!("failed to create destination directory: {e}"))
+            })?;
+        }
+        fs::rename(&merged_path, &final_path).map_err(|e| {
+            RecordingError::MergeFailed(format!("failed to finalize merged output: {e}"))
+        })?;
+        let processing_marker = processing_marker_path_for_recording(&final_path);
+        let _ = fs::write(&processing_marker, b"processing\n");
 
-        move_file_if_exists(&merged_path, &final_path);
-
-        // Write playback assets
-        let chapter_events = vec![
-            ChapterEvent {
-                offset_secs: 0,
-                title: "Stream Start".to_string(),
-            },
-            ChapterEvent {
-                offset_secs: now_unix_secs().saturating_sub(started_at_unix),
-                title: "Stream End".to_string(),
-            },
-        ];
-
-        self.write_playback_assets(
-            &channel_login,
-            &final_path,
-            &ActiveRecording {
-                channel_login: channel_login.clone(),
-                quality: quality.clone(),
-                started_at_unix,
-                output_path: final_path.display().to_string(),
-                pid: None,
-                mode,
-                error: None,
-            },
-            &chapter_events,
-        )
-        .await;
+        if let Err(error) = self.rebuild_hls_playlist(&channel_login, &final_path) {
+            let _ = fs::remove_file(&processing_marker);
+            let _ = fs::remove_dir_all(&tmp_dir);
+            return Err(RecordingError::MergeFailed(error));
+        }
+        let _ = fs::remove_file(&processing_marker);
 
         // Write NFO if enabled
         self.write_nfo_if_enabled(
@@ -537,7 +460,7 @@ impl RecordingService {
                 mode,
                 error: None,
             },
-            stream_title.as_deref(),
+            stream_title,
         )
         .await;
 
@@ -553,7 +476,7 @@ impl RecordingService {
             filename: final_path
                 .file_name()
                 .and_then(|f| f.to_str())
-                .unwrap_or("merged.ts")
+                .unwrap_or("merged.mp4")
                 .to_string(),
             path_display: final_path.display().to_string(),
             status: "completed".to_string(),
@@ -561,6 +484,45 @@ impl RecordingService {
             has_hls: final_path.with_extension("m3u8").exists(),
             processing_state: RecordingProcessingState::Ready,
         })
+    }
+
+    pub fn validate_merge_request(
+        &self,
+        channel_login: &str,
+        filenames: &[String],
+    ) -> Result<(String, String), RecordingError> {
+        let normalized = Self::normalize_channel_login(channel_login)?;
+        let (combined, stream_title) = self.validate_merge_sources(&normalized, filenames)?;
+        let first_file = &combined[0];
+        let started_at_unix =
+            parse_filename_timestamp_to_unix(&first_file.0.timestamp).unwrap_or_else(now_unix_secs);
+        let quality = first_file.0.quality.clone();
+        let mode = match first_file.0.mode.as_str() {
+            "manual" => RecordingMode::Manual,
+            "auto" => RecordingMode::Auto,
+            _ => RecordingMode::Manual,
+        };
+        let expected = build_completed_recording_path(
+            &self.channel_bucket_dir("completed", &normalized),
+            &normalized,
+            &ActiveRecording {
+                channel_login: normalized.clone(),
+                quality,
+                started_at_unix,
+                output_path: String::new(),
+                pid: None,
+                mode,
+                error: None,
+            },
+            stream_title.as_deref(),
+        );
+        let expected_name = expected
+            .with_extension("mp4")
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or("merged.mp4")
+            .to_string();
+        Ok((normalized, expected_name))
     }
 
     pub async fn repair_completed_recording(
@@ -657,6 +619,66 @@ impl RecordingService {
         filename: &str,
     ) -> Result<PathBuf, RecordingError> {
         self.resolve_recording_file_path(RecordingBucket::Completed, channel_login, filename)
+    }
+
+    fn validate_merge_sources(
+        &self,
+        channel_login: &str,
+        filenames: &[String],
+    ) -> Result<(Vec<MergeSourceItem>, Option<String>), RecordingError> {
+        if filenames.len() < 2 {
+            return Err(RecordingError::MergeFailed(
+                "at least 2 files are required for merging".to_string(),
+            ));
+        }
+
+        let channel_dir = self.channel_bucket_dir("incomplete", channel_login);
+        let mut combined: Vec<MergeSourceItem> = Vec::new();
+
+        for filename in filenames {
+            let validated = validate_recording_filename(filename)?;
+            let parsed = parse_recording_filename(&validated).map_err(|e| {
+                RecordingError::MergeFailed(format!("invalid filename format: {e}"))
+            })?;
+
+            if parsed.channel != channel_login {
+                return Err(RecordingError::MergeFailed(format!(
+                    "filename channel '{}' does not match requested channel '{}'",
+                    parsed.channel, channel_login
+                )));
+            }
+
+            let file_path = channel_dir.join(&validated);
+            if !file_path.exists() {
+                return Err(RecordingError::MergeFailed(format!(
+                    "file not found: {}",
+                    file_path.display()
+                )));
+            }
+            combined.push((parsed, file_path));
+        }
+
+        let first_date = combined[0].0.date.clone();
+        let first_title = combined[0].0.title.as_deref().unwrap_or("").to_string();
+        for (parsed, _) in &combined {
+            if parsed.date != first_date {
+                return Err(RecordingError::MergeFailed(
+                    "all files must have the same date (YYYY-MM-DD)".to_string(),
+                ));
+            }
+            if parsed.title.as_deref().unwrap_or("") != first_title {
+                return Err(RecordingError::MergeFailed(
+                    "all files must have the same title".to_string(),
+                ));
+            }
+        }
+
+        let stream_title = if first_title.is_empty() {
+            None
+        } else {
+            Some(first_title)
+        };
+        Ok((combined, stream_title))
     }
 
     pub async fn note_game_observation(

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -21,8 +21,8 @@ mod nfo;
 mod types;
 
 pub use types::{
-    ActiveRecording, RecordingBucket, RecordingError, RecordingFileEntry, RecordingMode,
-    RecordingProcessingConfig, RecordingsOverview,
+    ActiveRecording, MergeJob, MergeJobStatus, RecordingBucket, RecordingError, RecordingFileEntry,
+    RecordingMode, RecordingProcessingConfig, RecordingProcessingState, RecordingsOverview,
 };
 
 use files::*;
@@ -558,6 +558,8 @@ impl RecordingService {
             path_display: final_path.display().to_string(),
             status: "completed".to_string(),
             pinned: false,
+            has_hls: final_path.with_extension("m3u8").exists(),
+            processing_state: RecordingProcessingState::Ready,
         })
     }
 

--- a/src/recording/files.rs
+++ b/src/recording/files.rs
@@ -173,16 +173,32 @@ pub(super) fn list_recording_files(
     entries
         .into_iter()
         .take(limit)
-        .map(|(channel_login, path)| RecordingFileEntry {
-            channel_login,
-            filename: path
-                .file_name()
-                .and_then(|f| f.to_str())
-                .unwrap_or("unknown")
-                .to_string(),
-            path_display: path.display().to_string(),
-            status: status.to_string(),
-            pinned: is_recording_pinned(&path),
+        .map(|(channel_login, path)| {
+            let processing_marker = path.with_file_name(format!(
+                "{}.processing",
+                path.file_name()
+                    .and_then(|f| f.to_str())
+                    .unwrap_or("recording")
+            ));
+            let has_hls = path.with_extension("m3u8").exists();
+            let processing_state = if processing_marker.exists() {
+                RecordingProcessingState::Processing
+            } else {
+                RecordingProcessingState::Ready
+            };
+            RecordingFileEntry {
+                channel_login,
+                filename: path
+                    .file_name()
+                    .and_then(|f| f.to_str())
+                    .unwrap_or("unknown")
+                    .to_string(),
+                path_display: path.display().to_string(),
+                status: status.to_string(),
+                pinned: is_recording_pinned(&path),
+                has_hls,
+                processing_state,
+            }
         })
         .collect()
 }

--- a/src/recording/files.rs
+++ b/src/recording/files.rs
@@ -174,12 +174,7 @@ pub(super) fn list_recording_files(
         .into_iter()
         .take(limit)
         .map(|(channel_login, path)| {
-            let processing_marker = path.with_file_name(format!(
-                "{}.processing",
-                path.file_name()
-                    .and_then(|f| f.to_str())
-                    .unwrap_or("recording")
-            ));
+            let processing_marker = processing_marker_path_for_recording(&path);
             let has_hls = path.with_extension("m3u8").exists();
             let processing_state = if processing_marker.exists() {
                 RecordingProcessingState::Processing
@@ -254,6 +249,14 @@ pub(super) fn pin_marker_path_for_recording(recording_path: &Path) -> PathBuf {
         .and_then(|value| value.to_str())
         .unwrap_or("recording");
     recording_path.with_file_name(format!("{file_name}.pin"))
+}
+
+pub(super) fn processing_marker_path_for_recording(recording_path: &Path) -> PathBuf {
+    let file_name = recording_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("recording");
+    recording_path.with_file_name(format!("{file_name}.processing"))
 }
 
 pub(super) fn is_recording_pinned(recording_path: &Path) -> bool {

--- a/src/recording/files.rs
+++ b/src/recording/files.rs
@@ -388,6 +388,7 @@ fn collect_recording_media_paths(dir: &Path, out: &mut Vec<PathBuf>) {
 mod tests {
     use super::super::types::RecordingError;
     use super::*;
+    use std::fs;
 
     #[test]
     fn parse_recording_filename_with_title() {
@@ -428,5 +429,37 @@ mod tests {
     fn parse_recording_filename_rejects_empty() {
         let result = parse_recording_filename("");
         assert!(matches!(result, Err(RecordingError::EmptyFilename)));
+    }
+
+    #[test]
+    fn list_recording_files_maps_processing_and_hls_state() {
+        let base = std::env::temp_dir().join(format!("tr-files-test-{}", uuid::Uuid::new_v4()));
+        let channel_dir = base.join("completed").join("forsen");
+        fs::create_dir_all(&channel_dir).unwrap();
+
+        let mp4 = channel_dir.join("a.mp4");
+        fs::write(&mp4, b"video").unwrap();
+        fs::write(mp4.with_extension("m3u8"), b"#EXTM3U").unwrap();
+
+        let ts = channel_dir.join("b.ts");
+        fs::write(&ts, b"video").unwrap();
+        let marker = processing_marker_path_for_recording(&ts);
+        fs::write(marker, b"processing").unwrap();
+
+        let items = list_recording_files(&base.join("completed"), "completed", 10);
+        assert_eq!(items.len(), 2);
+
+        let ready = items.iter().find(|i| i.filename == "a.mp4").unwrap();
+        assert!(ready.has_hls);
+        assert_eq!(ready.processing_state, RecordingProcessingState::Ready);
+
+        let processing = items.iter().find(|i| i.filename == "b.ts").unwrap();
+        assert!(!processing.has_hls);
+        assert_eq!(
+            processing.processing_state,
+            RecordingProcessingState::Processing
+        );
+
+        let _ = fs::remove_dir_all(base);
     }
 }

--- a/src/recording/types.rs
+++ b/src/recording/types.rs
@@ -30,8 +30,6 @@ pub enum RecordingError {
     SpawnFailed(String),
     #[error("merge failed: {0}")]
     MergeFailed(String),
-    #[error("merge conflict: {0}")]
-    MergeConflict(String),
     #[error("repair failed: {0}")]
     RepairFailed(String),
     #[error("recordings directory not writable: {0}")]

--- a/src/recording/types.rs
+++ b/src/recording/types.rs
@@ -30,6 +30,10 @@ pub enum RecordingError {
     SpawnFailed(String),
     #[error("merge failed: {0}")]
     MergeFailed(String),
+    #[error("merge conflict: {0}")]
+    MergeConflict(String),
+    #[error("repair failed: {0}")]
+    RepairFailed(String),
     #[error("recordings directory not writable: {0}")]
     DirectoryNotWritable(String),
     #[error("io error: {0}")]
@@ -74,6 +78,37 @@ pub struct RecordingFileEntry {
     pub path_display: String,
     pub status: String,
     pub pinned: bool,
+    pub has_hls: bool,
+    pub processing_state: RecordingProcessingState,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum RecordingProcessingState {
+    Processing,
+    Ready,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MergeJobStatus {
+    Queued,
+    Running,
+    Completed,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MergeJob {
+    pub job_id: String,
+    pub channel_login: String,
+    pub source_filenames: Vec<String>,
+    pub status: MergeJobStatus,
+    pub expected_filename: String,
+    pub final_filename: Option<String>,
+    pub error: Option<String>,
+    pub created_at: u64,
+    pub updated_at: u64,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/recording/types.rs
+++ b/src/recording/types.rs
@@ -89,7 +89,14 @@ pub enum RecordingProcessingState {
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum MergeJobStatus {
+pub enum RecordingJobKind {
+    Merge,
+    Finalize,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RecordingJobStatus {
     Queued,
     Running,
     Completed,
@@ -97,11 +104,12 @@ pub enum MergeJobStatus {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct MergeJob {
+pub struct RecordingJob {
     pub job_id: String,
+    pub kind: RecordingJobKind,
     pub channel_login: String,
     pub source_filenames: Vec<String>,
-    pub status: MergeJobStatus,
+    pub status: RecordingJobStatus,
     pub expected_filename: String,
     pub final_filename: Option<String>,
     pub error: Option<String>,

--- a/src/routes/recordings.rs
+++ b/src/routes/recordings.rs
@@ -33,8 +33,8 @@ pub struct RecordingState {
     pub service: RecordingService,
     pub default_quality: String,
     pub progress: RecordingProgressStore,
-    pub active_merge_guard: Arc<RwLock<HashSet<String>>>,
-    pub merge_jobs: Arc<RwLock<HashMap<String, crate::recording::MergeJob>>>,
+    pub active_processing_guard: Arc<RwLock<HashSet<String>>>,
+    pub recording_jobs: Arc<RwLock<HashMap<String, crate::recording::RecordingJob>>>,
 }
 
 /// Request DTO for starting a recording.
@@ -97,19 +97,27 @@ pub struct RepairRecordingRequest {
     pub filename: String,
 }
 
-/// Response DTO for merge accept.
+#[derive(Debug, Deserialize)]
+pub struct FinalizeIncompleteRecordingRequest {
+    pub channel_login: String,
+    pub filename: String,
+}
+
+/// Response DTO for async recording job accept.
 #[derive(Debug, Serialize)]
-pub struct MergeRecordingsResponse {
+pub struct RecordingJobAcceptedResponse {
     pub job_id: String,
+    pub kind: crate::recording::RecordingJobKind,
     pub channel_login: String,
     pub expected_filename: String,
     pub source_count: usize,
 }
 
 #[derive(Debug, Serialize)]
-pub struct MergeStatusResponse {
+pub struct RecordingJobStatusResponse {
     pub job_id: String,
-    pub status: crate::recording::MergeJobStatus,
+    pub kind: crate::recording::RecordingJobKind,
+    pub status: crate::recording::RecordingJobStatus,
     pub channel_login: String,
     pub expected_filename: String,
     pub final_filename: Option<String>,
@@ -186,7 +194,14 @@ pub fn recording_routes(state: RecordingState, auth_config: WebAuthConfig) -> Ro
         .route("/api/recordings/unpin", post(unpin_recording_file))
         .route("/api/recordings/delete", post(delete_recording_file))
         .route("/api/recordings/merge", post(merge_recordings))
-        .route("/api/recordings/merge/{job_id}", get(get_merge_status))
+        .route(
+            "/api/recordings/finalize-incomplete",
+            post(finalize_incomplete_recording),
+        )
+        .route(
+            "/api/recordings/jobs/{job_id}",
+            get(get_recording_job_status),
+        )
         .route("/api/recordings/repair", post(repair_recording))
         .route("/api/recordings/playback-file", get(play_recording_asset))
         .route("/api/recordings/hls-playlist", get(serve_hls_playlist))
@@ -723,9 +738,12 @@ async fn merge_recordings(
     };
 
     {
-        let mut guard = state.active_merge_guard.write().await;
+        let mut guard = state.active_processing_guard.write().await;
         if guard.contains(&normalized_channel) {
-            return error_response(StatusCode::CONFLICT, "merge already running for channel");
+            return error_response(
+                StatusCode::CONFLICT,
+                "recording job already running for channel",
+            );
         }
         guard.insert(normalized_channel.clone());
     }
@@ -734,11 +752,12 @@ async fn merge_recordings(
     let source_count = source_filenames.len();
     let job_id = uuid::Uuid::new_v4().to_string();
     let now = crate::util::time::now_unix_secs();
-    let job = crate::recording::MergeJob {
+    let job = crate::recording::RecordingJob {
         job_id: job_id.clone(),
+        kind: crate::recording::RecordingJobKind::Merge,
         channel_login: normalized_channel.clone(),
         source_filenames: source_filenames.clone(),
-        status: crate::recording::MergeJobStatus::Queued,
+        status: crate::recording::RecordingJobStatus::Queued,
         expected_filename: expected_filename.clone(),
         final_filename: None,
         error: None,
@@ -746,7 +765,7 @@ async fn merge_recordings(
         updated_at: now,
     };
     {
-        let mut jobs = state.merge_jobs.write().await;
+        let mut jobs = state.recording_jobs.write().await;
         jobs.insert(job_id.clone(), job);
     }
 
@@ -757,9 +776,9 @@ async fn merge_recordings(
     let expected_for_task = expected_filename.clone();
     tokio::spawn(async move {
         {
-            let mut jobs = state_for_task.merge_jobs.write().await;
+            let mut jobs = state_for_task.recording_jobs.write().await;
             if let Some(job) = jobs.get_mut(&job_id_for_task) {
-                job.status = crate::recording::MergeJobStatus::Running;
+                job.status = crate::recording::RecordingJobStatus::Running;
                 job.updated_at = crate::util::time::now_unix_secs();
             }
         }
@@ -769,30 +788,31 @@ async fn merge_recordings(
             .merge_incomplete_recordings(&channel_for_task, filenames_for_task, &expected_for_task)
             .await;
 
-        let mut jobs = state_for_task.merge_jobs.write().await;
+        let mut jobs = state_for_task.recording_jobs.write().await;
         if let Some(job) = jobs.get_mut(&job_id_for_task) {
             match merge_result {
                 Ok(file) => {
-                    job.status = crate::recording::MergeJobStatus::Completed;
+                    job.status = crate::recording::RecordingJobStatus::Completed;
                     job.final_filename = Some(file.filename);
                     job.updated_at = crate::util::time::now_unix_secs();
                 }
                 Err(error) => {
-                    job.status = crate::recording::MergeJobStatus::Failed;
+                    job.status = crate::recording::RecordingJobStatus::Failed;
                     job.error = Some(error.to_string());
                     job.updated_at = crate::util::time::now_unix_secs();
                 }
             }
         }
 
-        let mut guard = state_for_task.active_merge_guard.write().await;
+        let mut guard = state_for_task.active_processing_guard.write().await;
         guard.remove(&channel_for_task);
     });
 
     (
         StatusCode::ACCEPTED,
-        Json(MergeRecordingsResponse {
+        Json(RecordingJobAcceptedResponse {
             job_id,
+            kind: crate::recording::RecordingJobKind::Merge,
             channel_login: normalized_channel,
             expected_filename,
             source_count,
@@ -801,19 +821,122 @@ async fn merge_recordings(
         .into_response()
 }
 
-async fn get_merge_status(
+async fn finalize_incomplete_recording(
+    State(state): State<RecordingState>,
+    Json(payload): Json<FinalizeIncompleteRecordingRequest>,
+) -> Response {
+    let (normalized_channel, expected_filename) = match state
+        .service
+        .validate_finalize_request(&payload.channel_login, &payload.filename)
+    {
+        Ok(value) => value,
+        Err(error) => {
+            let (status, message) = classify_recording_error(&error);
+            return error_response(status, message);
+        }
+    };
+
+    {
+        let mut guard = state.active_processing_guard.write().await;
+        if guard.contains(&normalized_channel) {
+            return error_response(
+                StatusCode::CONFLICT,
+                "recording job already running for channel",
+            );
+        }
+        guard.insert(normalized_channel.clone());
+    }
+
+    let source_filename = payload.filename;
+    let job_id = uuid::Uuid::new_v4().to_string();
+    let now = crate::util::time::now_unix_secs();
+    let job = crate::recording::RecordingJob {
+        job_id: job_id.clone(),
+        kind: crate::recording::RecordingJobKind::Finalize,
+        channel_login: normalized_channel.clone(),
+        source_filenames: vec![source_filename.clone()],
+        status: crate::recording::RecordingJobStatus::Queued,
+        expected_filename: expected_filename.clone(),
+        final_filename: None,
+        error: None,
+        created_at: now,
+        updated_at: now,
+    };
+    {
+        let mut jobs = state.recording_jobs.write().await;
+        jobs.insert(job_id.clone(), job);
+    }
+
+    let state_for_task = state.clone();
+    let job_id_for_task = job_id.clone();
+    let channel_for_task = normalized_channel.clone();
+    let filename_for_task = source_filename.clone();
+    let expected_for_task = expected_filename.clone();
+    tokio::spawn(async move {
+        {
+            let mut jobs = state_for_task.recording_jobs.write().await;
+            if let Some(job) = jobs.get_mut(&job_id_for_task) {
+                job.status = crate::recording::RecordingJobStatus::Running;
+                job.updated_at = crate::util::time::now_unix_secs();
+            }
+        }
+
+        let finalize_result = state_for_task
+            .service
+            .finalize_incomplete_recording(
+                &channel_for_task,
+                &filename_for_task,
+                &expected_for_task,
+            )
+            .await;
+
+        let mut jobs = state_for_task.recording_jobs.write().await;
+        if let Some(job) = jobs.get_mut(&job_id_for_task) {
+            match finalize_result {
+                Ok(file) => {
+                    job.status = crate::recording::RecordingJobStatus::Completed;
+                    job.final_filename = Some(file.filename);
+                    job.updated_at = crate::util::time::now_unix_secs();
+                }
+                Err(error) => {
+                    job.status = crate::recording::RecordingJobStatus::Failed;
+                    job.error = Some(error.to_string());
+                    job.updated_at = crate::util::time::now_unix_secs();
+                }
+            }
+        }
+
+        let mut guard = state_for_task.active_processing_guard.write().await;
+        guard.remove(&channel_for_task);
+    });
+
+    (
+        StatusCode::ACCEPTED,
+        Json(RecordingJobAcceptedResponse {
+            job_id,
+            kind: crate::recording::RecordingJobKind::Finalize,
+            channel_login: normalized_channel,
+            expected_filename,
+            source_count: 1,
+        }),
+    )
+        .into_response()
+}
+
+async fn get_recording_job_status(
     State(state): State<RecordingState>,
     Path(job_id): Path<String>,
 ) -> Response {
-    let jobs = state.merge_jobs.read().await;
+    let jobs = state.recording_jobs.read().await;
     let Some(job) = jobs.get(&job_id) else {
-        return error_response(StatusCode::NOT_FOUND, "merge job not found");
+        return error_response(StatusCode::NOT_FOUND, "recording job not found");
     };
 
     (
         StatusCode::OK,
-        Json(MergeStatusResponse {
+        Json(RecordingJobStatusResponse {
             job_id: job.job_id.clone(),
+            kind: job.kind,
             status: job.status,
             channel_login: job.channel_login.clone(),
             expected_filename: job.expected_filename.clone(),

--- a/src/routes/recordings.rs
+++ b/src/routes/recordings.rs
@@ -10,6 +10,11 @@ use axum::{
 };
 use futures_util::stream;
 use serde::{Deserialize, Serialize};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+use tokio::sync::RwLock;
 
 use crate::{
     auth::{self, WebAuthConfig},
@@ -28,6 +33,8 @@ pub struct RecordingState {
     pub service: RecordingService,
     pub default_quality: String,
     pub progress: RecordingProgressStore,
+    pub active_merge_guard: Arc<RwLock<HashSet<String>>>,
+    pub merge_jobs: Arc<RwLock<HashMap<String, crate::recording::MergeJob>>>,
 }
 
 /// Request DTO for starting a recording.
@@ -84,10 +91,23 @@ pub struct MergeRecordingsRequest {
     pub filenames: Vec<String>,
 }
 
-/// Response DTO for merge result.
+/// Response DTO for merge accept.
 #[derive(Debug, Serialize)]
 pub struct MergeRecordingsResponse {
-    pub merged_file: crate::recording::RecordingFileEntry,
+    pub job_id: String,
+    pub channel_login: String,
+    pub expected_filename: String,
+    pub source_count: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MergeStatusResponse {
+    pub job_id: String,
+    pub status: crate::recording::MergeJobStatus,
+    pub channel_login: String,
+    pub expected_filename: String,
+    pub final_filename: Option<String>,
+    pub error: Option<String>,
 }
 
 /// Query parameters for playing a recording asset.
@@ -155,6 +175,7 @@ pub fn recording_routes(state: RecordingState, auth_config: WebAuthConfig) -> Ro
         .route("/api/recordings/unpin", post(unpin_recording_file))
         .route("/api/recordings/delete", post(delete_recording_file))
         .route("/api/recordings/merge", post(merge_recordings))
+        .route("/api/recordings/merge/{job_id}", get(get_merge_status))
         .route("/api/recordings/playback-file", get(play_recording_asset))
         .route("/api/recordings/hls-playlist", get(serve_hls_playlist))
         .route(
@@ -678,24 +699,115 @@ async fn merge_recordings(
         );
     }
 
-    match state
-        .service
-        .merge_incomplete_recordings(&payload.channel_login, payload.filenames)
-        .await
+    let normalized_channel = match RecordingService::normalize_channel_login(&payload.channel_login)
     {
-        Ok(merged_file) => (
-            StatusCode::OK,
-            Json(MergeRecordingsResponse { merged_file }),
-        )
-            .into_response(),
+        Ok(value) => value,
         Err(error) => {
             let (status, message) = classify_recording_error(&error);
-            if status == StatusCode::INTERNAL_SERVER_ERROR {
-                tracing::error!(error = %error, "recording merge failed");
-            }
-            error_response(status, message)
+            return error_response(status, message);
         }
+    };
+
+    {
+        let mut guard = state.active_merge_guard.write().await;
+        if guard.contains(&normalized_channel) {
+            return error_response(StatusCode::CONFLICT, "merge already running for channel");
+        }
+        guard.insert(normalized_channel.clone());
     }
+
+    let source_filenames = payload.filenames;
+    let source_count = source_filenames.len();
+    let job_id = uuid::Uuid::new_v4().to_string();
+    let expected_filename = format!("merge-{job_id}.mp4");
+    let now = crate::util::time::now_unix_secs();
+    let job = crate::recording::MergeJob {
+        job_id: job_id.clone(),
+        channel_login: normalized_channel.clone(),
+        source_filenames: source_filenames.clone(),
+        status: crate::recording::MergeJobStatus::Queued,
+        expected_filename: expected_filename.clone(),
+        final_filename: None,
+        error: None,
+        created_at: now,
+        updated_at: now,
+    };
+    {
+        let mut jobs = state.merge_jobs.write().await;
+        jobs.insert(job_id.clone(), job);
+    }
+
+    let state_for_task = state.clone();
+    let job_id_for_task = job_id.clone();
+    let channel_for_task = normalized_channel.clone();
+    let filenames_for_task = source_filenames.clone();
+    tokio::spawn(async move {
+        {
+            let mut jobs = state_for_task.merge_jobs.write().await;
+            if let Some(job) = jobs.get_mut(&job_id_for_task) {
+                job.status = crate::recording::MergeJobStatus::Running;
+                job.updated_at = crate::util::time::now_unix_secs();
+            }
+        }
+
+        let merge_result = state_for_task
+            .service
+            .merge_incomplete_recordings(&channel_for_task, filenames_for_task)
+            .await;
+
+        let mut jobs = state_for_task.merge_jobs.write().await;
+        if let Some(job) = jobs.get_mut(&job_id_for_task) {
+            match merge_result {
+                Ok(file) => {
+                    job.status = crate::recording::MergeJobStatus::Completed;
+                    job.final_filename = Some(file.filename);
+                    job.updated_at = crate::util::time::now_unix_secs();
+                }
+                Err(error) => {
+                    job.status = crate::recording::MergeJobStatus::Failed;
+                    job.error = Some(error.to_string());
+                    job.updated_at = crate::util::time::now_unix_secs();
+                }
+            }
+        }
+
+        let mut guard = state_for_task.active_merge_guard.write().await;
+        guard.remove(&channel_for_task);
+    });
+
+    (
+        StatusCode::ACCEPTED,
+        Json(MergeRecordingsResponse {
+            job_id,
+            channel_login: normalized_channel,
+            expected_filename,
+            source_count,
+        }),
+    )
+        .into_response()
+}
+
+async fn get_merge_status(
+    State(state): State<RecordingState>,
+    Path(job_id): Path<String>,
+) -> Response {
+    let jobs = state.merge_jobs.read().await;
+    let Some(job) = jobs.get(&job_id) else {
+        return error_response(StatusCode::NOT_FOUND, "merge job not found");
+    };
+
+    (
+        StatusCode::OK,
+        Json(MergeStatusResponse {
+            job_id: job.job_id.clone(),
+            status: job.status,
+            channel_login: job.channel_login.clone(),
+            expected_filename: job.expected_filename.clone(),
+            final_filename: job.final_filename.clone(),
+            error: job.error.clone(),
+        }),
+    )
+        .into_response()
 }
 
 fn classify_recording_error(error: &RecordingError) -> (StatusCode, &'static str) {
@@ -724,6 +836,8 @@ fn classify_recording_error(error: &RecordingError) -> (StatusCode, &'static str
         RecordingError::MergeFailed(_) => {
             (StatusCode::INTERNAL_SERVER_ERROR, "recording merge failed")
         }
+        RecordingError::MergeConflict(_) => (StatusCode::CONFLICT, "recording merge conflict"),
+        RecordingError::RepairFailed(_) => (StatusCode::BAD_REQUEST, "recording repair failed"),
     }
 }
 

--- a/src/routes/recordings.rs
+++ b/src/routes/recordings.rs
@@ -91,6 +91,12 @@ pub struct MergeRecordingsRequest {
     pub filenames: Vec<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct RepairRecordingRequest {
+    pub channel_login: String,
+    pub filename: String,
+}
+
 /// Response DTO for merge accept.
 #[derive(Debug, Serialize)]
 pub struct MergeRecordingsResponse {
@@ -108,6 +114,11 @@ pub struct MergeStatusResponse {
     pub expected_filename: String,
     pub final_filename: Option<String>,
     pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RepairRecordingResponse {
+    pub repaired_file: crate::recording::RecordingFileEntry,
 }
 
 /// Query parameters for playing a recording asset.
@@ -176,6 +187,7 @@ pub fn recording_routes(state: RecordingState, auth_config: WebAuthConfig) -> Ro
         .route("/api/recordings/delete", post(delete_recording_file))
         .route("/api/recordings/merge", post(merge_recordings))
         .route("/api/recordings/merge/{job_id}", get(get_merge_status))
+        .route("/api/recordings/repair", post(repair_recording))
         .route("/api/recordings/playback-file", get(play_recording_asset))
         .route("/api/recordings/hls-playlist", get(serve_hls_playlist))
         .route(
@@ -810,6 +822,30 @@ async fn get_merge_status(
         .into_response()
 }
 
+async fn repair_recording(
+    State(state): State<RecordingState>,
+    Json(payload): Json<RepairRecordingRequest>,
+) -> Response {
+    match state
+        .service
+        .repair_completed_recording(&payload.channel_login, &payload.filename)
+        .await
+    {
+        Ok(repaired_file) => (
+            StatusCode::OK,
+            Json(RepairRecordingResponse { repaired_file }),
+        )
+            .into_response(),
+        Err(error) => {
+            let (status, message) = classify_recording_error(&error);
+            if status == StatusCode::INTERNAL_SERVER_ERROR {
+                tracing::error!(error = %error, "recording repair failed");
+            }
+            error_response(status, message)
+        }
+    }
+}
+
 fn classify_recording_error(error: &RecordingError) -> (StatusCode, &'static str) {
     match error {
         RecordingError::EmptyChannelLogin => {
@@ -836,8 +872,9 @@ fn classify_recording_error(error: &RecordingError) -> (StatusCode, &'static str
         RecordingError::MergeFailed(_) => {
             (StatusCode::INTERNAL_SERVER_ERROR, "recording merge failed")
         }
-        RecordingError::MergeConflict(_) => (StatusCode::CONFLICT, "recording merge conflict"),
-        RecordingError::RepairFailed(_) => (StatusCode::BAD_REQUEST, "recording repair failed"),
+        RecordingError::RepairFailed(_) => {
+            (StatusCode::BAD_REQUEST, "recording repair request failed")
+        }
     }
 }
 

--- a/src/routes/recordings.rs
+++ b/src/routes/recordings.rs
@@ -711,7 +711,9 @@ async fn merge_recordings(
         );
     }
 
-    let normalized_channel = match RecordingService::normalize_channel_login(&payload.channel_login)
+    let (normalized_channel, expected_filename) = match state
+        .service
+        .validate_merge_request(&payload.channel_login, &payload.filenames)
     {
         Ok(value) => value,
         Err(error) => {
@@ -731,7 +733,6 @@ async fn merge_recordings(
     let source_filenames = payload.filenames;
     let source_count = source_filenames.len();
     let job_id = uuid::Uuid::new_v4().to_string();
-    let expected_filename = format!("merge-{job_id}.mp4");
     let now = crate::util::time::now_unix_secs();
     let job = crate::recording::MergeJob {
         job_id: job_id.clone(),
@@ -753,6 +754,7 @@ async fn merge_recordings(
     let job_id_for_task = job_id.clone();
     let channel_for_task = normalized_channel.clone();
     let filenames_for_task = source_filenames.clone();
+    let expected_for_task = expected_filename.clone();
     tokio::spawn(async move {
         {
             let mut jobs = state_for_task.merge_jobs.write().await;
@@ -764,7 +766,7 @@ async fn merge_recordings(
 
         let merge_result = state_for_task
             .service
-            .merge_incomplete_recordings(&channel_for_task, filenames_for_task)
+            .merge_incomplete_recordings(&channel_for_task, filenames_for_task, &expected_for_task)
             .await;
 
         let mut jobs = state_for_task.merge_jobs.write().await;
@@ -870,7 +872,7 @@ fn classify_recording_error(error: &RecordingError) -> (StatusCode, &'static str
             "recording operation failed",
         ),
         RecordingError::MergeFailed(_) => {
-            (StatusCode::INTERNAL_SERVER_ERROR, "recording merge failed")
+            (StatusCode::BAD_REQUEST, "recording merge request failed")
         }
         RecordingError::RepairFailed(_) => {
             (StatusCode::BAD_REQUEST, "recording repair request failed")
@@ -985,8 +987,8 @@ mod tests {
     fn classify_recording_error_maps_merge_failed() {
         let (status, message) =
             classify_recording_error(&RecordingError::MergeFailed("some error".to_string()));
-        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
-        assert_eq!(message, "recording merge failed");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(message, "recording merge request failed");
     }
 
     #[test]

--- a/src/routes/recordings.rs
+++ b/src/routes/recordings.rs
@@ -988,4 +988,12 @@ mod tests {
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(message, "recording merge failed");
     }
+
+    #[test]
+    fn classify_recording_error_maps_repair_failed() {
+        let (status, message) =
+            classify_recording_error(&RecordingError::RepairFailed("some error".to_string()));
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(message, "recording repair request failed");
+    }
 }

--- a/web/src/lib/api-client/recordings.ts
+++ b/web/src/lib/api-client/recordings.ts
@@ -5,8 +5,8 @@ import type {
   ActiveRecording,
   RecordingFileEntry,
   RecordingWatchProgress,
-  MergeStartResponse,
-  MergeStatusResponse,
+  RecordingJobStartResponse,
+  RecordingJobStatusResponse,
 } from "./types";
 
 export async function getRecordingRules(): Promise<Array<RecordingRule>> {
@@ -186,7 +186,7 @@ export async function saveRecordingWatchProgress(payload: {
 export async function mergeRecordingFiles(payload: {
   channel_login: string;
   filenames: string[];
-}): Promise<MergeStartResponse> {
+}): Promise<RecordingJobStartResponse> {
   const response = await request("/api/recordings/merge", {
     method: "POST",
     headers: { "content-type": "application/json" },
@@ -200,20 +200,40 @@ export async function mergeRecordingFiles(payload: {
   if (!isObject(result) || typeof result.job_id !== "string") {
     throw new Error("merge response is invalid");
   }
-  return result as unknown as MergeStartResponse;
+  return result as unknown as RecordingJobStartResponse;
 }
 
-export async function getMergeStatus(jobId: string): Promise<MergeStatusResponse> {
-  const response = await request(`/api/recordings/merge/${encodeURIComponent(jobId)}`);
+export async function finalizeIncompleteRecording(payload: {
+  channel_login: string;
+  filename: string;
+}): Promise<RecordingJobStartResponse> {
+  const response = await request("/api/recordings/finalize-incomplete", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
   if (!response.ok) {
     const body = await safeJson(response);
     throw new Error(readError(body));
   }
   const result = await safeJson(response);
   if (!isObject(result) || typeof result.job_id !== "string") {
-    throw new Error("merge status response is invalid");
+    throw new Error("finalize response is invalid");
   }
-  return result as unknown as MergeStatusResponse;
+  return result as unknown as RecordingJobStartResponse;
+}
+
+export async function getRecordingJobStatus(jobId: string): Promise<RecordingJobStatusResponse> {
+  const response = await request(`/api/recordings/jobs/${encodeURIComponent(jobId)}`);
+  if (!response.ok) {
+    const body = await safeJson(response);
+    throw new Error(readError(body));
+  }
+  const result = await safeJson(response);
+  if (!isObject(result) || typeof result.job_id !== "string") {
+    throw new Error("recording job status response is invalid");
+  }
+  return result as unknown as RecordingJobStatusResponse;
 }
 
 export async function repairRecordingFile(payload: {

--- a/web/src/lib/api-client/recordings.ts
+++ b/web/src/lib/api-client/recordings.ts
@@ -5,6 +5,8 @@ import type {
   ActiveRecording,
   RecordingFileEntry,
   RecordingWatchProgress,
+  MergeStartResponse,
+  MergeStatusResponse,
 } from "./types";
 
 export async function getRecordingRules(): Promise<Array<RecordingRule>> {
@@ -184,7 +186,7 @@ export async function saveRecordingWatchProgress(payload: {
 export async function mergeRecordingFiles(payload: {
   channel_login: string;
   filenames: string[];
-}): Promise<RecordingFileEntry> {
+}): Promise<MergeStartResponse> {
   const response = await request("/api/recordings/merge", {
     method: "POST",
     headers: { "content-type": "application/json" },
@@ -195,8 +197,21 @@ export async function mergeRecordingFiles(payload: {
     throw new Error(readError(body));
   }
   const result = await safeJson(response);
-  if (!isObject(result) || !isObject(result.merged_file)) {
+  if (!isObject(result) || typeof result.job_id !== "string") {
     throw new Error("merge response is invalid");
   }
-  return result.merged_file as unknown as RecordingFileEntry;
+  return result as unknown as MergeStartResponse;
+}
+
+export async function getMergeStatus(jobId: string): Promise<MergeStatusResponse> {
+  const response = await request(`/api/recordings/merge/${encodeURIComponent(jobId)}`);
+  if (!response.ok) {
+    const body = await safeJson(response);
+    throw new Error(readError(body));
+  }
+  const result = await safeJson(response);
+  if (!isObject(result) || typeof result.job_id !== "string") {
+    throw new Error("merge status response is invalid");
+  }
+  return result as unknown as MergeStatusResponse;
 }

--- a/web/src/lib/api-client/recordings.ts
+++ b/web/src/lib/api-client/recordings.ts
@@ -215,3 +215,23 @@ export async function getMergeStatus(jobId: string): Promise<MergeStatusResponse
   }
   return result as unknown as MergeStatusResponse;
 }
+
+export async function repairRecordingFile(payload: {
+  channel_login: string;
+  filename: string;
+}): Promise<RecordingFileEntry> {
+  const response = await request("/api/recordings/repair", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    const body = await safeJson(response);
+    throw new Error(readError(body));
+  }
+  const result = await safeJson(response);
+  if (!isObject(result) || !isObject(result.repaired_file)) {
+    throw new Error("repair response is invalid");
+  }
+  return result.repaired_file as unknown as RecordingFileEntry;
+}

--- a/web/src/lib/api-client/types.ts
+++ b/web/src/lib/api-client/types.ts
@@ -93,15 +93,19 @@ export interface RecordingFileEntry {
   processing_state: "processing" | "ready";
 }
 
-export interface MergeStartResponse {
+export type RecordingJobKind = "merge" | "finalize";
+
+export interface RecordingJobStartResponse {
   job_id: string;
+  kind: RecordingJobKind;
   channel_login: string;
   expected_filename: string;
   source_count: number;
 }
 
-export interface MergeStatusResponse {
+export interface RecordingJobStatusResponse {
   job_id: string;
+  kind: RecordingJobKind;
   status: "queued" | "running" | "completed" | "failed";
   channel_login: string;
   expected_filename: string;

--- a/web/src/lib/api-client/types.ts
+++ b/web/src/lib/api-client/types.ts
@@ -89,6 +89,24 @@ export interface RecordingFileEntry {
   path_display: string;
   status: string;
   pinned: boolean;
+  has_hls: boolean;
+  processing_state: "processing" | "ready";
+}
+
+export interface MergeStartResponse {
+  job_id: string;
+  channel_login: string;
+  expected_filename: string;
+  source_count: number;
+}
+
+export interface MergeStatusResponse {
+  job_id: string;
+  status: "queued" | "running" | "completed" | "failed";
+  channel_login: string;
+  expected_filename: string;
+  final_filename: string | null;
+  error: string | null;
 }
 
 export interface RecordingsResponse {

--- a/web/src/lib/components/home/RecordingsOverview.svelte
+++ b/web/src/lib/components/home/RecordingsOverview.svelte
@@ -22,6 +22,7 @@ let {
   repairingRecordingKey,
   mergingRecordingKey,
   selectedIncompleteFilenames,
+  pendingMerge,
   onBackToChannels,
   onUpdateFilter,
   onOpenRecordingPlayer,
@@ -71,6 +72,16 @@ let {
   </div>
 
   <div class="recordings-grid">
+    {#if pendingMerge}
+      <section class="recordings-section">
+        <h2>Pending merge</h2>
+        <p class="ui-muted">
+          {pendingMerge.channelLogin}: {pendingMerge.status} ({pendingMerge.sourceCount} files) ->
+          {pendingMerge.expectedFilename}
+        </p>
+      </section>
+    {/if}
+
     <section class="recordings-section">
       <h2>Active ({activeList.length})</h2>
       {#if activeList.length === 0}

--- a/web/src/lib/components/home/RecordingsOverview.svelte
+++ b/web/src/lib/components/home/RecordingsOverview.svelte
@@ -22,7 +22,7 @@ let {
   repairingRecordingKey,
   mergingRecordingKey,
   selectedIncompleteFilenames,
-  pendingMerge,
+  pendingJob,
   onBackToChannels,
   onUpdateFilter,
   onOpenRecordingPlayer,
@@ -30,7 +30,7 @@ let {
   onToggleRecordingPin,
   onRepairRecording,
   onToggleIncompleteMergeSelection,
-  onMergeIncompleteFiles
+  onProcessIncompleteFiles
 }: RecordingsOverviewProps = $props();
 
   const channelOptions = $derived(recordingChannelOptions(
@@ -72,12 +72,12 @@ let {
   </div>
 
   <div class="recordings-grid">
-    {#if pendingMerge}
+    {#if pendingJob}
       <section class="recordings-section">
-        <h2>Pending merge</h2>
+        <h2>Pending {pendingJob.kind}</h2>
         <p class="ui-muted">
-          {pendingMerge.channelLogin}: {pendingMerge.status} ({pendingMerge.sourceCount} files) ->
-          {pendingMerge.expectedFilename}
+          {pendingJob.channelLogin}: {pendingJob.status} ({pendingJob.sourceCount} files) ->
+          {pendingJob.expectedFilename}
         </p>
       </section>
     {/if}
@@ -185,20 +185,22 @@ let {
            {@const selectedCount = Array.from(selectedIncompleteFilenames).filter(
              filename => shownIncomplete.some(file => file.filename === filename)
            ).length}
-           <button
-             type="button"
-             class="merge-btn"
-             onclick={() => onMergeIncompleteFiles(recordingsChannelFilter)}
-             disabled={selectedCount < 2 || mergingRecordingKey === recordingsChannelFilter}
-           >
-             {#if mergingRecordingKey === recordingsChannelFilter}
-               <span class="merge-btn-spinner"></span>
-               Merging...
-             {:else}
-               Merge selected ({selectedCount})
-             {/if}
-           </button>
-         {/if}
+            <button
+              type="button"
+              class="merge-btn"
+              onclick={() => onProcessIncompleteFiles(recordingsChannelFilter)}
+              disabled={selectedCount < 1 || mergingRecordingKey === recordingsChannelFilter}
+            >
+              {#if mergingRecordingKey === recordingsChannelFilter}
+                <span class="merge-btn-spinner"></span>
+                {selectedCount === 1 ? 'Finalizing...' : 'Merging...'}
+              {:else}
+                {selectedCount === 1
+                  ? 'Finalize selected'
+                  : `Merge selected (${selectedCount})`}
+              {/if}
+            </button>
+          {/if}
        </div>
        {#if incompleteList.length === 0}
          <p class="ui-muted">No incomplete files.</p>

--- a/web/src/lib/components/home/RecordingsOverview.svelte
+++ b/web/src/lib/components/home/RecordingsOverview.svelte
@@ -19,6 +19,7 @@ let {
   recordingsChannelFilter,
   deletingRecordingKey,
   pinningRecordingKey,
+  repairingRecordingKey,
   mergingRecordingKey,
   selectedIncompleteFilenames,
   onBackToChannels,
@@ -26,6 +27,7 @@ let {
   onOpenRecordingPlayer,
   onRemoveRecordingFile,
   onToggleRecordingPin,
+  onRepairRecording,
   onToggleIncompleteMergeSelection,
   onMergeIncompleteFiles
 }: RecordingsOverviewProps = $props();
@@ -107,7 +109,7 @@ let {
                   aria-label={file.pinned ? 'Unpin recording' : 'Pin recording'}
                   aria-pressed={file.pinned}
                   aria-busy={pinningRecordingKey === deleteKey}
-                  disabled={pinningRecordingKey === deleteKey}
+                  disabled={pinningRecordingKey === deleteKey || file.processing_state === 'processing'}
                 >
                   {file.pinned ? '★' : '☆'}
                 </button>
@@ -117,9 +119,23 @@ let {
                   onclick={() => onOpenRecordingPlayer(file)}
                   title="Play recording"
                   aria-label="Play recording"
+                  disabled={file.processing_state === 'processing'}
                 >
                   Play
                 </button>
+                {#if file.processing_state === 'processing' || !file.has_hls}
+                  <button
+                    type="button"
+                    class="recording-play-btn"
+                    onclick={() => onRepairRecording(file)}
+                    title="Repair playback assets"
+                    aria-label="Repair playback assets"
+                    aria-busy={repairingRecordingKey === deleteKey}
+                    disabled={repairingRecordingKey === deleteKey}
+                  >
+                    {repairingRecordingKey === deleteKey ? 'Repairing...' : 'Repair'}
+                  </button>
+                {/if}
                 <button
                   type="button"
                   class="recording-delete-btn"
@@ -127,7 +143,7 @@ let {
                   title="Delete recording"
                   aria-label="Delete recording"
                   aria-busy={deletingRecordingKey === deleteKey}
-                  disabled={deletingRecordingKey === deleteKey}
+                  disabled={deletingRecordingKey === deleteKey || file.processing_state === 'processing'}
                 >
                   {#if deletingRecordingKey === deleteKey}
                     <svg class="recording-delete-spinner" viewBox="0 0 24 24" aria-hidden="true">

--- a/web/src/lib/components/home/types.ts
+++ b/web/src/lib/components/home/types.ts
@@ -104,6 +104,7 @@ export interface RecordingsOverviewProps {
   recordingsChannelFilter: string;
   deletingRecordingKey: string | null;
   pinningRecordingKey: string | null;
+  repairingRecordingKey: string | null;
   mergingRecordingKey: string | null;
   selectedIncompleteFilenames: Set<string>;
   onBackToChannels: () => void;
@@ -111,6 +112,7 @@ export interface RecordingsOverviewProps {
   onOpenRecordingPlayer: (file: RecordingFileEntry) => void;
   onRemoveRecordingFile: (bucket: "completed" | "incomplete", file: RecordingFileEntry) => void;
   onToggleRecordingPin: (file: RecordingFileEntry) => void;
+  onRepairRecording: (file: RecordingFileEntry) => void;
   onToggleIncompleteMergeSelection: (filename: string) => void;
   onMergeIncompleteFiles: (channelLogin: string) => void;
 }

--- a/web/src/lib/components/home/types.ts
+++ b/web/src/lib/components/home/types.ts
@@ -107,6 +107,13 @@ export interface RecordingsOverviewProps {
   repairingRecordingKey: string | null;
   mergingRecordingKey: string | null;
   selectedIncompleteFilenames: Set<string>;
+  pendingMerge: {
+    jobId: string;
+    channelLogin: string;
+    expectedFilename: string;
+    sourceCount: number;
+    status: "queued" | "running" | "completed" | "failed";
+  } | null;
   onBackToChannels: () => void;
   onUpdateFilter: (value: string) => void;
   onOpenRecordingPlayer: (file: RecordingFileEntry) => void;

--- a/web/src/lib/components/home/types.ts
+++ b/web/src/lib/components/home/types.ts
@@ -107,8 +107,9 @@ export interface RecordingsOverviewProps {
   repairingRecordingKey: string | null;
   mergingRecordingKey: string | null;
   selectedIncompleteFilenames: Set<string>;
-  pendingMerge: {
+  pendingJob: {
     jobId: string;
+    kind: "merge" | "finalize";
     channelLogin: string;
     expectedFilename: string;
     sourceCount: number;
@@ -121,7 +122,7 @@ export interface RecordingsOverviewProps {
   onToggleRecordingPin: (file: RecordingFileEntry) => void;
   onRepairRecording: (file: RecordingFileEntry) => void;
   onToggleIncompleteMergeSelection: (filename: string) => void;
-  onMergeIncompleteFiles: (channelLogin: string) => void;
+  onProcessIncompleteFiles: (channelLogin: string) => void;
 }
 
 // ConfirmRemoveDialog props

--- a/web/src/lib/home/recordingsController.svelte.ts
+++ b/web/src/lib/home/recordingsController.svelte.ts
@@ -8,9 +8,23 @@ import {
   pinRecordingFile,
   unpinRecordingFile,
   mergeRecordingFiles,
+  getMergeStatus,
 } from "$lib/api";
 import { readMessage } from "$lib/home/errors";
-import type { RecordingRule, ActiveRecording, RecordingFileEntry } from "$lib/api-client/types";
+import type {
+  RecordingRule,
+  ActiveRecording,
+  RecordingFileEntry,
+  MergeStatusResponse,
+} from "$lib/api-client/types";
+
+interface PendingMergeState {
+  jobId: string;
+  channelLogin: string;
+  expectedFilename: string;
+  sourceCount: number;
+  status: MergeStatusResponse["status"];
+}
 
 export interface RecordingsControllerDeps {
   setError: (message: string | null) => void;
@@ -25,6 +39,7 @@ export interface RecordingsController {
   pinningRecordingKey: string | null;
   mergingRecordingKey: string | null;
   selectedIncompleteFilenames: Set<string>;
+  pendingMerge: PendingMergeState | null;
 
   loadRecordingRules: () => Promise<void>;
   loadRecordingState: () => Promise<void>;
@@ -50,6 +65,7 @@ export function createRecordingsController(deps: RecordingsControllerDeps): Reco
   let pinningRecordingKey = $state<string | null>(null);
   let mergingRecordingKey = $state<string | null>(null);
   let selectedIncompleteFilenames = $state<Set<string>>(new Set());
+  let pendingMerge = $state<PendingMergeState | null>(null);
 
   const { setError } = deps;
 
@@ -209,12 +225,46 @@ export function createRecordingsController(deps: RecordingsControllerDeps): Reco
     setError(null);
 
     try {
-      await mergeRecordingFiles({
+      const mergeStart = await mergeRecordingFiles({
         channel_login: channelLogin,
         filenames: selectedFiles,
       });
-      await loadRecordingState();
+
+      pendingMerge = {
+        jobId: mergeStart.job_id,
+        channelLogin: mergeStart.channel_login,
+        expectedFilename: mergeStart.expected_filename,
+        sourceCount: mergeStart.source_count,
+        status: "queued",
+      };
+
+      const startedAt = Date.now();
+      while (Date.now() - startedAt < 10 * 60 * 1000) {
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+        const status = await getMergeStatus(mergeStart.job_id);
+        pendingMerge = {
+          jobId: status.job_id,
+          channelLogin: status.channel_login,
+          expectedFilename: status.expected_filename,
+          sourceCount: mergeStart.source_count,
+          status: status.status,
+        };
+
+        if (status.status === "completed") {
+          pendingMerge = null;
+          await loadRecordingState();
+          return;
+        }
+        if (status.status === "failed") {
+          pendingMerge = null;
+          setError(status.error ?? "merge failed");
+          return;
+        }
+      }
+
+      setError("merge status polling timed out");
     } catch (err) {
+      pendingMerge = null;
       setError(readMessage(err, "failed to merge recordings"));
     } finally {
       mergingRecordingKey = null;
@@ -245,6 +295,9 @@ export function createRecordingsController(deps: RecordingsControllerDeps): Reco
     },
     get selectedIncompleteFilenames() {
       return selectedIncompleteFilenames;
+    },
+    get pendingMerge() {
+      return pendingMerge;
     },
     loadRecordingRules,
     loadRecordingState,

--- a/web/src/lib/home/recordingsController.svelte.ts
+++ b/web/src/lib/home/recordingsController.svelte.ts
@@ -9,6 +9,7 @@ import {
   unpinRecordingFile,
   mergeRecordingFiles,
   getMergeStatus,
+  repairRecordingFile,
 } from "$lib/api";
 import { readMessage } from "$lib/home/errors";
 import type {
@@ -40,6 +41,7 @@ export interface RecordingsController {
   mergingRecordingKey: string | null;
   selectedIncompleteFilenames: Set<string>;
   pendingMerge: PendingMergeState | null;
+  repairingRecordingKey: string | null;
 
   loadRecordingRules: () => Promise<void>;
   loadRecordingState: () => Promise<void>;
@@ -50,6 +52,7 @@ export interface RecordingsController {
     file: RecordingFileEntry,
   ) => Promise<void>;
   toggleRecordingPin: (file: RecordingFileEntry) => Promise<void>;
+  repairRecording: (file: RecordingFileEntry) => Promise<void>;
   toggleIncompleteMergeSelection: (filename: string) => void;
   clearMergeSelection: () => void;
   mergeSelectedIncompleteFiles: (channelLogin: string) => Promise<void>;
@@ -66,6 +69,7 @@ export function createRecordingsController(deps: RecordingsControllerDeps): Reco
   let mergingRecordingKey = $state<string | null>(null);
   let selectedIncompleteFilenames = $state<Set<string>>(new Set());
   let pendingMerge = $state<PendingMergeState | null>(null);
+  let repairingRecordingKey = $state<string | null>(null);
 
   const { setError } = deps;
 
@@ -193,6 +197,23 @@ export function createRecordingsController(deps: RecordingsControllerDeps): Reco
     }
   }
 
+  async function repairRecording(file: RecordingFileEntry): Promise<void> {
+    const key = `completed:${file.channel_login}:${file.filename}`;
+    repairingRecordingKey = key;
+    setError(null);
+    try {
+      await repairRecordingFile({
+        channel_login: file.channel_login,
+        filename: file.filename,
+      });
+      await loadRecordingState();
+    } catch (err) {
+      setError(readMessage(err, "failed to repair recording"));
+    } finally {
+      repairingRecordingKey = null;
+    }
+  }
+
   function toggleIncompleteMergeSelection(filename: string): void {
     const newSelection = new Set(selectedIncompleteFilenames);
     if (newSelection.has(filename)) {
@@ -299,12 +320,16 @@ export function createRecordingsController(deps: RecordingsControllerDeps): Reco
     get pendingMerge() {
       return pendingMerge;
     },
+    get repairingRecordingKey() {
+      return repairingRecordingKey;
+    },
     loadRecordingRules,
     loadRecordingState,
     toggleAutoRecord,
     toggleManualRecording,
     removeRecordingFile,
     toggleRecordingPin,
+    repairRecording,
     toggleIncompleteMergeSelection,
     clearMergeSelection,
     mergeSelectedIncompleteFiles,

--- a/web/src/lib/home/recordingsController.svelte.ts
+++ b/web/src/lib/home/recordingsController.svelte.ts
@@ -8,7 +8,8 @@ import {
   pinRecordingFile,
   unpinRecordingFile,
   mergeRecordingFiles,
-  getMergeStatus,
+  finalizeIncompleteRecording,
+  getRecordingJobStatus,
   repairRecordingFile,
 } from "$lib/api";
 import { readMessage } from "$lib/home/errors";
@@ -16,15 +17,17 @@ import type {
   RecordingRule,
   ActiveRecording,
   RecordingFileEntry,
-  MergeStatusResponse,
+  RecordingJobKind,
+  RecordingJobStatusResponse,
 } from "$lib/api-client/types";
 
-interface PendingMergeState {
+interface PendingRecordingJobState {
   jobId: string;
+  kind: RecordingJobKind;
   channelLogin: string;
   expectedFilename: string;
   sourceCount: number;
-  status: MergeStatusResponse["status"];
+  status: RecordingJobStatusResponse["status"];
 }
 
 export interface RecordingsControllerDeps {
@@ -40,7 +43,7 @@ export interface RecordingsController {
   pinningRecordingKey: string | null;
   mergingRecordingKey: string | null;
   selectedIncompleteFilenames: Set<string>;
-  pendingMerge: PendingMergeState | null;
+  pendingJob: PendingRecordingJobState | null;
   repairingRecordingKey: string | null;
 
   loadRecordingRules: () => Promise<void>;
@@ -55,7 +58,7 @@ export interface RecordingsController {
   repairRecording: (file: RecordingFileEntry) => Promise<void>;
   toggleIncompleteMergeSelection: (filename: string) => void;
   clearMergeSelection: () => void;
-  mergeSelectedIncompleteFiles: (channelLogin: string) => Promise<void>;
+  processSelectedIncompleteFiles: (channelLogin: string) => Promise<void>;
   selectedQuality: (channelLogin: string) => string;
 }
 
@@ -68,7 +71,7 @@ export function createRecordingsController(deps: RecordingsControllerDeps): Reco
   let pinningRecordingKey = $state<string | null>(null);
   let mergingRecordingKey = $state<string | null>(null);
   let selectedIncompleteFilenames = $state<Set<string>>(new Set());
-  let pendingMerge = $state<PendingMergeState | null>(null);
+  let pendingJob = $state<PendingRecordingJobState | null>(null);
   let repairingRecordingKey = $state<string | null>(null);
 
   const { setError } = deps;
@@ -228,17 +231,19 @@ export function createRecordingsController(deps: RecordingsControllerDeps): Reco
     selectedIncompleteFilenames = new Set();
   }
 
-  async function mergeSelectedIncompleteFiles(channelLogin: string): Promise<void> {
+  async function processSelectedIncompleteFiles(channelLogin: string): Promise<void> {
     const selectedFiles = Array.from(selectedIncompleteFilenames);
-    if (selectedFiles.length < 2) {
-      setError("Please select at least 2 files to merge");
+    if (selectedFiles.length === 0) {
+      setError("Please select at least 1 file to process");
       return;
     }
 
-    const shouldMerge = window.confirm(
-      `Merge ${selectedFiles.length} incomplete recording(s) for ${channelLogin}?`,
+    const action = selectedFiles.length === 1 ? "finalize" : "merge";
+
+    const shouldContinue = window.confirm(
+      `${action === "finalize" ? "Finalize" : "Merge"} ${selectedFiles.length} incomplete recording(s) for ${channelLogin}?`,
     );
-    if (!shouldMerge) {
+    if (!shouldContinue) {
       return;
     }
 
@@ -246,47 +251,55 @@ export function createRecordingsController(deps: RecordingsControllerDeps): Reco
     setError(null);
 
     try {
-      const mergeStart = await mergeRecordingFiles({
-        channel_login: channelLogin,
-        filenames: selectedFiles,
-      });
+      const startResponse =
+        action === "finalize"
+          ? await finalizeIncompleteRecording({
+              channel_login: channelLogin,
+              filename: selectedFiles[0],
+            })
+          : await mergeRecordingFiles({
+              channel_login: channelLogin,
+              filenames: selectedFiles,
+            });
 
-      pendingMerge = {
-        jobId: mergeStart.job_id,
-        channelLogin: mergeStart.channel_login,
-        expectedFilename: mergeStart.expected_filename,
-        sourceCount: mergeStart.source_count,
+      pendingJob = {
+        jobId: startResponse.job_id,
+        kind: startResponse.kind,
+        channelLogin: startResponse.channel_login,
+        expectedFilename: startResponse.expected_filename,
+        sourceCount: startResponse.source_count,
         status: "queued",
       };
 
       const startedAt = Date.now();
       while (Date.now() - startedAt < 10 * 60 * 1000) {
         await new Promise((resolve) => setTimeout(resolve, 1500));
-        const status = await getMergeStatus(mergeStart.job_id);
-        pendingMerge = {
+        const status = await getRecordingJobStatus(startResponse.job_id);
+        pendingJob = {
           jobId: status.job_id,
+          kind: status.kind,
           channelLogin: status.channel_login,
           expectedFilename: status.expected_filename,
-          sourceCount: mergeStart.source_count,
+          sourceCount: startResponse.source_count,
           status: status.status,
         };
 
         if (status.status === "completed") {
-          pendingMerge = null;
+          pendingJob = null;
           await loadRecordingState();
           return;
         }
         if (status.status === "failed") {
-          pendingMerge = null;
-          setError(status.error ?? "merge failed");
+          pendingJob = null;
+          setError(status.error ?? "recording job failed");
           return;
         }
       }
 
-      setError("merge status polling timed out");
+      setError("recording job polling timed out");
     } catch (err) {
-      pendingMerge = null;
-      setError(readMessage(err, "failed to merge recordings"));
+      pendingJob = null;
+      setError(readMessage(err, "failed to process recordings"));
     } finally {
       mergingRecordingKey = null;
     }
@@ -317,8 +330,8 @@ export function createRecordingsController(deps: RecordingsControllerDeps): Reco
     get selectedIncompleteFilenames() {
       return selectedIncompleteFilenames;
     },
-    get pendingMerge() {
-      return pendingMerge;
+    get pendingJob() {
+      return pendingJob;
     },
     get repairingRecordingKey() {
       return repairingRecordingKey;
@@ -332,7 +345,7 @@ export function createRecordingsController(deps: RecordingsControllerDeps): Reco
     repairRecording,
     toggleIncompleteMergeSelection,
     clearMergeSelection,
-    mergeSelectedIncompleteFiles,
+    processSelectedIncompleteFiles,
     selectedQuality,
   };
 }

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -241,7 +241,7 @@
              repairingRecordingKey={recordingsController.repairingRecordingKey}
              mergingRecordingKey={recordingsController.mergingRecordingKey}
              selectedIncompleteFilenames={recordingsController.selectedIncompleteFilenames}
-             pendingMerge={recordingsController.pendingMerge}
+             pendingJob={recordingsController.pendingJob}
              onBackToChannels={backToChannels}
              onUpdateFilter={(value) => (recordingsChannelFilter = value)}
              onOpenRecordingPlayer={openRecordingPlayer}
@@ -249,8 +249,8 @@
              onToggleRecordingPin={recordingsController.toggleRecordingPin}
              onRepairRecording={recordingsController.repairRecording}
              onToggleIncompleteMergeSelection={recordingsController.toggleIncompleteMergeSelection}
-             onMergeIncompleteFiles={recordingsController.mergeSelectedIncompleteFiles}
-           />
+             onProcessIncompleteFiles={recordingsController.processSelectedIncompleteFiles}
+            />
         {/if}
       {/if}
     {/if}

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -238,6 +238,7 @@
              recordingsChannelFilter={recordingsChannelFilter}
              deletingRecordingKey={recordingsController.deletingRecordingKey}
              pinningRecordingKey={recordingsController.pinningRecordingKey}
+             repairingRecordingKey={recordingsController.repairingRecordingKey}
              mergingRecordingKey={recordingsController.mergingRecordingKey}
              selectedIncompleteFilenames={recordingsController.selectedIncompleteFilenames}
              onBackToChannels={backToChannels}
@@ -245,6 +246,7 @@
              onOpenRecordingPlayer={openRecordingPlayer}
              onRemoveRecordingFile={recordingsController.removeRecordingFile}
              onToggleRecordingPin={recordingsController.toggleRecordingPin}
+             onRepairRecording={recordingsController.repairRecording}
              onToggleIncompleteMergeSelection={recordingsController.toggleIncompleteMergeSelection}
              onMergeIncompleteFiles={recordingsController.mergeSelectedIncompleteFiles}
            />

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -241,6 +241,7 @@
              repairingRecordingKey={recordingsController.repairingRecordingKey}
              mergingRecordingKey={recordingsController.mergingRecordingKey}
              selectedIncompleteFilenames={recordingsController.selectedIncompleteFilenames}
+             pendingMerge={recordingsController.pendingMerge}
              onBackToChannels={backToChannels}
              onUpdateFilter={(value) => (recordingsChannelFilter = value)}
              onOpenRecordingPlayer={openRecordingPlayer}


### PR DESCRIPTION
## Summary
- Generalize recording processing into async jobs with shared status polling.
- Add single-file finalize support alongside multi-file merge and replace merge-specific status polling with a generic jobs endpoint.
- Update the recordings UI to switch between finalize and merge based on selection count.

## Verification
- cargo check
- cargo clippy --all-targets --all-features
- cargo test
- cargo fmt -- --check
- pnpm run verify (web)