### PR TITLE
Chat: add unsubscribe grace period, SSE connection logs, and client-side subscribe lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "twitch-relay"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twitch-relay"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2024"
 description = "A relay service for Twitch streams"
 license = "MIT"
@@ -20,7 +20,7 @@ reqwest = { version = "0.12.24", default-features = false, features = ["json", "
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 thiserror = "2.0.17"
-tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread", "process", "net"] }
+tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread", "process", "net", "time"] }
 tokio-stream = { version = "0.1.17", features = ["sync"] }
 tokio-tungstenite = { version = "0.28.0", features = ["rustls-tls-webpki-roots"] }
 tower-http = { version = "0.6.6", features = ["fs"] }

--- a/src/chat/events.rs
+++ b/src/chat/events.rs
@@ -47,6 +47,7 @@ pub enum ChatPart {
 pub struct ChatChannelStatus {
    pub subscribed: bool,
    pub connected:  bool,
+   pub joined:     bool,
    #[serde(skip_serializing_if = "Option::is_none")]
    pub error:      Option<String>,
 }

--- a/src/chat/irc.rs
+++ b/src/chat/irc.rs
@@ -4,6 +4,7 @@ use std::{
       HashSet,
    },
    sync::Arc,
+   time::Duration,
 };
 
 use futures_util::{
@@ -11,10 +12,16 @@ use futures_util::{
    StreamExt,
    future::pending,
 };
-use tokio::sync::{
-   RwLock,
-   broadcast,
-   mpsc,
+use tokio::{
+   sync::{
+      RwLock,
+      broadcast,
+      mpsc,
+   },
+   time::{
+      Instant,
+      sleep_until,
+   },
 };
 use tokio_tungstenite::{
    connect_async,
@@ -45,6 +52,7 @@ use crate::{
 };
 
 const LOCAL_ECHO_TTL_SECS: u64 = 8;
+const PART_GRACE_PERIOD: Duration = Duration::from_secs(3);
 
 #[derive(Debug)]
 pub enum ReaderEvent {
@@ -68,6 +76,7 @@ struct ChatManagerState {
    reader_rx:          Option<mpsc::UnboundedReceiver<ReaderEvent>>,
    chat_identity:      Option<ChatIdentity>,
    pending_local_echo: HashMap<String, u64>,
+   pending_parts:      HashMap<String, Instant>,
 }
 
 impl ChatManagerState {
@@ -81,8 +90,63 @@ impl ChatManagerState {
          reader_rx:          None,
          chat_identity:      None,
          pending_local_echo: HashMap::new(),
+         pending_parts:      HashMap::new(),
       }
    }
+}
+
+async fn handle_subscribe_command(
+   channel: String,
+   response: tokio::sync::oneshot::Sender<Result<(), ChatError>>,
+   state: &mut ChatManagerState,
+   channels: &Arc<RwLock<HashMap<String, broadcast::Sender<ChatEvent>>>>,
+) {
+   let canceled_part = state.pending_parts.remove(&channel).is_some();
+   let entry = state.subscribed_counts.entry(channel.clone()).or_insert(0);
+   *entry = entry.saturating_add(1);
+   tracing::info!(
+      channel = %channel,
+      count = *entry,
+      canceled_part,
+      connected = state.connected,
+      joined = state.joined_channels.contains(&channel),
+      "chat channel subscribed"
+   );
+   ensure_channel_sender(channels, &channel).await;
+
+   if state.connected
+      && !state.joined_channels.contains(&channel)
+      && let Some(writer) = state.writer_tx.as_ref()
+   {
+      tracing::info!(channel = %channel, count = *entry, "sending chat JOIN");
+      let _ = writer.send(format!("JOIN #{channel}"));
+      state.joined_channels.insert(channel.clone());
+   }
+
+   let _ = response.send(Ok(()));
+}
+
+fn handle_unsubscribe_command(
+   channel: &str,
+   response: tokio::sync::oneshot::Sender<Result<(), ChatError>>,
+   state: &mut ChatManagerState,
+) {
+   if let Some(entry) = state.subscribed_counts.get_mut(channel) {
+      if *entry > 1 {
+         *entry -= 1;
+         tracing::debug!(channel = %channel, count = *entry, "chat channel unsubscribed");
+      } else {
+         state.subscribed_counts.remove(channel);
+         let deadline = Instant::now() + PART_GRACE_PERIOD;
+         state.pending_parts.insert(channel.to_string(), deadline);
+         tracing::debug!(
+            channel = %channel,
+            grace_ms = PART_GRACE_PERIOD.as_millis(),
+            "chat channel unsubscribe reached zero; scheduling PART"
+         );
+      }
+   }
+   let _ = response.send(Ok(()));
 }
 
 /// Handle a single chat command.
@@ -96,35 +160,10 @@ async fn handle_command(
 ) -> bool {
    match command {
       ChatCommand::Subscribe { channel, response } => {
-         let entry = state.subscribed_counts.entry(channel.clone()).or_insert(0);
-         *entry = entry.saturating_add(1);
-         ensure_channel_sender(channels, &channel).await;
-
-         if state.connected
-            && !state.joined_channels.contains(&channel)
-            && let Some(writer) = state.writer_tx.as_ref()
-         {
-            let _ = writer.send(format!("JOIN #{channel}"));
-            state.joined_channels.insert(channel.clone());
-         }
-
-         let _ = response.send(Ok(()));
+         handle_subscribe_command(channel, response, state, channels).await;
       },
       ChatCommand::Unsubscribe { channel, response } => {
-         if let Some(entry) = state.subscribed_counts.get_mut(&channel) {
-            if *entry > 1 {
-               *entry -= 1;
-            } else {
-               state.subscribed_counts.remove(&channel);
-               if state.connected
-                  && state.joined_channels.remove(&channel)
-                  && let Some(writer) = state.writer_tx.as_ref()
-               {
-                  let _ = writer.send(format!("PART #{channel}"));
-               }
-            }
-         }
-         let _ = response.send(Ok(()));
+         handle_unsubscribe_command(&channel, response, state);
       },
       ChatCommand::SendMessage {
          channel,
@@ -143,6 +182,7 @@ async fn handle_command(
          if !state.joined_channels.contains(&channel)
             && let Some(writer) = state.writer_tx.as_ref()
          {
+            tracing::info!(channel = %channel, "sending chat JOIN before message");
             let _ = writer.send(format!("JOIN #{channel}"));
             state.joined_channels.insert(channel.clone());
          }
@@ -180,10 +220,20 @@ async fn handle_command(
          }
       },
       ChatCommand::Status { channel, response } => {
-         let subscribed = state.subscribed_counts.get(&channel).copied().unwrap_or(0) > 0;
+         let subscribed_count = state.subscribed_counts.get(&channel).copied().unwrap_or(0);
+         let subscribed = subscribed_count > 0;
+         tracing::debug!(
+            channel = %channel,
+            subscribed_count,
+            connected = state.connected,
+            joined = state.joined_channels.contains(&channel),
+            pending_part = state.pending_parts.contains_key(&channel),
+            "chat status reported"
+         );
          let _ = response.send(crate::chat::events::ChatChannelStatus {
             subscribed,
             connected: state.connected,
+            joined: state.joined_channels.contains(&channel),
             error: state.last_error.clone(),
          });
       },
@@ -247,6 +297,7 @@ async fn maybe_connect(state: &mut ChatManagerState, auth: &TwitchAuthService) {
                   "CAP REQ :twitch.tv/tags twitch.tv/commands twitch.tv/membership".to_string(),
                );
                for channel in state.subscribed_counts.keys() {
+                  tracing::debug!(channel = %channel, "sending chat JOIN after connect");
                   let _ = writer.send(format!("JOIN #{channel}"));
                   state.joined_channels.insert(channel.clone());
                }
@@ -262,6 +313,36 @@ async fn maybe_connect(state: &mut ChatManagerState, auth: &TwitchAuthService) {
    }
 }
 
+fn part_deadline(state: &ChatManagerState) -> Option<Instant> {
+   state.pending_parts.values().copied().min()
+}
+
+fn process_due_parts(state: &mut ChatManagerState) {
+   let now = Instant::now();
+   let due_channels: Vec<String> = state
+      .pending_parts
+      .iter()
+      .filter(|(_, deadline)| **deadline <= now)
+      .map(|(channel, _)| channel.clone())
+      .collect();
+
+   for channel in due_channels {
+      state.pending_parts.remove(&channel);
+      if state.subscribed_counts.contains_key(&channel) {
+         tracing::debug!(channel = %channel, "skipping scheduled chat PART because channel was resubscribed");
+         continue;
+      }
+
+      if state.connected
+         && state.joined_channels.remove(&channel)
+         && let Some(writer) = state.writer_tx.as_ref()
+      {
+         tracing::debug!(channel = %channel, "sending chat PART");
+         let _ = writer.send(format!("PART #{channel}"));
+      }
+   }
+}
+
 pub async fn run_chat_manager(
    auth: TwitchAuthService,
    mut command_rx: mpsc::UnboundedReceiver<ChatCommand>,
@@ -273,12 +354,23 @@ pub async fn run_chat_manager(
 
    loop {
       maybe_connect(&mut state, &auth).await;
+      process_due_parts(&mut state);
+
+      let next_part_deadline = part_deadline(&state);
 
       let read_event = async {
          if let Some(rx) = state.reader_rx.as_mut() {
             rx.recv().await
          } else {
             pending().await
+         }
+      };
+
+      let part_timer = async {
+         if let Some(deadline) = next_part_deadline {
+            sleep_until(deadline).await;
+         } else {
+            pending::<()>().await;
          }
       };
 
@@ -308,6 +400,9 @@ pub async fn run_chat_manager(
                       &auth,
                   ).await;
               }
+          }
+          () = part_timer => {
+              process_due_parts(&mut state);
           }
       }
    }
@@ -546,4 +641,65 @@ fn local_echo_key(event: &ChatEvent) -> Option<String> {
    }
 
    Some(format!("{channel}|{sender}|{text}"))
+}
+
+#[cfg(test)]
+mod tests {
+   use super::*;
+
+   #[test]
+   fn due_part_is_delayed_until_grace_deadline() {
+      let (writer_tx, mut writer_rx) = mpsc::unbounded_channel();
+      let mut state = ChatManagerState::new();
+      state.connected = true;
+      state.writer_tx = Some(writer_tx);
+      state.joined_channels.insert("example".to_string());
+      state.pending_parts.insert(
+         "example".to_string(),
+         Instant::now() + Duration::from_mins(1),
+      );
+
+      process_due_parts(&mut state);
+
+      assert!(state.joined_channels.contains("example"));
+      assert!(writer_rx.try_recv().is_err());
+   }
+
+   #[test]
+   fn due_part_sends_part_and_removes_joined_channel() {
+      let (writer_tx, mut writer_rx) = mpsc::unbounded_channel();
+      let mut state = ChatManagerState::new();
+      state.connected = true;
+      state.writer_tx = Some(writer_tx);
+      state.joined_channels.insert("example".to_string());
+      state.pending_parts.insert(
+         "example".to_string(),
+         Instant::now() - Duration::from_secs(1),
+      );
+
+      process_due_parts(&mut state);
+
+      assert!(!state.joined_channels.contains("example"));
+      assert_eq!(writer_rx.try_recv().expect("PART command"), "PART #example");
+   }
+
+   #[test]
+   fn due_part_is_skipped_after_resubscribe() {
+      let (writer_tx, mut writer_rx) = mpsc::unbounded_channel();
+      let mut state = ChatManagerState::new();
+      state.connected = true;
+      state.writer_tx = Some(writer_tx);
+      state.joined_channels.insert("example".to_string());
+      state.subscribed_counts.insert("example".to_string(), 1);
+      state.pending_parts.insert(
+         "example".to_string(),
+         Instant::now() - Duration::from_secs(1),
+      );
+
+      process_due_parts(&mut state);
+
+      assert!(state.joined_channels.contains("example"));
+      assert!(writer_rx.try_recv().is_err());
+      assert!(!state.pending_parts.contains_key("example"));
+   }
 }

--- a/src/chat/service.rs
+++ b/src/chat/service.rs
@@ -173,28 +173,38 @@ impl ChatService {
       let (tx, rx) = oneshot::channel();
       let normalized =
          normalize_channel_login(channel).map_err(|_| ChatError::InvalidChannelName)?;
+      tracing::info!(channel = %normalized, "chat subscribe requested");
       self
          .command_tx
          .send(ChatCommand::Subscribe {
-            channel:  normalized,
+            channel:  normalized.clone(),
             response: tx,
          })
          .map_err(|_| ChatError::RuntimeUnavailable)?;
-      rx.await.map_err(|_| ChatError::StatusTimeout)?
+      let result = rx.await.map_err(|_| ChatError::StatusTimeout)?;
+      if result.is_ok() {
+         tracing::info!(channel = %normalized, "chat subscribe completed");
+      }
+      result
    }
 
    pub async fn unsubscribe_channel(&self, channel: &str) -> Result<(), ChatError> {
       let (tx, rx) = oneshot::channel();
       let normalized =
          normalize_channel_login(channel).map_err(|_| ChatError::InvalidChannelName)?;
+      tracing::info!(channel = %normalized, "chat unsubscribe requested");
       self
          .command_tx
          .send(ChatCommand::Unsubscribe {
-            channel:  normalized,
+            channel:  normalized.clone(),
             response: tx,
          })
          .map_err(|_| ChatError::RuntimeUnavailable)?;
-      rx.await.map_err(|_| ChatError::StatusTimeout)?
+      let result = rx.await.map_err(|_| ChatError::StatusTimeout)?;
+      if result.is_ok() {
+         tracing::info!(channel = %normalized, "chat unsubscribe completed");
+      }
+      result
    }
 
    pub async fn send_message(&self, channel: &str, message: &str) -> Result<(), ChatError> {
@@ -212,7 +222,7 @@ impl ChatService {
       self
          .command_tx
          .send(ChatCommand::SendMessage {
-            channel:  normalized,
+            channel:  normalized.clone(),
             message:  trimmed.to_string(),
             response: tx,
          })
@@ -227,7 +237,7 @@ impl ChatService {
       self
          .command_tx
          .send(ChatCommand::Status {
-            channel:  normalized,
+            channel:  normalized.clone(),
             response: tx,
          })
          .map_err(|_| ChatError::RuntimeUnavailable)?;
@@ -243,7 +253,7 @@ impl ChatService {
       let sender = {
          let mut guard = self.channels.write().await;
          guard
-            .entry(normalized)
+            .entry(normalized.clone())
             .or_insert_with(|| {
                let (sender, _receiver) = broadcast::channel(256);
                sender
@@ -251,7 +261,13 @@ impl ChatService {
             .clone()
       };
 
-      Ok(sender.subscribe())
+      let receiver = sender.subscribe();
+      tracing::info!(
+         channel = %normalized,
+         receivers = sender.receiver_count(),
+         "chat EventSource receiver subscribed"
+      );
+      Ok(receiver)
    }
 
    pub async fn emotes_for_channel(
@@ -338,6 +354,7 @@ pub async fn subscribe(
    State(state): State<ChatState>,
    Json(payload): Json<ChatChannelRequest>,
 ) -> Response {
+   tracing::debug!(channel = %payload.channel_login, "chat subscribe request");
    match state
       .service
       .subscribe_channel(&payload.channel_login)
@@ -352,6 +369,7 @@ pub async fn subscribe(
 }
 
 pub async fn unsubscribe(State(state): State<ChatState>, Path(channel): Path<String>) -> Response {
+   tracing::debug!(channel = %channel, "chat unsubscribe request");
    match state.service.unsubscribe_channel(&channel).await {
       Ok(()) => StatusCode::NO_CONTENT.into_response(),
       Err(e) => {
@@ -404,15 +422,19 @@ pub async fn emotes(State(state): State<ChatState>, Query(query): Query<EmotesQu
 }
 
 pub async fn events(State(state): State<ChatState>, Path(channel): Path<String>) -> Response {
+   tracing::info!(channel = %channel, "chat events SSE request");
    let receiver = match state.service.receiver_for_channel(&channel).await {
       Ok(receiver) => receiver,
       Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string(), None),
    };
 
-   let stream = BroadcastStream::new(receiver).filter_map(|result| {
+   let log_guard = ChatSseConnectionLog::new(channel);
+   let stream = BroadcastStream::new(receiver).filter_map(move |result| {
+      let channel = log_guard.channel();
       async move {
          match result {
             Ok(event) => {
+               tracing::trace!(channel = %channel, "chat EventSource event sent");
                let sse_event = Event::default().event("chat").json_data(event).ok()?;
                Some(Ok::<Event, Infallible>(sse_event))
             },
@@ -424,4 +446,25 @@ pub async fn events(State(state): State<ChatState>, Path(channel): Path<String>)
    Sse::new(stream)
       .keep_alive(KeepAlive::new().interval(std::time::Duration::from_secs(12)))
       .into_response()
+}
+
+struct ChatSseConnectionLog {
+   channel: String,
+}
+
+impl ChatSseConnectionLog {
+   fn new(channel: String) -> Self {
+      tracing::info!(channel = %channel, "chat EventSource opened");
+      Self { channel }
+   }
+
+   fn channel(&self) -> String {
+      self.channel.clone()
+   }
+}
+
+impl Drop for ChatSseConnectionLog {
+   fn drop(&mut self) {
+      tracing::info!(channel = %self.channel, "chat EventSource closed");
+   }
 }

--- a/src/stream_proxy/session.rs
+++ b/src/stream_proxy/session.rs
@@ -1143,7 +1143,7 @@ mod tests {
 
       let fake_variants: HashMap<String, QualityVariant> =
          HashMap::from([("source".to_string(), QualityVariant {
-            manifest_url:   "http://localhost:9999/fake.m3u8".to_string(),
+            manifest_url:   "http://[invalid-local-manifest".to_string(),
             segment_lookup: HashMap::new(),
             cdn_base:       String::new(),
             bandwidth:      Some(5_000_000),
@@ -1216,7 +1216,7 @@ mod tests {
 
       let fake_variants: HashMap<String, QualityVariant> =
          HashMap::from([("720p60".to_string(), QualityVariant {
-            manifest_url:   "http://localhost:9998/fake2.m3u8".to_string(),
+            manifest_url:   "http://[invalid-local-manifest-2".to_string(),
             segment_lookup: HashMap::new(),
             cdn_base:       String::new(),
             bandwidth:      Some(5_000_000),

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/src/hooks/watch/use-chat-connection.ts
+++ b/web/src/hooks/watch/use-chat-connection.ts
@@ -1,10 +1,167 @@
 import { useCallback, useRef, useState } from 'react';
+import { isObject } from '../../api-client/core';
 import { parseChatEvent, type ChatMessage } from './chat-utils';
 
 const UNREAD_COUNT_ZERO = 0;
 const UNREAD_INCREMENT = 1;
 const AUTO_SCROLL_THRESHOLD_PX = 32;
 const SCROLL_DEBOUNCE_MS = 0;
+const UNSUBSCRIBE_GRACE_MS = 3000;
+const INITIAL_CONNECTION_GENERATION = 0;
+const NEXT_CONNECTION_GENERATION_INCREMENT = 1;
+
+const logChatLifecycle = (message: string, detail: Record<string, unknown>): void => {
+  globalThis.dispatchEvent(new CustomEvent('chat:lifecycle', { detail: { message, ...detail } }));
+};
+
+interface ChatChannelStatus {
+  connected?: boolean;
+  error?: string;
+  joined?: boolean;
+  subscribed?: boolean;
+}
+
+const isChatChannelStatus = (value: unknown): value is ChatChannelStatus => {
+  if (!isObject(value)) {
+    return false;
+  }
+  const candidate = value;
+  return (
+    (candidate.connected === undefined || typeof candidate.connected === 'boolean') &&
+    (candidate.error === undefined || typeof candidate.error === 'string') &&
+    (candidate.joined === undefined || typeof candidate.joined === 'boolean') &&
+    (candidate.subscribed === undefined || typeof candidate.subscribed === 'boolean')
+  );
+};
+
+const parseChatStatusResponse = (payload: unknown): ChatChannelStatus | null => {
+  if (!isObject(payload)) {
+    return null;
+  }
+  const { status } = payload;
+  return isChatChannelStatus(status) ? status : null;
+};
+
+const readChatStatus = async (
+  channelLogin: string,
+  signal: AbortSignal,
+): Promise<ChatChannelStatus | null> => {
+  const statusUrl = `/api/chat/status?channel_login=${encodeURIComponent(channelLogin)}`;
+  const response = await fetch(statusUrl, {
+    credentials: 'same-origin',
+    signal,
+  });
+  if (!response.ok) {
+    return null;
+  }
+  return parseChatStatusResponse(await response.json());
+};
+
+const subscribeChat = async (channelLogin: string, signal: AbortSignal): Promise<void> => {
+  logChatLifecycle('Subscribing to chat channel', { channelLogin });
+  const response = await fetch('/api/chat/subscribe', {
+    body: JSON.stringify({ channel_login: channelLogin }),
+    credentials: 'same-origin',
+    headers: { 'content-type': 'application/json' },
+    method: 'POST',
+    signal,
+  });
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(error || 'Failed to subscribe to chat');
+  }
+  logChatLifecycle('Chat subscribe accepted', { channelLogin });
+};
+
+interface OpenChatEventsOptions {
+  appendMessage: (message: ChatMessage) => void;
+  channelLogin: string;
+  chatEventsRef: React.RefObject<EventSource | null>;
+  connectionGenerationRef: React.RefObject<number>;
+  generation: number;
+  setChatConnected: (connected: boolean) => void;
+  setChatStatus: (status: string) => void;
+}
+
+const openChatEventsForConnection = (options: OpenChatEventsOptions): void => {
+  const {
+    appendMessage,
+    channelLogin,
+    chatEventsRef,
+    connectionGenerationRef,
+    generation,
+    setChatConnected,
+    setChatStatus,
+  } = options;
+
+  if (chatEventsRef.current) {
+    chatEventsRef.current.close();
+  }
+
+  const eventsUrl = `/api/chat/events/${encodeURIComponent(channelLogin)}`;
+  logChatLifecycle('Opening chat EventSource', { channelLogin, generation });
+  const eventSource = new EventSource(eventsUrl, {
+    withCredentials: true,
+  });
+
+  chatEventsRef.current = eventSource;
+
+  const isCurrentEventSource = (): boolean =>
+    chatEventsRef.current === eventSource && connectionGenerationRef.current === generation;
+
+  eventSource.addEventListener('open', () => {
+    if (!isCurrentEventSource()) {
+      return;
+    }
+    logChatLifecycle('Chat EventSource opened', { channelLogin, generation });
+    setChatConnected(true);
+    setChatStatus(`SSE connected to #${channelLogin}; waiting for IRC messages`);
+  });
+
+  eventSource.addEventListener('error', () => {
+    if (!isCurrentEventSource()) {
+      return;
+    }
+    logChatLifecycle('Chat EventSource reconnecting', { channelLogin, generation });
+    setChatConnected(false);
+    setChatStatus('Chat SSE reconnecting...');
+  });
+
+  eventSource.addEventListener('chat', (event: Event) => {
+    if (!isCurrentEventSource() || !(event instanceof MessageEvent)) {
+      return;
+    }
+    const messageData: unknown = event.data;
+    const messageText = typeof messageData === 'string' ? messageData : String(messageData);
+    const message = parseChatEvent(messageText);
+    if (message) {
+      appendMessage(message);
+    }
+  });
+};
+
+const scheduleChatUnsubscribe = (
+  channelLogin: string,
+  unsubscribeTimersRef: React.RefObject<Map<string, ReturnType<typeof setTimeout>>>,
+): void => {
+  const existingTimer = unsubscribeTimersRef.current.get(channelLogin);
+  if (existingTimer) {
+    clearTimeout(existingTimer);
+  }
+
+  const timer = setTimeout(() => {
+    unsubscribeTimersRef.current.delete(channelLogin);
+    logChatLifecycle('Unsubscribing from chat channel after grace period', { channelLogin });
+    void fetch(`/api/chat/subscribe/${encodeURIComponent(channelLogin)}`, {
+      body: JSON.stringify({}),
+      credentials: 'same-origin',
+      keepalive: true,
+      method: 'DELETE',
+    });
+  }, UNSUBSCRIBE_GRACE_MS);
+
+  unsubscribeTimersRef.current.set(channelLogin, timer);
+};
 
 export interface UseChatConnectionReturn {
   chatConnected: boolean;
@@ -18,7 +175,7 @@ export interface UseChatConnectionReturn {
   clearUnreadCount: () => void;
   appendMessage: (message: ChatMessage) => void;
   setupConnection: (channelLogin: string, chatAvailable: boolean) => Promise<void>;
-  cleanupConnection: (channelLogin: string) => Promise<void>;
+  cleanupConnection: (channelLogin: string) => void;
   setChatStatus: (status: string) => void;
   setChatConnected: (connected: boolean) => void;
 }
@@ -26,6 +183,9 @@ export interface UseChatConnectionReturn {
 export const useChatConnection = (): UseChatConnectionReturn => {
   const chatMessagesRef = useRef<HTMLDivElement>(null);
   const chatEventsRef = useRef<EventSource | null>(null);
+  const connectionGenerationRef = useRef(INITIAL_CONNECTION_GENERATION);
+  const subscribeAbortRef = useRef<AbortController | null>(null);
+  const unsubscribeTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
   const [chatConnected, setChatConnected] = useState(false);
   const [chatStatus, setChatStatus] = useState('Checking Twitch chat...');
@@ -77,91 +237,84 @@ export const useChatConnection = (): UseChatConnectionReturn => {
     }
   }, []);
 
-  const openChatEvents = useCallback(
-    (channelLogin: string): void => {
-      if (chatEventsRef.current) {
-        chatEventsRef.current.close();
-      }
-
-      const eventSource = new EventSource(`/api/chat/events/${encodeURIComponent(channelLogin)}`, {
-        withCredentials: true,
-      });
-
-      chatEventsRef.current = eventSource;
-
-      eventSource.addEventListener('open', () => {
-        setChatConnected(true);
-        setChatStatus(`Connected to #${channelLogin}`);
-      });
-
-      eventSource.addEventListener('error', () => {
-        setChatConnected(false);
-        setChatStatus('Chat reconnecting...');
-      });
-
-      eventSource.addEventListener('chat', (event: Event) => {
-        if (!(event instanceof MessageEvent)) {
-          return;
-        }
-        const messageData: unknown = event.data;
-        const messageText = typeof messageData === 'string' ? messageData : String(messageData);
-        const message = parseChatEvent(messageText);
-        if (message) {
-          appendMessage(message);
-        }
-      });
-    },
-    [appendMessage],
-  );
-
-  const subscribeChat = useCallback(async (channelLogin: string): Promise<void> => {
-    const response = await fetch('/api/chat/subscribe', {
-      body: JSON.stringify({ channel_login: channelLogin }),
-      credentials: 'same-origin',
-      headers: { 'content-type': 'application/json' },
-      method: 'POST',
-    });
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(error || 'Failed to subscribe to chat');
-    }
-    setChatStatus(`Connected to #${channelLogin}`);
-  }, []);
-
   const setupConnection = useCallback(
     async (channelLogin: string, chatAvailable: boolean): Promise<void> => {
       if (!chatAvailable) {
         return;
       }
-      setChatStatus('Connecting to chat...');
+      const pendingTimer = unsubscribeTimersRef.current.get(channelLogin);
+      if (pendingTimer) {
+        clearTimeout(pendingTimer);
+        unsubscribeTimersRef.current.delete(channelLogin);
+        logChatLifecycle('Canceled pending chat unsubscribe', { channelLogin });
+      }
+
+      const generation = connectionGenerationRef.current + NEXT_CONNECTION_GENERATION_INCREMENT;
+      connectionGenerationRef.current = generation;
+      subscribeAbortRef.current?.abort();
+      const abortController = new AbortController();
+      subscribeAbortRef.current = abortController;
+
+      setChatStatus(`Subscribing to #${channelLogin}...`);
       setChatConnected(false);
 
       try {
-        await subscribeChat(channelLogin);
-        openChatEvents(channelLogin);
-      } catch {
+        await subscribeChat(channelLogin, abortController.signal);
+        if (connectionGenerationRef.current !== generation) {
+          return;
+        }
+        const status = await readChatStatus(channelLogin, abortController.signal);
+        if (connectionGenerationRef.current !== generation) {
+          return;
+        }
+        if (status?.joined === true) {
+          setChatStatus(`IRC joined #${channelLogin}; opening chat SSE...`);
+        } else if (status?.connected === true && status.subscribed === true) {
+          setChatStatus(`IRC connected; joining #${channelLogin}...`);
+        } else if (typeof status?.error === 'string' && status.error.length > UNREAD_COUNT_ZERO) {
+          setChatStatus(`Chat unavailable: ${status.error}`);
+        } else {
+          setChatStatus(`Opening chat SSE for #${channelLogin}...`);
+        }
+        openChatEventsForConnection({
+          appendMessage,
+          channelLogin,
+          chatEventsRef,
+          connectionGenerationRef,
+          generation,
+          setChatConnected,
+          setChatStatus,
+        });
+      } catch (error: unknown) {
+        if (abortController.signal.aborted || connectionGenerationRef.current !== generation) {
+          return;
+        }
+        logChatLifecycle('Chat subscribe failed', { channelLogin, error });
+        setChatConnected(false);
         setChatStatus('Chat unavailable');
       }
     },
-    [subscribeChat, openChatEvents],
+    [appendMessage],
   );
 
-  const cleanupConnection = useCallback(async (channelLogin: string): Promise<void> => {
+  const cleanupConnection = useCallback((channelLogin: string): void => {
+    connectionGenerationRef.current += NEXT_CONNECTION_GENERATION_INCREMENT;
+    subscribeAbortRef.current?.abort();
+    subscribeAbortRef.current = null;
+
     if (chatEventsRef.current) {
+      logChatLifecycle('Closing chat EventSource', { channelLogin });
       chatEventsRef.current.close();
       chatEventsRef.current = null;
     }
+
+    setChatConnected(false);
 
     if (!channelLogin) {
       return;
     }
 
-    await fetch(`/api/chat/subscribe/${encodeURIComponent(channelLogin)}`, {
-      body: JSON.stringify({}),
-      credentials: 'same-origin',
-      keepalive: true,
-      method: 'DELETE',
-    });
+    scheduleChatUnsubscribe(channelLogin, unsubscribeTimersRef);
   }, []);
 
   return {

--- a/web/src/hooks/watch/use-chat.ts
+++ b/web/src/hooks/watch/use-chat.ts
@@ -110,7 +110,7 @@ export const useChat = (options: UseChatOptions): UseChatReturn => {
     }
 
     return (): void => {
-      void cleanupConnection(channelLogin);
+      cleanupConnection(channelLogin);
     };
   }, [chatAvailable, channelLogin, cleanupConnection, loadEmotes, setupConnection]);
 


### PR DESCRIPTION
### Motivation
- Prevent flapping PART commands when clients briefly unsubscribe and resubscribe by delaying PARTs with a short grace period. 
- Improve observability for chat SSE lifecycle and channel subscription actions on both server and client. 
- Harden client chat connection handling to avoid races and to schedule unsubscribe requests instead of immediate teardown.

### Description
- Bumped package versions to `0.6.5` in `Cargo.toml`, `Cargo.lock`, and `web/package.json`, and added `tokio` `time` feature. 
- Added `joined` field to `ChatChannelStatus` and surfaced more `tracing` logs across chat service and SSE endpoints. 
- Implemented a PART grace period in the chat manager: added `pending_parts` with `PART_GRACE_PERIOD`, functions `process_due_parts`, `part_deadline`, and scheduling logic to delay sending `PART #{channel}` until the deadline; refactored subscribe/unsubscribe handlers into `handle_subscribe_command` and `handle_unsubscribe_command`. 
- Integrated a timer into the chat manager `select!` loop to run due PARTs, and ensured PARTs are skipped if channel is resubscribed before deadline. 
- Added unit tests for `process_due_parts` behavior (delayed PART, sending PART when due, skipping PART after resubscribe). 
- Enhanced SSE handling: per-connection `ChatSseConnectionLog` to log open/close and trace per-event sends. 
- Improved `ChatService` methods to log subscribe/unsubscribe lifecycle events and to return results after awaiting command responses. 
- Client-side `use-chat-connection` changes: added connection generation tracking, subscribe abort handling, reading chat status from server before opening SSE, cancelable subscribe, scheduling of DELETE unsubscribe after a grace period (`UNSUBSCRIBE_GRACE_MS`), lifecycle event logging, and robust EventSource management. 
- Minor test adjustments in `stream_proxy` tests to avoid local manifest URLs.

### Testing
- Ran unit tests including the new `chat::irc` tests for delayed/due/skip PART behavior and existing `stream_proxy` tests, and all tests passed. 
- Ran `cargo test` for Rust units and verified no regressions in modified modules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35d057e1bc8328a5f3bfeddd847880)