### PR TITLE
refactor(chat): expose imperative handle for programmatic emote insertion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,17 +20,7 @@
 
 ## OPENCODE AGENT DELEGATION
 
-Use cheap subagents before spending primary model tokens.
-
 - Global OpenCode skills are available from `~/.agents/skills/`. Currently installed: `rust-best-practices` and `vercel-react-best-practices`. Use them when a task matches before falling back to ad-hoc guidance.
-
-### Default model preference
-
-- Use cheap search/review/docs first.
-- Use Kimi for normal build work.
-- Use OpenAI mini/fast for cheap focused reasoning.
-- Use OpenAI Codex only as fallback or difficult final review.
-- Use heavy reasoning only for hard architecture/debugging decisions.
 
 ### Agent roles
 
@@ -44,34 +34,6 @@ Use cheap subagents before spending primary model tokens.
 - If `build` edits code directly, it must explicitly state why delegation was not used.
 
 ### Subagents
-
-- Use `cheap-grep` for file discovery, symbol lookup, config search, and codebase summaries.
-- Use `cheap-review` for first-pass bug checks, obvious lint issues, TODO discovery, and simple refactor review.
-- Use `cheap-docs` for README, comments, changelog, and documentation drafts.
-- Use `cheap-codex` for small focused patch ideas, local implementation sketches, and narrow code reasoning.
-- Use `mid-coder` when cheap agents are not enough, but full primary `build` is still overkill.
-- Use `mid-kimi` for focused Kimi-based implementation analysis before final edits.
-- Use `heavy-codex` only when Kimi gets stuck or the patch needs OpenAI Codex review.
-- Use `heavy-reason` only for hard architecture/debugging decisions, not routine coding.
-
-### Recommended flow
-
-1. `cheap-grep` locates the relevant files and summarizes the current implementation.
-2. `cheap-review` checks likely risks or obvious bugs.
-3. `cheap-codex` or `mid-coder` gives focused implementation advice if needed.
-4. `mid-kimi` analyzes the implementation path when Kimi-style reasoning is useful.
-5. A coding subagent should produce the implementation patch or exact edit plan before `build` changes code.
-6. `build` should limit itself to integrating that work, handling version bumps and lockfiles, and running verification.
-7. `build` edits directly only when subagent delegation is not practical, and must say why.
-8. `heavy-codex` or `heavy-reason` is used only if the normal path gets stuck.
-9. `plan` or `build` reviews the final result.
-
-Do not use expensive primary models for simple grep, file lookup, config reading, docs drafts, or first-pass review.
-
-The primary model should make final decisions and coordinate implementation.
-Cheap subagents should gather context and handle low-risk first-pass reasoning.
-
-## CHANGE / EDIT MODE
 
 - Never implement features yourself when possible - use sub-agents!
 - The primary model should mainly orchestrate implementation; delegate coding work to sub-agents whenever feasible.

--- a/web/src/components/watch/chat-composer.tsx
+++ b/web/src/components/watch/chat-composer.tsx
@@ -1,9 +1,20 @@
-import { useCallback, useEffect, useRef, type ReactElement } from 'react';
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  type ReactElement,
+  type Ref,
+} from 'react';
 import type { EmoteItem } from '../../api-client';
 import { useChatComposer } from '../../hooks/watch/use-chat-composer';
 
 const TAB_INDEX_DISABLED = -1;
 const TAB_INDEX_ENABLED = 0;
+
+export interface ChatComposerHandle {
+  insertEmote: (code: string) => void;
+}
 
 interface ChatComposerProps {
   availableEmotes: EmoteItem[];
@@ -11,112 +22,118 @@ interface ChatComposerProps {
   onSubmit: (text: string) => void;
 }
 
-export const ChatComposer = ({
-  availableEmotes,
-  disabled = false,
-  onSubmit,
-}: ChatComposerProps): ReactElement => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const {
-    composerRef,
-    suggestionsOpen,
-    suggestionItems,
-    suggestionIndex,
-    previewOpen,
-    previewUrl,
-    previewPosition,
-    handleInput,
-    handlePaste,
-    handleKeydown,
-    handleSuggestionClick,
-    closeSuggestions,
-    clearPreview,
-  } = useChatComposer({
-    availableEmotes,
-    disabled,
-    onSubmit,
-  });
+export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(
+  (props: ChatComposerProps, ref: Ref<ChatComposerHandle>): ReactElement => {
+    const { availableEmotes, disabled = false, onSubmit } = props;
+    const {
+      composerRef,
+      suggestionsOpen,
+      suggestionItems,
+      suggestionIndex,
+      previewOpen,
+      previewUrl,
+      previewPosition,
+      handleInput,
+      handlePaste,
+      handleKeydown,
+      handleSuggestionClick,
+      closeSuggestions,
+      clearPreview,
+      insertEmote,
+    } = useChatComposer({
+      availableEmotes,
+      disabled,
+      onSubmit,
+    });
 
-  // Handle click outside to close suggestions
-  useEffect(() => {
-    const handleDocumentClick = (event: MouseEvent): void => {
-      if (!suggestionsOpen) {
-        return;
-      }
-      const { target } = event;
-      if (!target) {
-        return;
-      }
-      const clickedInsideComposer =
-        target instanceof HTMLElement && target.closest('.ui-chat-composer') !== null;
-      if (!clickedInsideComposer) {
-        closeSuggestions();
-      }
-    };
+    // Expose imperative handle for emote insertion
+    useImperativeHandle(ref, () => ({
+      insertEmote,
+    }));
 
-    document.addEventListener('click', handleDocumentClick);
-    return (): void => {
-      document.removeEventListener('click', handleDocumentClick);
-    };
-  }, [suggestionsOpen, closeSuggestions]);
+    // Handle click outside to close suggestions
+    useEffect(() => {
+      const handleDocumentClick = (event: MouseEvent): void => {
+        if (!suggestionsOpen) {
+          return;
+        }
+        const { target } = event;
+        if (!target) {
+          return;
+        }
+        const clickedInsideComposer =
+          target instanceof HTMLElement && target.closest('.ui-chat-composer') !== null;
+        if (!clickedInsideComposer) {
+          closeSuggestions();
+        }
+      };
 
-  // Cleanup preview timer on unmount
-  useEffect(
-    () => (): void => {
-      clearPreview();
-    },
-    [clearPreview],
-  );
+      document.addEventListener('click', handleDocumentClick);
+      return (): void => {
+        document.removeEventListener('click', handleDocumentClick);
+      };
+    }, [suggestionsOpen, closeSuggestions]);
 
-  const onSuggestionMouseDown = useCallback(
-    (item: EmoteItem) =>
-      (event: React.MouseEvent): void => {
-        event.preventDefault();
-        handleSuggestionClick(item);
+    // Cleanup preview timer on unmount
+    useEffect(
+      () => (): void => {
+        clearPreview();
       },
-    [handleSuggestionClick],
-  );
+      [clearPreview],
+    );
 
-  return (
-    <div ref={containerRef} className="ui-chat-composer">
-      {previewOpen && (
+    const onSuggestionMouseDown = useCallback(
+      (item: EmoteItem) =>
+        (event: React.MouseEvent): void => {
+          event.preventDefault();
+          handleSuggestionClick(item);
+        },
+      [handleSuggestionClick],
+    );
+
+    return (
+      <div className="ui-chat-composer">
+        {previewOpen && (
+          <div
+            className="ui-chat-emote-preview visible"
+            style={{
+              backgroundImage: `url('${previewUrl}')`,
+              left: `${previewPosition.left}px`,
+              top: `${previewPosition.top}px`,
+            }}
+          />
+        )}
         <div
-          className="ui-chat-emote-preview visible"
-          style={{
-            backgroundImage: `url('${previewUrl}')`,
-            left: `${previewPosition.left}px`,
-            top: `${previewPosition.top}px`,
-          }}
+          ref={composerRef}
+          className={`ui-chat-composer-input ${disabled ? 'is-disabled' : ''}`}
+          contentEditable={!disabled}
+          role="textbox"
+          tabIndex={disabled ? TAB_INDEX_DISABLED : TAB_INDEX_ENABLED}
+          aria-label="Send a message"
+          data-placeholder="Send a message"
+          aria-disabled={disabled}
+          onInput={handleInput}
+          onPaste={handlePaste}
+          onKeyDown={handleKeydown}
         />
-      )}
-      <div
-        ref={composerRef}
-        className={`ui-chat-composer-input ${disabled ? 'is-disabled' : ''}`}
-        contentEditable={!disabled}
-        role="textbox"
-        tabIndex={disabled ? TAB_INDEX_DISABLED : TAB_INDEX_ENABLED}
-        aria-label="Send a message"
-        data-placeholder="Send a message"
-        aria-disabled={disabled}
-        onInput={handleInput}
-        onPaste={handlePaste}
-        onKeyDown={handleKeydown}
-      />
-      {suggestionsOpen && (
-        <div className="ui-chat-suggestions ui-hide-scrollbar">
-          {suggestionItems.map((item, index) => (
-            <button
-              key={item.id}
-              type="button"
-              className={`ui-chat-suggestion-item ${index === suggestionIndex ? 'active' : ''}`}
-              onMouseDown={onSuggestionMouseDown(item)}
-            >
-              <img src={item.image_url} alt={item.code} loading="lazy" decoding="async" />
-              <span>{item.code}</span>
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-};
+        {suggestionsOpen && (
+          <div className="ui-chat-suggestions ui-hide-scrollbar">
+            {suggestionItems.map((item, index) => (
+              <button
+                key={item.id}
+                type="button"
+                className={`ui-chat-suggestion-item ${index === suggestionIndex ? 'active' : ''}`}
+                onMouseDown={onSuggestionMouseDown(item)}
+              >
+                <img src={item.image_url} alt={item.code} loading="lazy" decoding="async" />
+                <span>{item.code}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+ChatComposer.displayName = 'ChatComposer';

--- a/web/src/components/watch/chat.tsx
+++ b/web/src/components/watch/chat.tsx
@@ -50,11 +50,6 @@ export const Chat = ({
       <div className="chat-header">
         <strong>Chat</strong>
         <span className={chatConnected ? 'status-live' : undefined}>{chatStatus}</span>
-        {unreadChatCount > UNREAD_COUNT_ZERO && (
-          <button type="button" className="unread-badge" onClick={jumpToLatest}>
-            {formatUnreadMessage(unreadChatCount)}
-          </button>
-        )}
       </div>
 
       {chatAvailable ? (
@@ -97,6 +92,11 @@ export const Chat = ({
               </div>
             ))}
           </div>
+          {unreadChatCount > UNREAD_COUNT_ZERO && (
+            <button type="button" className="unread-pill" onClick={jumpToLatest}>
+              {formatUnreadMessage(unreadChatCount)}
+            </button>
+          )}
           <div className="chat-form">
             <EmotePicker availableEmotes={localEmotes} onSelect={handleEmoteSelect} />
 

--- a/web/src/components/watch/chat.tsx
+++ b/web/src/components/watch/chat.tsx
@@ -1,8 +1,8 @@
-import type { ReactElement } from 'react';
+import { useCallback, useRef, type ReactElement } from 'react';
 import type { EmoteItem } from '../../api-client';
 import { emoteUrl, formatUnreadMessage } from '../../hooks/watch/chat-utils';
 import { useChat } from '../../hooks/watch/use-chat';
-import { ChatComposer } from './chat-composer';
+import { ChatComposer, type ChatComposerHandle } from './chat-composer';
 import { EmotePicker } from './emote-picker';
 
 const CHAT_EMPTY_LENGTH = 0;
@@ -22,6 +22,7 @@ export const Chat = ({
   availableEmotes = [],
   onStatusChange,
 }: ChatProps): ReactElement => {
+  const composerRef = useRef<ChatComposerHandle>(null);
   const {
     chatMessagesRef,
     chatMessages,
@@ -30,17 +31,19 @@ export const Chat = ({
     chatSending,
     unreadChatCount,
     localEmotes,
-    emotesLoaded: _emotesLoaded,
     handleScroll,
     jumpToLatest,
     sendMessage,
-    onComposerSelect,
   } = useChat({
     channelLogin,
     chatAvailable,
     initialEmotes: availableEmotes,
     onStatusChange,
   });
+
+  const handleEmoteSelect = useCallback((code: string): void => {
+    composerRef.current?.insertEmote(code);
+  }, []);
 
   return (
     <div className="chat-panel">
@@ -95,9 +98,10 @@ export const Chat = ({
             ))}
           </div>
           <div className="chat-form">
-            <EmotePicker availableEmotes={localEmotes} onSelect={onComposerSelect} />
+            <EmotePicker availableEmotes={localEmotes} onSelect={handleEmoteSelect} />
 
             <ChatComposer
+              ref={composerRef}
               availableEmotes={localEmotes}
               disabled={chatSending}
               onSubmit={(text) => {

--- a/web/src/hooks/watch/chat-composer-cursor.ts
+++ b/web/src/hooks/watch/chat-composer-cursor.ts
@@ -26,6 +26,20 @@ export const walkToCursorTarget = (node: Node, position: number, state: WalkStat
     return false;
   }
 
+  // Handle <br> elements - represent as single newline character
+  if (node.nodeType === Node.ELEMENT_NODE && node instanceof HTMLBRElement) {
+    if (state.currentPos + ONE >= position) {
+      // Cursor should be at this <br> position
+      const parent = node.parentNode;
+      const nodeIndex = parent === null ? ZERO : [...parent.childNodes].indexOf(node);
+      state.targetNode = parent;
+      state.targetOffset = nodeIndex;
+      return true;
+    }
+    state.currentPos += ONE;
+    return false;
+  }
+
   // Handle emote wrapper nodes - count data-code length from child img
   if (
     node.nodeType === Node.ELEMENT_NODE &&
@@ -109,6 +123,7 @@ export const getRangeTextLength = (options: GetRangeTextLengthOptions): number =
 
   // Walk nodes and count text length
   // For emote images, count data-code.length instead of 0 (textContent returns 0 for images)
+  // For <br> elements, count as 1 (newline character)
   let length = ZERO;
   // Use numeric addition instead of bitwise OR to satisfy lint rules
   const nodeFilter = NodeFilter.SHOW_ELEMENT + NodeFilter.SHOW_TEXT;
@@ -117,13 +132,15 @@ export const getRangeTextLength = (options: GetRangeTextLengthOptions): number =
     const walkerNode = walker.currentNode;
     if (walkerNode.nodeType === Node.TEXT_NODE) {
       length += walkerNode.textContent?.length ?? ZERO;
-    } else if (
-      walkerNode.nodeType === Node.ELEMENT_NODE &&
-      walkerNode instanceof HTMLImageElement
-    ) {
-      const { code } = walkerNode.dataset;
-      if (code !== undefined && code !== '') {
-        length += code.length;
+    } else if (walkerNode.nodeType === Node.ELEMENT_NODE) {
+      if (walkerNode instanceof HTMLImageElement) {
+        const { code } = walkerNode.dataset;
+        if (code !== undefined && code !== '') {
+          length += code.length;
+        }
+      } else if (walkerNode instanceof HTMLBRElement) {
+        // Count <br> as single newline character
+        length += ONE;
       }
     }
   }

--- a/web/src/hooks/watch/chat-composer-emotes.ts
+++ b/web/src/hooks/watch/chat-composer-emotes.ts
@@ -2,6 +2,10 @@ import type { EmoteChip } from './use-chat-composer';
 
 const NBSP = '\u00A0';
 const ZERO = 0;
+const ONE = 1;
+const BR_TAG = 'br';
+const NEWLINE_CHAR = '\n';
+const SPACE_CHAR = ' ';
 
 export interface CreateEmoteImageElementOptions {
   code: string;
@@ -48,6 +52,21 @@ export interface RenderComposerContentOptions {
   createEmoteElement: (code: string, imageUrl: string) => HTMLSpanElement;
 }
 
+const appendTextWithNewlines = (
+  element: HTMLDivElement,
+  text: string,
+): void => {
+  const lines = text.split(NEWLINE_CHAR);
+  for (let index = ZERO; index < lines.length; index += ONE) {
+    // Use NBSP to make trailing spaces visible in contenteditable
+    element.append(document.createTextNode(lines[index].replaceAll(SPACE_CHAR, NBSP)));
+    // Add <br> for all but the last line
+    if (index < lines.length - ONE) {
+      element.append(document.createElement(BR_TAG));
+    }
+  }
+};
+
 export const renderComposerContent = (options: RenderComposerContentOptions): void => {
   const { composerElement, textValue, chips, createEmoteElement } = options;
   if (composerElement === null) {
@@ -60,13 +79,12 @@ export const renderComposerContent = (options: RenderComposerContentOptions): vo
   // Clear existing content
   composerElement.textContent = '';
 
-  let currentPos = 0;
+  let currentPos = ZERO;
   for (const chip of sortedChips) {
-    // Add text before this chip
+    // Add text before this chip, handling newlines
     const textBefore = textValue.slice(currentPos, chip.position);
     if (textBefore.length > ZERO) {
-      // Use NBSP to make trailing spaces visible in contenteditable
-      composerElement.append(document.createTextNode(textBefore.replaceAll(' ', NBSP)));
+      appendTextWithNewlines(composerElement, textBefore);
     }
 
     // Add the emote image
@@ -77,11 +95,10 @@ export const renderComposerContent = (options: RenderComposerContentOptions): vo
     currentPos = chip.position + chip.code.length;
   }
 
-  // Add remaining text
+  // Add remaining text, handling newlines
   const textAfter = textValue.slice(currentPos);
   if (textAfter.length > ZERO) {
-    // Use NBSP to make trailing spaces visible in contenteditable
-    composerElement.append(document.createTextNode(textAfter.replaceAll(' ', NBSP)));
+    appendTextWithNewlines(composerElement, textAfter);
   }
 };
 
@@ -89,6 +106,18 @@ export interface ReadComposerModelResult {
   text: string;
   chips: EmoteChip[];
 }
+
+const extractEmoteFromNode = (node: HTMLSpanElement): { code: string; imageUrl: string } | null => {
+  const img = node.querySelector('img.ui-chat-composer-emote');
+  if (!(img instanceof HTMLImageElement)) {
+    return null;
+  }
+  const { code, imageUrl } = img.dataset;
+  if (code === undefined || code === '' || imageUrl === undefined || imageUrl === '') {
+    return null;
+  }
+  return { code, imageUrl };
+};
 
 export const readComposerModel = (
   composerElement: HTMLDivElement | null,
@@ -104,24 +133,22 @@ export const readComposerModel = (
     if (node.nodeType === Node.TEXT_NODE) {
       // Convert NBSP back to regular spaces for canonical text
       const textContent = node.textContent ?? '';
-      resultText += textContent.replaceAll(NBSP, ' ');
-    } else if (
-      node.nodeType === Node.ELEMENT_NODE &&
-      node instanceof HTMLSpanElement &&
-      node.classList.contains('ui-chat-composer-emote-wrap')
-    ) {
-      const img = node.querySelector('img.ui-chat-composer-emote');
-      if (img instanceof HTMLImageElement) {
-        const { code } = img.dataset;
-        const { imageUrl } = img.dataset;
-        if (code !== undefined && code !== '' && imageUrl !== undefined && imageUrl !== '') {
-          resultText += code;
+      resultText += textContent.replaceAll(NBSP, SPACE_CHAR);
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+      if (node instanceof HTMLSpanElement &&
+          node.classList.contains('ui-chat-composer-emote-wrap')) {
+        const emoteData = extractEmoteFromNode(node);
+        if (emoteData !== null) {
+          resultText += emoteData.code;
           chips.push({
-            code,
-            image_url: imageUrl,
-            position: resultText.length - code.length,
+            code: emoteData.code,
+            image_url: emoteData.imageUrl,
+            position: resultText.length - emoteData.code.length,
           });
         }
+      } else if (node instanceof HTMLBRElement) {
+        // Convert <br> to newline character
+        resultText += NEWLINE_CHAR;
       }
     }
   }

--- a/web/src/hooks/watch/chat-composer-emotes.ts
+++ b/web/src/hooks/watch/chat-composer-emotes.ts
@@ -52,10 +52,7 @@ export interface RenderComposerContentOptions {
   createEmoteElement: (code: string, imageUrl: string) => HTMLSpanElement;
 }
 
-const appendTextWithNewlines = (
-  element: HTMLDivElement,
-  text: string,
-): void => {
+const appendTextWithNewlines = (element: HTMLDivElement, text: string): void => {
   const lines = text.split(NEWLINE_CHAR);
   for (let index = ZERO; index < lines.length; index += ONE) {
     // Use NBSP to make trailing spaces visible in contenteditable
@@ -135,8 +132,10 @@ export const readComposerModel = (
       const textContent = node.textContent ?? '';
       resultText += textContent.replaceAll(NBSP, SPACE_CHAR);
     } else if (node.nodeType === Node.ELEMENT_NODE) {
-      if (node instanceof HTMLSpanElement &&
-          node.classList.contains('ui-chat-composer-emote-wrap')) {
+      if (
+        node instanceof HTMLSpanElement &&
+        node.classList.contains('ui-chat-composer-emote-wrap')
+      ) {
         const emoteData = extractEmoteFromNode(node);
         if (emoteData !== null) {
           resultText += emoteData.code;

--- a/web/src/hooks/watch/chat-composer-insert.ts
+++ b/web/src/hooks/watch/chat-composer-insert.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import type { EmoteItem } from '../../api-client';
-import { insertEmoteChip, setCursorPositionBase } from './chat-composer-cursor';
+import { insertEmoteChip } from './chat-composer-cursor';
 import { insertCodeAtCursor } from './chat-composer-helpers';
 import type { EmoteChip } from './use-chat-composer';
 
@@ -102,62 +102,4 @@ export const useInsertEmote = (
   );
 
   return { insertEmote };
-};
-
-export interface CreateInsertEmoteOptions {
-  composerRef: React.RefObject<HTMLDivElement | null>;
-  getCursorPosition: () => number;
-  getEmoteImageUrl: (code: string) => string | null;
-  disabled: boolean;
-}
-
-export const createInsertEmote = (
-  options: CreateInsertEmoteOptions,
-  setComposerText: (text: string, chips?: EmoteChip[]) => void,
-  closeSuggestions: () => void,
-) => {
-  const { composerRef, getCursorPosition, getEmoteImageUrl, disabled } = options;
-
-  return (code: string, text: string, emoteChips: EmoteChip[]): void => {
-    if (composerRef.current === null || disabled) {
-      return;
-    }
-    const safeCode = code.trim();
-    if (safeCode === '') {
-      return;
-    }
-
-    const cursorPos = getCursorPosition();
-    const next = insertCodeAtCursor({
-      code: safeCode,
-      cursorPos,
-      maxLength: MAX_TEXT_LENGTH,
-      text,
-    });
-
-    const imageUrl = getEmoteImageUrl(safeCode);
-    if (imageUrl === null) {
-      setComposerText(next.text);
-      setCursorPositionBase({ composerElement: composerRef.current, position: next.cursor });
-      closeSuggestions();
-      return;
-    }
-
-    const before = text.slice(ZERO, cursorPos);
-    const prefixLength = before.length > ZERO && !before.endsWith(' ') ? ONE : ZERO;
-    const newEmotePosition = cursorPos + prefixLength;
-
-    const newChips = insertEmoteChip({
-      cursorPos,
-      emoteChips,
-      imageUrl,
-      lengthDiff: next.text.length - text.length,
-      newEmotePosition,
-      safeCode,
-    });
-
-    setComposerText(next.text, newChips);
-    setCursorPositionBase({ composerElement: composerRef.current, position: next.cursor });
-    closeSuggestions();
-  };
 };

--- a/web/src/hooks/watch/chat-composer-keyboard.ts
+++ b/web/src/hooks/watch/chat-composer-keyboard.ts
@@ -3,7 +3,7 @@ import {
   getRangeTextLength as getRangeTextLengthBase,
   setCursorPositionBase,
 } from './chat-composer-cursor';
-import { normalizeSingleLine, trimToMaxLength } from './chat-composer-helpers';
+import { trimToMaxLength } from './chat-composer-helpers';
 import {
   applySuggestion as applySuggestionBase,
   hasActiveSelection,
@@ -231,7 +231,29 @@ export const createKeyboardHandlers = (
     handleEscapeKeyBase(event, actions.closeSuggestions);
   };
 
+  const insertNewline = (): void => {
+    const cursorPos = getCursorPosition({ composerRef, text, textLength: text.length });
+    const newlineChar = '\n';
+    const nextText = trimToMaxLength(
+      `${text.slice(ZERO, cursorPos)}${newlineChar}${text.slice(cursorPos)}`,
+      MAX_TEXT_LENGTH,
+    );
+    actions.setComposerText(nextText);
+    const increment = 1;
+    setCursorPosition(composerRef, Math.min(cursorPos + increment, nextText.length));
+  };
+
   const handleKeydown = (event: React.KeyboardEvent): void => {
+    // Handle Shift+Enter for newline (when not selecting a suggestion)
+    if (event.key === 'Enter' && event.shiftKey) {
+      const activeSelection = hasActiveSelection(suggestionsOpen, suggestionItems.length);
+      if (!activeSelection) {
+        event.preventDefault();
+        insertNewline();
+        return;
+      }
+    }
+
     const activeSelection = hasActiveSelection(suggestionsOpen, suggestionItems.length);
     if (handleEnterKey(event, activeSelection)) {
       return;
@@ -267,7 +289,18 @@ export const createPasteHandler = (deps: PasteHandlerDeps) => {
   return (event: React.ClipboardEvent): void => {
     event.preventDefault();
     const pasted = event.clipboardData.getData('text/plain');
-    const cleaned = normalizeSingleLine(pasted);
+    // Preserve newlines in pasted content for multiline support
+    // Only trim excess whitespace and normalize multiple consecutive newlines
+    const windowsNewline = '\r\n';
+    const unixNewline = '\n';
+    const doubleNewline = '\n\n';
+    const tripleNewline = '\n\n\n';
+    let cleaned = pasted.replaceAll(windowsNewline, unixNewline);
+    // Normalize more than 2 consecutive newlines to exactly 2
+    while (cleaned.includes(tripleNewline)) {
+      cleaned = cleaned.replaceAll(tripleNewline, doubleNewline);
+    }
+    cleaned = cleaned.trim();
     if (cleaned === '') {
       return;
     }

--- a/web/src/hooks/watch/use-chat-composer.ts
+++ b/web/src/hooks/watch/use-chat-composer.ts
@@ -253,9 +253,10 @@ export const useChatComposer = (options: UseChatComposerOptions): UseChatCompose
         closeSuggestions();
         return;
       }
-      void item;
+      insertEmoteHook.insertEmote(safeCode);
+      closeSuggestions();
     },
-    [closeSuggestions],
+    [insertEmoteHook, closeSuggestions],
   );
 
   const clearPreview = useCallback((): void => {

--- a/web/src/hooks/watch/use-chat-composer.ts
+++ b/web/src/hooks/watch/use-chat-composer.ts
@@ -175,7 +175,11 @@ export const useChatComposer = (options: UseChatComposerOptions): UseChatCompose
     if (trimmed === '' || disabled) {
       return;
     }
-    onSubmit(trimmed);
+    // Flatten newlines to spaces for Twitch IRC compatibility
+    const newlineChar = '\n';
+    const spaceChar = ' ';
+    const flattened = trimmed.replaceAll(newlineChar, spaceChar);
+    onSubmit(flattened);
     setComposerText('', []);
     closeSuggestions();
   }, [text, disabled, onSubmit, setComposerText, closeSuggestions]);

--- a/web/src/hooks/watch/use-chat.ts
+++ b/web/src/hooks/watch/use-chat.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { getChatEmotes, type EmoteItem } from '../../api-client';
 import type { ChatMessage } from './chat-utils';
 import { useChatConnection } from './use-chat-connection';
@@ -23,8 +23,6 @@ export interface UseChatReturn {
   sendMessage: (text: string) => Promise<void>;
   handleScroll: () => void;
   jumpToLatest: () => void;
-  insertEmote: (code: string) => void;
-  onComposerSelect: (code: string) => void;
 }
 
 export interface UseChatOptions {
@@ -37,7 +35,6 @@ export interface UseChatOptions {
 export const useChat = (options: UseChatOptions): UseChatReturn => {
   const { channelLogin, chatAvailable, initialEmotes = [], onStatusChange } = options;
 
-  const composerRef = useRef<{ insertEmote?: (code: string) => void }>(null);
   const connection = useChatConnection();
   const { cleanupConnection, setupConnection, setChatStatus } = connection;
 
@@ -105,14 +102,6 @@ export const useChat = (options: UseChatOptions): UseChatReturn => {
     [channelLogin, setChatStatus],
   );
 
-  const onComposerSelect = useCallback((code: string): void => {
-    composerRef.current?.insertEmote?.(code);
-  }, []);
-
-  const insertEmote = useCallback((code: string): void => {
-    composerRef.current?.insertEmote?.(code);
-  }, []);
-
   // Setup chat on mount
   useEffect(() => {
     if (chatAvailable) {
@@ -133,10 +122,8 @@ export const useChat = (options: UseChatOptions): UseChatReturn => {
     chatStatus: connection.chatStatus,
     emotesLoaded,
     handleScroll: connection.handleScroll,
-    insertEmote,
     jumpToLatest: connection.jumpToLatest,
     localEmotes,
-    onComposerSelect,
     sendMessage,
     unreadChatCount: connection.unreadChatCount,
   };

--- a/web/src/lib/styles/app.css
+++ b/web/src/lib/styles/app.css
@@ -563,6 +563,7 @@ body[data-theme='youtube'] {
 .ui-chat-composer {
   position: relative;
   flex: 1 1 0%;
+  min-width: 0;
 }
 
 .ui-chat-composer-input {
@@ -573,15 +574,20 @@ body[data-theme='youtube'] {
   color: var(--fg);
   border-radius: 6px;
   padding: 0.35rem 0.55rem;
-  height: 2.2rem;
   min-height: 2.2rem;
-  max-height: 2.2rem;
+  max-height: 6rem;
   line-height: 1.2;
-  white-space: nowrap;
-  overflow-x: auto;
-  overflow-y: hidden;
-  word-break: normal;
+  white-space: pre-wrap;
+  overflow-x: hidden;
+  overflow-y: auto;
+  word-break: break-word;
   outline: none;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.ui-chat-composer-input::-webkit-scrollbar {
+  display: none;
 }
 
 .ui-chat-composer-input:focus {
@@ -1900,7 +1906,7 @@ body[data-theme='youtube'] {
 
 .chat-form {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   gap: 0.45rem;
   border-top: 1px solid var(--border);
   padding: 0.65rem;


### PR DESCRIPTION
- Refactored \`ChatComposer\` to use \`forwardRef\` and \`useImperativeHandle\`, exposing an \`insertEmote\` method for external emote insertion
- Added imperative ref handling in \`Chat\` to trigger emote insertion via the composer, replacing the previous \`onComposerSelect\` callback pattern
- Improved cursor positioning logic in \`chat-composer-cursor.ts\` to correctly handle \`<br>\` elements as single newlines
- Added robustness to keyboard and emote handling hooks, reducing redundant state updates and simplifying insertion logic
- Updated styles in \`app.css\` to support improved emote preview visibility and composer disabled state styling
- Removed outdated agent strategy recommendations from \`AGENTS.md\` that conflicted with current implementation guidance