### PR TITLE
chore(config): update Docker workflows to use Buildx and enhance caching

### DIFF
--- a/.github/workflows/docker-checks.yml
+++ b/.github/workflows/docker-checks.yml
@@ -2,6 +2,8 @@ name: Docker Checks
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  REGISTRY: ghcr.io
+  IMAGE_NAME: wandabastyle/twitch_relay
 
 on:
   pull_request:
@@ -29,11 +31,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Log in to GHCR
+        run: echo "${{ github.token }}" | docker login "$REGISTRY" -u "${{ github.actor }}" --password-stdin
+
       - name: Build Docker image
         uses: docker/build-push-action@v7
         with:
           context: .
           push: false
           tags: twitch-relay:ci
-          cache-from: type=gha
+          cache-from: |
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+            type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -25,22 +25,27 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Log in to GHCR
         run: echo "${{ github.token }}" | docker login "$REGISTRY" -u "${{ github.actor }}" --password-stdin
 
-      - name: Build image
-        run: |
-          docker build \
-            -t "$REGISTRY/$IMAGE_NAME:latest" \
-            -t "$REGISTRY/$IMAGE_NAME:${{ github.sha }}" \
-            .
-
-      - name: Push image
-        run: |
-          docker push "$REGISTRY/$IMAGE_NAME:latest"
-          docker push "$REGISTRY/$IMAGE_NAME:${{ github.sha }}"
+      - name: Build and push image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,18 +45,16 @@ FROM rust-base AS rust-cook
 COPY --from=rust-planner /build/recipe.json recipe.json
 RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
     --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git \
-    --mount=type=cache,id=cargo-target,target=/build/target \
     cargo chef cook --release --locked --recipe-path recipe.json
 
 # Stage: rust-build
 # Purpose: Build the Rust binary. Dependencies are pre-cooked from the previous stage.
-FROM rust-base AS rust-build
+FROM rust-cook AS rust-build
 
 COPY rust-toolchain.toml Cargo.toml Cargo.lock ./
 COPY src ./src
 RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
     --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git \
-    --mount=type=cache,id=cargo-target,target=/build/target \
     cargo build --release --locked \
     && cp /build/target/release/twitch-relay /build/twitch-relay
 

--- a/src/stream_proxy/session.rs
+++ b/src/stream_proxy/session.rs
@@ -76,10 +76,10 @@ struct PrewarmedEntry {
 
 /// Hard TTL - entries older than this are considered expired
 const PREWARM_TTL_SECS: u64 = 90;
-/// Validation interval - check validity every 15 minutes + jitter
-const PREWARM_VALIDATE_AFTER_SECS: u64 = 900;
+/// Validation interval - check validity every 1 hour + jitter
+const PREWARM_VALIDATE_AFTER_SECS: u64 = 3600;
 /// Maximum jitter in seconds to spread validation load
-const PREWARM_JITTER_MAX_SECS: u64 = 120;
+const PREWARM_JITTER_MAX_SECS: u64 = 300;
 const PREWARM_MAX_CHANNELS: usize = 20;
 const PREWARM_POOL_QUALITIES: [&str; 5] = ["source", "1080p60", "720p60", "480p", "360p"];
 const PREWARM_POOL_CONCURRENCY: usize = 3;
@@ -765,7 +765,7 @@ impl StreamSessionService {
 
    /// Maintenance method for live channels.
    /// - If no entry: start prewarm
-   /// - If entry age < 240s + jitter: do nothing
+   /// - If validation age < 1 hour + jitter: do nothing
    /// - If due for validation: start background validation
    pub async fn maintain_prewarm_for_live_channel(&self, channel: &str) {
       if !self.prewarm_enabled() {


### PR DESCRIPTION
- Switched Docker workflows to use Buildx for improved caching and reliability
- Updated caching strategy to use registry-based cache (\`buildcache\` tag) in addition to GHA cache
- Refactored Dockerfile by changing build stage base image from \`rust-base\` to \`rust-cook\`
- Extended prewarm validation interval from 15 minutes to 1 hour and increased jitter from 2 to 5 minutes
- Added explicit permissions (\`contents: read\`, \`packages: write\`) to publish workflow for GHCR integration