### PR TITLE
fix(youtube): stabilize recent feed and drain deploys

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Get current running image
         id: current
         run: |
-          CONTAINER_ID=$(docker compose ps -q app 2>/dev/null || echo "")
+          CONTAINER_ID=$(docker compose ps -q twitch-relay 2>/dev/null || echo "")
           if [ -n "$CONTAINER_ID" ]; then
             IMAGE=$(docker inspect --format='{{.Config.Image}}' "$CONTAINER_ID" 2>/dev/null || echo "")
           else
@@ -36,14 +36,28 @@ jobs:
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
           echo "Current image: $IMAGE"
 
+      - name: Create drain sentinel
+        run: |
+          docker run --rm -v twitch-relay-data:/data alpine sh -ceu 'mkdir -p /data/twitch-relay && touch /data/twitch-relay/drain.sentinel'
+
+      - name: Wait for deploy safe
+        run: |
+          echo "Waiting for deploy safe flag..."
+          while true; do
+            RESPONSE=$(curl -fsS http://127.0.0.1:18081/deployz || true)
+            if printf '%s' "$RESPONSE" | grep -Eq '"deploy_safe"[[:space:]]*:[[:space:]]*true'; then
+              echo "Deploy safe confirmed"
+              exit 0
+            fi
+            echo "Deploy not yet safe: ${RESPONSE:-unreachable}"
+            sleep 15
+          done
+
       - name: Pull latest image
-        run: docker compose pull
+        run: docker compose pull twitch-relay
 
       - name: Restart stack
-        run: docker compose up -d
-
-      - name: Show status
-        run: docker compose ps
+        run: docker compose up -d twitch-relay
 
       - name: Health check with rollback
         run: |
@@ -60,7 +74,6 @@ jobs:
 
           if [ -n "${{ steps.current.outputs.image }}" ]; then
             echo "Restoring previous image: ${{ steps.current.outputs.image }}"
-            # Update compose file to use previous image
             sed -i "s|image: .*|image: ${{ steps.current.outputs.image }}|" docker-compose.yml
             docker compose pull
             docker compose up -d
@@ -84,3 +97,8 @@ jobs:
         if: always()
         run: |
           echo "Deployment completed with status: ${{ job.status }}"
+
+      - name: Remove drain sentinel
+        if: always()
+        run: |
+          docker run --rm -v twitch-relay-data:/data alpine sh -ceu 'rm -f /data/twitch-relay/drain.sentinel'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@
 
 Use cheap subagents before spending primary model tokens.
 
+- Global OpenCode skills are available from `~/.agents/skills/`. Currently installed: `rust-best-practices` and `vercel-react-best-practices`. Use them when a task matches before falling back to ad-hoc guidance.
+
 ### Default model preference
 
 - Use cheap search/review/docs first.
@@ -32,12 +34,14 @@ Use cheap subagents before spending primary model tokens.
 
 ### Agent roles
 
-- `build` is the main coordinator and final editor.
+- `build` is the main coordinator and final decision-maker. It should primarily orchestrate work rather than implement code directly.
+- `build` must not write feature or bug-fix code directly when a suitable coding subagent can handle the implementation.
 - `plan` is the planning/review coordinator and must not edit code.
-- Subagents gather context, review, draft docs, and provide implementation support.
-- Only `build` should freely apply final risky edits.
+- Subagents gather context, review, draft docs, and should handle most code implementation.
+- For risky edits, prefer heavy coding agents before falling back to direct `build` edits.
 - Subagents may ask before edits when their role requires it.
 - Subagents must not bump versions.
+- If `build` edits code directly, it must explicitly state why delegation was not used.
 
 ### Subagents
 
@@ -56,22 +60,27 @@ Use cheap subagents before spending primary model tokens.
 2. `cheap-review` checks likely risks or obvious bugs.
 3. `cheap-codex` or `mid-coder` gives focused implementation advice if needed.
 4. `mid-kimi` analyzes the implementation path when Kimi-style reasoning is useful.
-5. `build` applies the final patch.
-6. `heavy-codex` or `heavy-reason` is used only if the normal path gets stuck.
-7. `plan` or `build` reviews the final result.
+5. A coding subagent should produce the implementation patch or exact edit plan before `build` changes code.
+6. `build` should limit itself to integrating that work, handling version bumps and lockfiles, and running verification.
+7. `build` edits directly only when subagent delegation is not practical, and must say why.
+8. `heavy-codex` or `heavy-reason` is used only if the normal path gets stuck.
+9. `plan` or `build` reviews the final result.
 
 Do not use expensive primary models for simple grep, file lookup, config reading, docs drafts, or first-pass review.
 
-The primary model should make final decisions and apply risky edits.
+The primary model should make final decisions and coordinate implementation.
 Cheap subagents should gather context and handle low-risk first-pass reasoning.
 
 ## CHANGE / EDIT MODE
 
 - Never implement features yourself when possible - use sub-agents!
+- The primary model should mainly orchestrate implementation; delegate coding work to sub-agents whenever feasible.
+- Before any non-trivial code edit, delegate implementation or patch design to a coding subagent first.
 - Identify changes from the plan that can be implemented in parallel, and use sub-agents to implement the features efficiently
 - When using sub-agents to implement features, act as a coordinator only
 - Use the best model for the task - premium models for complex tasks (like coding) and mid-tier models for simpler tasks, like documentation
 - After completing features (large or small), always run commands like lint, type check and next build to check code quality
+- The primary model may edit code directly only for version bumps, lockfile updates, conflict resolution after subagent work, very small mechanical fixes discovered during verification, or when delegation failed or is unavailable.
 
 ## DATABASE SCHEMA CHANGES
 
@@ -124,12 +133,12 @@ The project uses `--deny-warnings` with all lint categories enabled:
 **Never suppress warnings with `eslint-disable` comments** - always fix the underlying issue.
 
 ### Global Configuration
-Svelte runes (`$props`, `$state`, `$effect`, `$derived`, etc.) and browser globals (`window`, `document`, `fetch`, etc.) are configured in `.oxlintrc.json`.
+Oxlint uses `web/.oxlintrc.json` with browser and ES2024 env settings; do not assume any separate manual globals list is maintained there.
 
-### Migration Notes
-- Migrated from SvelteKit to Vite+ + Svelte-only
-- Client-side routing via `src/lib/router/router.svelte.ts`
-- No `$app/*` imports - use router exports instead
+### Frontend Notes
+- The frontend stack is React 19 + Vite+ + TypeScript. See `@DESIGN.md` for the current design system and stack details.
+- Use React components in `web/src/components/`.
+- Styling uses plain CSS with CSS custom properties. Do not introduce utility-framework or CSS-in-JS assumptions.
 
 ## VERSION BUMPING
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "twitch-relay"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twitch-relay"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 description = "A relay service for Twitch streams"
 license = "MIT"

--- a/src/app.rs
+++ b/src/app.rs
@@ -84,7 +84,16 @@ struct RouteModuleContext<'a> {
 /// Build route modules for the application.
 fn build_route_modules(
    ctx: &RouteModuleContext<'_>,
-) -> (Router, Router, Router, Router, Router, Router, Router) {
+) -> (
+   Router,
+   Router,
+   Router,
+   Router,
+   Router,
+   Router,
+   Router,
+   Router,
+) {
    let twitch_state = twitch_auth::TwitchAuthState {
       auth:    ctx.auth_config.clone(),
       twitch:  ctx.twitch_auth_service.clone(),
@@ -107,7 +116,10 @@ fn build_route_modules(
       catalog: ctx.catalog_service.clone(),
    };
 
+   let health_routes = routes::health_routes(recording_state.clone());
+
    (
+      health_routes,
       routes::channel_routes(ctx.channel_state.clone(), ctx.auth_config.clone()),
       routes::live_status_routes(live_status_state, ctx.auth_config.clone()),
       routes::watch_routes(ctx.protected_state.clone(), ctx.auth_config.clone()),
@@ -179,6 +191,7 @@ pub fn build_router(config: &AppConfig, access_code_hash: String) -> Result<Rout
    );
 
    let (
+      health_routes,
       channel_routes,
       live_status_routes,
       watch_routes,
@@ -210,7 +223,7 @@ pub fn build_router(config: &AppConfig, access_code_hash: String) -> Result<Rout
    let youtube_routes = youtube::build_routes_with_client(auth_config, config, youtube_client);
 
    let router = Router::new()
-      .merge(routes::health_routes())
+      .merge(health_routes)
       .merge(auth_routes)
       .merge(channel_routes)
       .merge(live_status_routes)

--- a/src/invidious.rs
+++ b/src/invidious.rs
@@ -38,6 +38,7 @@ use crate::{
 };
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const RECENT_VIDEOS_MAX_RESULTS: u32 = 40;
 const AVATAR_CACHE_TTL_SECS: u64 = 86400; // 24 hours
 const DESCRIPTION_CACHE_TTL_SECS: u64 = 86400; // 24 hours
 const FALLBACK_FETCH_CONCURRENCY: usize = 3;
@@ -749,8 +750,11 @@ impl InvidiousClient {
       &self,
       max_results: Option<u32>,
    ) -> Result<Vec<YoutubeVideo>, AppError> {
-      let max = max_results.unwrap_or(25).min(40);
-      let url = format!("{}/api/v1/auth/feed?max_results={}", self.base_url, max);
+      let max = max_results.unwrap_or(25).min(RECENT_VIDEOS_MAX_RESULTS);
+      let url = format!(
+         "{}/api/v1/auth/feed?max_results={}",
+         self.base_url, RECENT_VIDEOS_MAX_RESULTS
+      );
 
       let response = self
          .with_basic_auth(self.http.get(&url))
@@ -808,7 +812,17 @@ impl InvidiousClient {
             let fallback_durations = build_fallback_duration_map(fallback_results);
             apply_fallback_durations(&mut videos, &fallback_durations);
 
-            videos.sort_by_key(|video| std::cmp::Reverse(video.published));
+            videos.sort_by(|left, right| {
+               right
+                  .published
+                  .cmp(&left.published)
+                  .then_with(|| left.video_id.cmp(&right.video_id))
+            });
+
+            let mut seen_video_ids = HashSet::new();
+            videos.retain(|video| seen_video_ids.insert(video.video_id.clone()));
+
+            videos.truncate(max as usize);
             Ok(videos)
          },
          status if status.as_u16() == 401 => Err(AppError::InvidiousAuthFailed),

--- a/src/recording/service.rs
+++ b/src/recording/service.rs
@@ -1,5 +1,8 @@
 use std::{
-   collections::HashMap,
+   collections::{
+      HashMap,
+      HashSet,
+   },
    fs,
    path::{
       Path,
@@ -79,6 +82,7 @@ pub struct RecordingService {
    chapter_min_gap_secs:         u64,
    chapter_change_confirmations: u64,
    active:                       Arc<RwLock<HashMap<String, ActiveProcess>>>,
+   post_processing:              Arc<RwLock<HashSet<String>>>,
 }
 
 impl RecordingService {
@@ -101,6 +105,7 @@ impl RecordingService {
          chapter_min_gap_secs: processing.chapter_min_gap_secs,
          chapter_change_confirmations: processing.chapter_change_confirmations,
          active: Arc::new(RwLock::new(HashMap::new())),
+         post_processing: Arc::new(RwLock::new(HashSet::new())),
       };
       service.ensure_directories()?;
       service.cleanup_startup_tmp()?;
@@ -115,6 +120,10 @@ impl RecordingService {
       } else {
          Err(RecordingError::InvalidQuality)
       }
+   }
+
+   pub fn is_drain_active() -> bool {
+      crate::storage::paths::drain_sentinel_path().is_some_and(|path| path.exists())
    }
 
    /// Convert a validated quality into the Streamlink recording argument with
@@ -134,6 +143,10 @@ impl RecordingService {
       mode: RecordingMode,
       stream_title: Option<&str>,
    ) -> Result<ActiveRecording, RecordingError> {
+      if Self::is_drain_active() {
+         return Err(RecordingError::DrainModeActive);
+      }
+
       let channel_login =
          normalize_channel_login(channel_login).map_err(RecordingError::InvalidChannelLogin)?;
       let quality = Self::validate_quality(quality)?;
@@ -228,47 +241,63 @@ impl RecordingService {
 
       let channel_login =
          normalize_channel_login(channel_login).map_err(RecordingError::InvalidChannelLogin)?;
-      let mut process = {
-         let mut active = self.active.write().await;
-         active.remove(&channel_login)
+
+      {
+         let mut post_processing = self.post_processing.write().await;
+         post_processing.insert(channel_login.clone());
       }
-      .ok_or(RecordingError::NotActive)?;
 
-      let _ = process.child.kill().await;
-      let _ = process.child.wait().await;
+      let stop_result = async {
+         let mut process = {
+            let mut active = self.active.write().await;
+            active.remove(&channel_login)
+         }
+         .ok_or(RecordingError::NotActive)?;
 
-      let output_path = PathBuf::from(&process.metadata.output_path);
-      if output_path.exists() {
-         let final_path = build_completed_recording_path(
-            &self.channel_bucket_dir("completed", &channel_login),
-            &channel_login,
-            &process.metadata,
-            process.stream_title.as_deref(),
-         );
-         move_file_if_exists(&output_path, &final_path);
-         tracing::info!(from = %output_path.display(), to = %final_path.display(), "recording moved to completed");
-         write_playback_assets(
-            &channel_login,
-            &final_path,
-            &process.metadata,
-            &process.chapter_events,
-            &self.recordings_dir,
-            &self.ffmpeg_path,
-         )
-         .await;
-         self
-            .write_nfo_if_enabled(
+         let _ = process.child.kill().await;
+         let _ = process.child.wait().await;
+
+         let output_path = PathBuf::from(&process.metadata.output_path);
+         if output_path.exists() {
+            let final_path = build_completed_recording_path(
+               &self.channel_bucket_dir("completed", &channel_login),
+               &channel_login,
+               &process.metadata,
+               process.stream_title.as_deref(),
+            );
+            move_file_if_exists(&output_path, &final_path);
+            tracing::info!(from = %output_path.display(), to = %final_path.display(), "recording moved to completed");
+            write_playback_assets(
                &channel_login,
                &final_path,
                &process.metadata,
-               process.stream_title.as_deref(),
+               &process.chapter_events,
+               &self.recordings_dir,
+               &self.ffmpeg_path,
             )
             .await;
-         self.prune_completed_for_channel(&channel_login);
+            self
+               .write_nfo_if_enabled(
+                  &channel_login,
+                  &final_path,
+                  &process.metadata,
+                  process.stream_title.as_deref(),
+               )
+               .await;
+            self.prune_completed_for_channel(&channel_login);
+         }
+
+         tracing::info!(channel = %channel_login, "recording stopped");
+         Ok(process.metadata)
+      }
+      .await;
+
+      {
+         let mut post_processing = self.post_processing.write().await;
+         post_processing.remove(&channel_login);
       }
 
-      tracing::info!(channel = %channel_login, "recording stopped");
-      Ok(process.metadata)
+      stop_result
    }
 
    /// Get list of active recordings.
@@ -290,6 +319,14 @@ impl RecordingService {
       active
          .get(&channel_login.trim().to_ascii_lowercase())
          .map(|p| p.metadata.clone())
+   }
+
+   pub async fn post_processing_channels(&self) -> Vec<String> {
+      let post_processing = self.post_processing.read().await;
+      let mut channels: Vec<String> = post_processing.iter().cloned().collect();
+      drop(post_processing);
+      channels.sort();
+      channels
    }
 
    /// Get overview of recordings (active, completed, incomplete).

--- a/src/recording/types.rs
+++ b/src/recording/types.rs
@@ -11,6 +11,8 @@ use thiserror::Error;
 pub enum RecordingError {
    #[error("invalid quality")]
    InvalidQuality,
+   #[error("deploy drain active")]
+   DrainModeActive,
    #[error("recording already active")]
    AlreadyActive,
    #[error("recording not active")]

--- a/src/recording_scheduler.rs
+++ b/src/recording_scheduler.rs
@@ -38,6 +38,10 @@ impl RecordingScheduler {
          loop {
             tick.tick().await;
 
+            if RecordingService::is_drain_active() {
+               continue;
+            }
+
             let rules = match recording_rules::load_rules() {
                Ok(rules) => rules,
                Err(error) => {

--- a/src/routes/health.rs
+++ b/src/routes/health.rs
@@ -1,9 +1,20 @@
 use axum::{
    Json,
    Router,
+   extract::State,
    routing::get,
 };
 use serde::Serialize;
+
+use crate::{
+   recording::{
+      ActiveRecording,
+      RecordingJobKind,
+      RecordingJobStatus,
+   },
+   routes::recordings::RecordingState,
+   storage::paths::drain_sentinel_path,
+};
 
 pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -18,11 +29,33 @@ pub struct VersionResponse<'a> {
    pub version: &'a str,
 }
 
-pub fn health_routes() -> Router {
+#[derive(Debug, Serialize)]
+pub struct DeployPendingJob {
+   pub job_id:        String,
+   pub channel_login: String,
+   pub kind:          RecordingJobKind,
+   pub status:        RecordingJobStatus,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DeployInfo {
+   pub drain_active:           bool,
+   pub deploy_safe:            bool,
+   pub active_recording_count: usize,
+   pub processing_count:       usize,
+   pub running_job_count:      usize,
+   pub active_recordings:      Vec<ActiveRecording>,
+   pub processing_channels:    Vec<String>,
+   pub pending_jobs:           Vec<DeployPendingJob>,
+}
+
+pub fn health_routes(state: RecordingState) -> Router {
    Router::new()
       .route("/healthz", get(healthz))
       .route("/readyz", get(readyz))
       .route("/api/version", get(get_version))
+      .route("/deployz", get(get_deploy_info))
+      .with_state(state)
 }
 
 async fn healthz() -> Json<ProbeResponse<'static>> {
@@ -42,5 +75,61 @@ async fn readyz() -> Json<ProbeResponse<'static>> {
 async fn get_version() -> Json<VersionResponse<'static>> {
    Json(VersionResponse {
       version: APP_VERSION,
+   })
+}
+
+/// Public read‑only endpoint reporting deploy‑drain status and current
+/// activity.
+async fn get_deploy_info(State(state): State<RecordingState>) -> Json<DeployInfo> {
+   let drain_active = drain_sentinel_path().is_some_and(|path| path.exists());
+   let active_recordings = state.service.active_recordings().await;
+   let mut processing_channels = state.service.post_processing_channels().await;
+
+   {
+      let guard = state.active_processing_guard.read().await;
+      for channel in &*guard {
+         if !processing_channels.contains(channel) {
+            processing_channels.push(channel.clone());
+         }
+      }
+   }
+   processing_channels.sort();
+
+   let pending_jobs = {
+      let jobs = state.recording_jobs.read().await;
+      let mut pending_jobs: Vec<DeployPendingJob> = jobs
+         .values()
+         .filter(|job| {
+            matches!(
+               job.status,
+               RecordingJobStatus::Queued | RecordingJobStatus::Running
+            )
+         })
+         .map(|job| {
+            DeployPendingJob {
+               job_id:        job.job_id.clone(),
+               channel_login: job.channel_login.clone(),
+               kind:          job.kind,
+               status:        job.status,
+            }
+         })
+         .collect();
+      pending_jobs.sort_by(|left, right| left.job_id.cmp(&right.job_id));
+      pending_jobs
+   };
+
+   let active_recording_count = active_recordings.len();
+   let processing_count = processing_channels.len();
+   let running_job_count = pending_jobs.len();
+
+   Json(DeployInfo {
+      drain_active,
+      deploy_safe: active_recording_count == 0 && processing_count == 0 && running_job_count == 0,
+      active_recording_count,
+      processing_count,
+      running_job_count,
+      active_recordings,
+      processing_channels,
+      pending_jobs,
    })
 }

--- a/src/routes/health.rs
+++ b/src/routes/health.rs
@@ -95,9 +95,9 @@ async fn get_deploy_info(State(state): State<RecordingState>) -> Json<DeployInfo
    }
    processing_channels.sort();
 
-   let pending_jobs = {
+   let mut pending_jobs = {
       let jobs = state.recording_jobs.read().await;
-      let mut pending_jobs: Vec<DeployPendingJob> = jobs
+      jobs
          .values()
          .filter(|job| {
             matches!(
@@ -113,10 +113,9 @@ async fn get_deploy_info(State(state): State<RecordingState>) -> Json<DeployInfo
                status:        job.status,
             }
          })
-         .collect();
-      pending_jobs.sort_by(|left, right| left.job_id.cmp(&right.job_id));
-      pending_jobs
+         .collect::<Vec<_>>()
    };
+   pending_jobs.sort_by(|left, right| left.job_id.cmp(&right.job_id));
 
    let active_recording_count = active_recordings.len();
    let processing_count = processing_channels.len();

--- a/src/routes/recordings/mod.rs
+++ b/src/routes/recordings/mod.rs
@@ -209,6 +209,7 @@ pub const fn classify_recording_error(
          (StatusCode::BAD_REQUEST, "channel login cannot be empty")
       },
       RecordingError::InvalidQuality => (StatusCode::BAD_REQUEST, "invalid quality"),
+      RecordingError::DrainModeActive => (StatusCode::CONFLICT, "deployment drain in progress"),
       RecordingError::AlreadyActive => (StatusCode::CONFLICT, "recording already active"),
       RecordingError::NotActive => (StatusCode::NOT_FOUND, "recording not active"),
       RecordingError::FileNotFound => (StatusCode::NOT_FOUND, "recording file not found"),
@@ -256,6 +257,13 @@ mod tests {
       let (status, message) = classify_recording_error(&RecordingError::AlreadyActive);
       assert_eq!(status, StatusCode::CONFLICT);
       assert_eq!(message, "recording already active");
+   }
+
+   #[test]
+   fn classify_recording_error_maps_drain_mode_active() {
+      let (status, message) = classify_recording_error(&RecordingError::DrainModeActive);
+      assert_eq!(status, StatusCode::CONFLICT);
+      assert_eq!(message, "deployment drain in progress");
    }
 
    #[test]

--- a/src/storage/paths.rs
+++ b/src/storage/paths.rs
@@ -26,6 +26,13 @@ pub fn data_file_path(filename: &str) -> Option<PathBuf> {
    Some(dir.join(filename))
 }
 
+/// Persistent deploy‑drain sentinel file.
+///
+/// Presence of this file signals that new recordings must be blocked.
+pub fn drain_sentinel_path() -> Option<PathBuf> {
+   data_file_path("drain.sentinel")
+}
+
 /// Path to the channels.toml file.
 pub fn channels_path() -> Option<PathBuf> {
    data_file_path("channels.toml")

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/src/pages/you-tube-recent-page.tsx
+++ b/web/src/pages/you-tube-recent-page.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type ReactElement } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react';
 import { getYouTubeRecentVideos, type YoutubeVideo } from '../api-client';
 import { getYouTubeThumbnailUrl } from '../api-client/youtube-progress';
 import {
@@ -20,23 +20,40 @@ const NO_VIDEOS_DESC = 'Recent videos from your subscriptions will appear here.'
 const NO_VIDEOS_TITLE = 'No recent videos found';
 const RETURN_URL = '/youtube/recent';
 const SKELETON_COUNT = 6;
+const INITIAL_REQUEST_ID = 0;
+const REQUEST_ID_INCREMENT = 1;
 
 export const YouTubeRecentPage = (): ReactElement => {
   const [videos, setVideos] = useState<readonly YoutubeVideo[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const latestRequestIdRef = useRef(INITIAL_REQUEST_ID);
 
   const loadRecentVideos = useCallback(async (): Promise<void> => {
+    latestRequestIdRef.current += REQUEST_ID_INCREMENT;
+    const requestId = latestRequestIdRef.current;
+
     setIsLoading(true);
     setError(null);
     try {
       const data = await getYouTubeRecentVideos(DEFAULT_MAX_RESULTS);
+
+      if (requestId !== latestRequestIdRef.current) {
+        return;
+      }
+
       setVideos(data);
     } catch (error_) {
+      if (requestId !== latestRequestIdRef.current) {
+        return;
+      }
+
       const errorMessage = error_ instanceof Error ? error_.message : FAILED_TO_LOAD;
       setError(errorMessage);
     } finally {
-      setIsLoading(false);
+      if (requestId === latestRequestIdRef.current) {
+        setIsLoading(false);
+      }
     }
   }, []);
 


### PR DESCRIPTION
- Stabilizes the YouTube recent page by fetching a fuller upstream feed window, sorting deterministically, deduplicating repeated videos, and ignoring stale frontend responses.
- Adds a public `\`/deployz\`` endpoint that reports deploy drain state, active recordings, post-processing channels, and queued/running recording jobs.
- Blocks new recording starts while a deploy drain sentinel is active and makes the recording scheduler skip auto-starts during drain mode.
- Updates the production deploy workflow to create the drain sentinel, wait until `\`deploy_safe\`` is true, deploy the new image, and always remove the sentinel afterward.
- Keeps the app version at `\`0.6.4\`` and retains the earlier `\`AGENTS.md\`` delegation guidance updates included on this branch.