### PR TITLE
chore(release): bump to 0.6.1 and update versioning docs

### DIFF
--- a/.github/workflows/docker-checks.yml
+++ b/.github/workflows/docker-checks.yml
@@ -5,6 +5,14 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: wandabastyle/twitch_relay
 
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches:
@@ -15,6 +23,7 @@ on:
       - .dockerignore
       - Cargo.toml
       - Cargo.lock
+      - rust-toolchain.toml
       - src/**
       - web/**
   workflow_dispatch:
@@ -43,4 +52,4 @@ jobs:
           cache-from: |
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
             type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,scope=docker-pr-${{ github.event.pull_request.number || 'manual' }},mode=max

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -9,6 +9,7 @@ on:
       - .dockerignore
       - Cargo.toml
       - Cargo.lock
+      - rust-toolchain.toml
       - src/**
       - web/**
       - .github/workflows/publish-ghcr.yml
@@ -17,6 +18,10 @@ on:
 permissions:
   contents: read
   packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,11 @@ Svelte runes (`$props`, `$state`, `$effect`, `$derived`, etc.) and browser globa
 - Client-side routing via `src/lib/router/router.svelte.ts`
 - No `$app/*` imports - use router exports instead
 
-## UI DESIGN
+## VERSION BUMPING
+
+- When making bug fixes or small improvements that could reasonably constitute a patch release, bump the project version in **both** `Cargo.toml` and `web/package.json` together, and run `cargo update -p twitch-relay` to keep `Cargo.lock` in sync.
+- Only bump the minor/major version when the changeset is large enough or includes breaking changes. When in doubt, patch bump.
+- Do not leave `Cargo.toml` and `web/package.json` out of sync.
 
 - Always follow the UI design system when creating or reviewing components or pages.
 - Design System: @DESIGN.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "twitch-relay"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twitch-relay"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 description = "A relay service for Twitch streams"
 license = "MIT"
@@ -36,8 +36,8 @@ time = { version = "0.3.44", features = ["formatting", "parsing"] }
 uuid = { version = "1.10.0", features = ["v4"] }
 
 [profile.release]
-lto = "thin"
-codegen-units = 1
+lto = false
+codegen-units = 16
 panic = "abort"
 strip = "symbols"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM rust-base AS rust-cook
 
 COPY --from=rust-planner /build/recipe.json recipe.json
-RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
-    --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git \
-    cargo chef cook --release --locked --recipe-path recipe.json
+RUN cargo chef cook --release --locked --recipe-path recipe.json
 
 # Stage: rust-build
 # Purpose: Build the Rust binary. Dependencies are pre-cooked from the previous stage.
@@ -53,9 +51,7 @@ FROM rust-cook AS rust-build
 
 COPY rust-toolchain.toml Cargo.toml Cargo.lock ./
 COPY src ./src
-RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
-    --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git \
-    cargo build --release --locked \
+RUN cargo build --release --locked \
     && cp /build/target/release/twitch-relay /build/twitch-relay
 
 # Stage: runtime

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
- Bumped project version to 0.6.1 in both \`Cargo.toml\` and \`web/package.json\`, with \`Cargo.lock\` updated accordingly
- Updated Docker workflow caches to include PR numbers for better isolation in \`docker-checks.yml\`
- Removed explicit cache mounts from \`Dockerfile\`, relying solely on GitHub Actions cache mounts
- Adjusted Rust build settings: disabled LTO and increased codegen units for faster compilation
- Added version bumping guidelines to \`AGENTS.md\` to standardize release versioning practices