### PR TITLE
feat(web): add watch session data to API response and update components

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -823,6 +823,36 @@ Watch page for a ticket. Returns HTML.
 - `401 Unauthorized`: Invalid/expired ticket or authentication required
 - `403 Forbidden`: Ticket belongs to different session
 
+### `GET /api/watch-session/{ticket}`
+
+Get watch session bootstrap data for a ticket. Used by the watch page to initialize the player.
+
+**Query:** `relay=1` to force relay mode
+
+**Response:**
+
+```json
+{
+  "channel": "string",
+  "manifest_url": "string",
+  "relay": "bool",
+  "app_version": "string",
+  "display_name": "string?",
+  "profile_url": "string?",
+  "title": "string?",
+  "game": "string?",
+  "viewer_count": "number?",
+  "live": "bool",
+  "resolver": "native | streamlink | auto",
+  "delivery_mode": "cdn_first | relay"
+}
+```
+
+**Errors:**
+- `401 Unauthorized`: Invalid/expired ticket or authentication required
+- `403 Forbidden`: Ticket belongs to a different session
+- `502 Bad Gateway`: Stream unavailable
+
 ### `GET /stream/{stream_id}/{session_token}/manifest`
 
 HLS master manifest for a stream.

--- a/src/app.rs
+++ b/src/app.rs
@@ -131,6 +131,27 @@ fn build_route_modules(
    )
 }
 
+/// Attach static asset and frontend fallback services to a router.
+fn serve_frontend(router: Router) -> Router {
+   let base_path = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+   let static_path = base_path.join("web").join("build");
+   let assets_path = base_path.join("web").join("static");
+   let images_path = channels::images_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+   let youtube_images_path =
+      crate::youtube_channels::images_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+
+   router
+      .nest_service("/static/images", ServeDir::new(&images_path))
+      .nest_service(
+         "/static/youtube_images",
+         ServeDir::new(&youtube_images_path),
+      )
+      .nest_service("/static", ServeDir::new(&assets_path))
+      .fallback_service(
+         ServeDir::new(&static_path).fallback(ServeFile::new(static_path.join("index.html"))),
+      )
+}
+
 /// Build a router for the application.
 pub fn build_router(config: &AppConfig, access_code_hash: String) -> Result<Router, AppError> {
    let auth_config = WebAuthConfig::new(
@@ -216,34 +237,21 @@ pub fn build_router(config: &AppConfig, access_code_hash: String) -> Result<Rout
    });
 
    let auth_routes = routes::auth_routes(auth_config.clone());
-   let base_path = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-   let static_path = base_path.join("web").join("build");
-   let assets_path = base_path.join("web").join("static");
-   let images_path = channels::images_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
-   let youtube_images_path =
-      crate::youtube_channels::images_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
    let youtube_routes = youtube::build_routes_with_client(auth_config, config, youtube_client);
 
-   let router = Router::new()
-      .merge(health_routes)
-      .merge(auth_routes)
-      .merge(channel_routes)
-      .merge(live_status_routes)
-      .merge(watch_routes)
-      .merge(recording_routes)
-      .merge(twitch_routes)
-      .merge(chat_routes)
-      .merge(stream_routes)
-      .merge(youtube_routes)
-      .nest_service("/static/images", ServeDir::new(&images_path))
-      .nest_service(
-         "/static/youtube_images",
-         ServeDir::new(&youtube_images_path),
-      )
-      .nest_service("/static", ServeDir::new(&assets_path))
-      .fallback_service(
-         ServeDir::new(&static_path).fallback(ServeFile::new(static_path.join("index.html"))),
-      );
+   let router = serve_frontend(
+      Router::new()
+         .merge(health_routes)
+         .merge(auth_routes)
+         .merge(channel_routes)
+         .merge(live_status_routes)
+         .merge(watch_routes)
+         .merge(recording_routes)
+         .merge(twitch_routes)
+         .merge(chat_routes)
+         .merge(stream_routes)
+         .merge(youtube_routes),
+   );
 
    Ok(router)
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -148,22 +148,22 @@ pub fn build_router(config: &AppConfig, access_code_hash: String) -> Result<Rout
       .clone()
       .unwrap_or_else(|| "streamlink".to_string());
 
-    let stream_service = stream_proxy::StreamSessionService::new(
-       streamlink_path.clone(),
-       config.playback.stream_resolver_mode,
-       config.playback.stream_delivery_mode,
-       config.playback.twitch_client_id.clone(),
-    );
+   let stream_service = stream_proxy::StreamSessionService::new(
+      streamlink_path.clone(),
+      config.playback.stream_resolver_mode,
+      config.playback.stream_delivery_mode,
+      config.playback.twitch_client_id.clone(),
+   );
 
-    let live_status_service = LiveStatusService::new();
+   let live_status_service = LiveStatusService::new();
 
-    let protected_state = ProtectedState {
-       auth: auth_config.clone(),
-       playback,
-       stream: stream_service.clone(),
-       catalog: catalog_service.clone(),
-       live_status: live_status_service.clone(),
-    };
+   let protected_state = ProtectedState {
+      auth: auth_config.clone(),
+      playback,
+      stream: stream_service.clone(),
+      catalog: catalog_service.clone(),
+      live_status: live_status_service.clone(),
+   };
    let channel_state = routes::ChannelState {
       live_status: live_status_service.clone(),
    };

--- a/src/app.rs
+++ b/src/app.rs
@@ -39,10 +39,11 @@ use crate::{
 /// State shared between channel list and watch routes.
 #[derive(Debug, Clone)]
 pub struct ProtectedState {
-   pub auth:     WebAuthConfig,
-   pub playback: PlaybackTicketService,
-   pub stream:   stream_proxy::StreamSessionService,
-   pub catalog:  ChannelCatalogService,
+   pub auth:        WebAuthConfig,
+   pub playback:    PlaybackTicketService,
+   pub stream:      stream_proxy::StreamSessionService,
+   pub catalog:     ChannelCatalogService,
+   pub live_status: LiveStatusService,
 }
 
 /// Build a recording service with the given configuration.
@@ -147,21 +148,22 @@ pub fn build_router(config: &AppConfig, access_code_hash: String) -> Result<Rout
       .clone()
       .unwrap_or_else(|| "streamlink".to_string());
 
-   let stream_service = stream_proxy::StreamSessionService::new(
-      streamlink_path.clone(),
-      config.playback.stream_resolver_mode,
-      config.playback.stream_delivery_mode,
-      config.playback.twitch_client_id.clone(),
-   );
+    let stream_service = stream_proxy::StreamSessionService::new(
+       streamlink_path.clone(),
+       config.playback.stream_resolver_mode,
+       config.playback.stream_delivery_mode,
+       config.playback.twitch_client_id.clone(),
+    );
 
-   let protected_state = ProtectedState {
-      auth: auth_config.clone(),
-      playback,
-      stream: stream_service.clone(),
-      catalog: catalog_service.clone(),
-   };
+    let live_status_service = LiveStatusService::new();
 
-   let live_status_service = LiveStatusService::new();
+    let protected_state = ProtectedState {
+       auth: auth_config.clone(),
+       playback,
+       stream: stream_service.clone(),
+       catalog: catalog_service.clone(),
+       live_status: live_status_service.clone(),
+    };
    let channel_state = routes::ChannelState {
       live_status: live_status_service.clone(),
    };

--- a/src/routes/watch.rs
+++ b/src/routes/watch.rs
@@ -230,38 +230,41 @@ async fn watch_session_handler(
       };
    }
 
-    let force_relay = query.force_relay();
-    let relay_suffix = if force_relay { "?relay=1" } else { "" };
-    let channel_login = validated.channel_login;
-    let status = state.live_status.check_multiple(&[channel_login.clone()]).await;
-    let channel_status = status
-       .channels
-       .get(&channel_login.to_ascii_lowercase())
-       .cloned()
-       .unwrap_or(crate::live_status::ChannelStatus {
-          live:         false,
-          viewer_count: None,
-          game:         None,
-          title:        None,
-          profile_url:  None,
-          display_name: None,
-       });
-    let response = WatchSessionResponse {
-       channel:      channel_login,
-       manifest_url: format!("/stream/{ticket}/{session_token}/manifest{relay_suffix}"),
-       relay:        force_relay,
-       app_version:  APP_VERSION,
-       display_name: channel_status.display_name,
-       profile_url:  channel_status.profile_url,
-       title:        channel_status.title,
-       game:         channel_status.game,
-       viewer_count: channel_status.viewer_count,
-       live:         channel_status.live,
-       resolver:     resolver_label(state.stream.resolver_mode()),
-       delivery_mode: delivery_label(state.stream.delivery_mode()),
-    };
+   let force_relay = query.force_relay();
+   let relay_suffix = if force_relay { "?relay=1" } else { "" };
+   let channel_login = validated.channel_login;
+   let status = state
+      .live_status
+      .check_multiple(&[channel_login.clone()])
+      .await;
+   let channel_status = status
+      .channels
+      .get(&channel_login.to_ascii_lowercase())
+      .cloned()
+      .unwrap_or(crate::live_status::ChannelStatus {
+         live:         false,
+         viewer_count: None,
+         game:         None,
+         title:        None,
+         profile_url:  None,
+         display_name: None,
+      });
+   let response = WatchSessionResponse {
+      channel:       channel_login,
+      manifest_url:  format!("/stream/{ticket}/{session_token}/manifest{relay_suffix}"),
+      relay:         force_relay,
+      app_version:   APP_VERSION,
+      display_name:  channel_status.display_name,
+      profile_url:   channel_status.profile_url,
+      title:         channel_status.title,
+      game:          channel_status.game,
+      viewer_count:  channel_status.viewer_count,
+      live:          channel_status.live,
+      resolver:      resolver_label(state.stream.resolver_mode()),
+      delivery_mode: delivery_label(state.stream.delivery_mode()),
+   };
 
-    (StatusCode::OK, Json(response)).into_response()
+   (StatusCode::OK, Json(response)).into_response()
 }
 
 fn resolver_label(mode: StreamResolverMode) -> String {

--- a/src/routes/watch.rs
+++ b/src/routes/watch.rs
@@ -235,7 +235,7 @@ async fn watch_session_handler(
    let channel_login = validated.channel_login;
    let status = state
       .live_status
-      .check_multiple(&[channel_login.clone()])
+      .check_multiple(std::slice::from_ref(&channel_login))
       .await;
    let channel_status = status
       .channels

--- a/src/routes/watch.rs
+++ b/src/routes/watch.rs
@@ -34,6 +34,10 @@ use crate::{
       WebAuthConfig,
    },
    channel_catalog::CatalogChannel,
+   config::{
+      StreamDeliveryMode,
+      StreamResolverMode,
+   },
    playback::PlaybackTicketError,
    routes::{
       APP_VERSION,
@@ -78,10 +82,18 @@ pub struct WatchTicketResponse {
 /// Response DTO for watch session bootstrap data.
 #[derive(Debug, Serialize)]
 pub struct WatchSessionResponse {
-   pub channel:      String,
-   pub manifest_url: String,
-   pub relay:        bool,
-   pub app_version:  &'static str,
+   pub channel:       String,
+   pub manifest_url:  String,
+   pub relay:         bool,
+   pub app_version:   &'static str,
+   pub display_name:  Option<String>,
+   pub profile_url:   Option<String>,
+   pub title:         Option<String>,
+   pub game:          Option<String>,
+   pub viewer_count:  Option<u64>,
+   pub live:          bool,
+   pub resolver:      String,
+   pub delivery_mode: String,
 }
 
 /// Build watch routes.
@@ -218,14 +230,51 @@ async fn watch_session_handler(
       };
    }
 
-   let force_relay = query.force_relay();
-   let relay_suffix = if force_relay { "?relay=1" } else { "" };
-   let response = WatchSessionResponse {
-      channel:      validated.channel_login,
-      manifest_url: format!("/stream/{ticket}/{session_token}/manifest{relay_suffix}"),
-      relay:        force_relay,
-      app_version:  APP_VERSION,
-   };
+    let force_relay = query.force_relay();
+    let relay_suffix = if force_relay { "?relay=1" } else { "" };
+    let channel_login = validated.channel_login;
+    let status = state.live_status.check_multiple(&[channel_login.clone()]).await;
+    let channel_status = status
+       .channels
+       .get(&channel_login.to_ascii_lowercase())
+       .cloned()
+       .unwrap_or(crate::live_status::ChannelStatus {
+          live:         false,
+          viewer_count: None,
+          game:         None,
+          title:        None,
+          profile_url:  None,
+          display_name: None,
+       });
+    let response = WatchSessionResponse {
+       channel:      channel_login,
+       manifest_url: format!("/stream/{ticket}/{session_token}/manifest{relay_suffix}"),
+       relay:        force_relay,
+       app_version:  APP_VERSION,
+       display_name: channel_status.display_name,
+       profile_url:  channel_status.profile_url,
+       title:        channel_status.title,
+       game:         channel_status.game,
+       viewer_count: channel_status.viewer_count,
+       live:         channel_status.live,
+       resolver:     resolver_label(state.stream.resolver_mode()),
+       delivery_mode: delivery_label(state.stream.delivery_mode()),
+    };
 
-   (StatusCode::OK, Json(response)).into_response()
+    (StatusCode::OK, Json(response)).into_response()
+}
+
+fn resolver_label(mode: StreamResolverMode) -> String {
+   match mode {
+      StreamResolverMode::Auto => "auto".to_string(),
+      StreamResolverMode::Native => "native".to_string(),
+      StreamResolverMode::Streamlink => "streamlink".to_string(),
+   }
+}
+
+fn delivery_label(mode: StreamDeliveryMode) -> String {
+   match mode {
+      StreamDeliveryMode::CdnFirst => "cdn_first".to_string(),
+      StreamDeliveryMode::Relay => "relay".to_string(),
+   }
 }

--- a/src/stream_proxy/session.rs
+++ b/src/stream_proxy/session.rs
@@ -654,21 +654,21 @@ impl StreamSessionService {
       Ok(variants)
    }
 
-    pub const fn should_redirect_to_cdn(&self, force_relay: bool) -> bool {
-       matches!(self.delivery_mode, StreamDeliveryMode::CdnFirst) && !force_relay
-    }
+   pub const fn should_redirect_to_cdn(&self, force_relay: bool) -> bool {
+      matches!(self.delivery_mode, StreamDeliveryMode::CdnFirst) && !force_relay
+   }
 
-    pub const fn resolver_mode(&self) -> StreamResolverMode {
-       self.resolver_mode
-    }
+   pub const fn resolver_mode(&self) -> StreamResolverMode {
+      self.resolver_mode
+   }
 
-    pub const fn delivery_mode(&self) -> StreamDeliveryMode {
-       self.delivery_mode
-    }
+   pub const fn delivery_mode(&self) -> StreamDeliveryMode {
+      self.delivery_mode
+   }
 
-    const fn prewarm_enabled(&self) -> bool {
-       matches!(self.resolver_mode, StreamResolverMode::Streamlink)
-    }
+   const fn prewarm_enabled(&self) -> bool {
+      matches!(self.resolver_mode, StreamResolverMode::Streamlink)
+   }
 
    async fn has_fresh_prewarm(&self, channel: &str) -> bool {
       let guard = self.prewarmed.read().await;

--- a/src/stream_proxy/session.rs
+++ b/src/stream_proxy/session.rs
@@ -654,13 +654,21 @@ impl StreamSessionService {
       Ok(variants)
    }
 
-   pub const fn should_redirect_to_cdn(&self, force_relay: bool) -> bool {
-      matches!(self.delivery_mode, StreamDeliveryMode::CdnFirst) && !force_relay
-   }
+    pub const fn should_redirect_to_cdn(&self, force_relay: bool) -> bool {
+       matches!(self.delivery_mode, StreamDeliveryMode::CdnFirst) && !force_relay
+    }
 
-   const fn prewarm_enabled(&self) -> bool {
-      matches!(self.resolver_mode, StreamResolverMode::Streamlink)
-   }
+    pub const fn resolver_mode(&self) -> StreamResolverMode {
+       self.resolver_mode
+    }
+
+    pub const fn delivery_mode(&self) -> StreamDeliveryMode {
+       self.delivery_mode
+    }
+
+    const fn prewarm_enabled(&self) -> bool {
+       matches!(self.resolver_mode, StreamResolverMode::Streamlink)
+    }
 
    async fn has_fresh_prewarm(&self, channel: &str) -> bool {
       let guard = self.prewarmed.read().await;

--- a/web/src/api-client/types.ts
+++ b/web/src/api-client/types.ts
@@ -224,4 +224,12 @@ export interface WatchSessionResponse {
   manifest_url: string;
   relay: boolean;
   app_version: string;
+  display_name?: string;
+  profile_url?: string;
+  title?: string;
+  game?: string;
+  viewer_count?: number;
+  live: boolean;
+  resolver: 'native' | 'streamlink' | 'auto';
+  delivery_mode: 'cdn_first' | 'relay';
 }

--- a/web/src/api-client/watch.ts
+++ b/web/src/api-client/watch.ts
@@ -2,21 +2,57 @@ import { isObject, readApiError, request, safeJson } from './core.js';
 import type { WatchSessionResponse } from './types.js';
 
 const parseWatchSessionPayload = (payload: unknown): WatchSessionResponse => {
-  if (
-    !isObject(payload) ||
-    typeof payload.app_version !== 'string' ||
-    typeof payload.channel !== 'string' ||
-    typeof payload.manifest_url !== 'string' ||
-    typeof payload.relay !== 'boolean'
-  ) {
+  if (!isObject(payload)) {
     throw new Error('watch session payload is invalid');
   }
 
+  const {
+    app_version: appVersion,
+    channel,
+    delivery_mode: deliveryMode,
+    display_name: displayName,
+    game,
+    live,
+    manifest_url: manifestUrl,
+    profile_url: profileUrl,
+    relay,
+    resolver,
+    title,
+    viewer_count: viewerCount,
+  } = payload;
+
+  if (
+    typeof appVersion !== 'string' ||
+    typeof channel !== 'string' ||
+    typeof manifestUrl !== 'string' ||
+    typeof relay !== 'boolean' ||
+    typeof live !== 'boolean' ||
+    typeof resolver !== 'string' ||
+    typeof deliveryMode !== 'string'
+  ) {
+    throw new TypeError('watch session payload is invalid');
+  }
+
+  if (
+    (resolver !== 'native' && resolver !== 'streamlink' && resolver !== 'auto') ||
+    (deliveryMode !== 'cdn_first' && deliveryMode !== 'relay')
+  ) {
+    throw new TypeError('watch session payload is invalid');
+  }
+
   return {
-    app_version: payload.app_version,
-    channel: payload.channel,
-    manifest_url: payload.manifest_url,
-    relay: payload.relay,
+    app_version: appVersion,
+    channel,
+    delivery_mode: deliveryMode,
+    display_name: typeof displayName === 'string' ? displayName : undefined,
+    game: typeof game === 'string' ? game : undefined,
+    live,
+    manifest_url: manifestUrl,
+    profile_url: typeof profileUrl === 'string' ? profileUrl : undefined,
+    relay,
+    resolver,
+    title: typeof title === 'string' ? title : undefined,
+    viewer_count: typeof viewerCount === 'number' ? viewerCount : undefined,
   };
 };
 

--- a/web/src/components/watch/chat-composer.tsx
+++ b/web/src/components/watch/chat-composer.tsx
@@ -13,7 +13,9 @@ const TAB_INDEX_DISABLED = -1;
 const TAB_INDEX_ENABLED = 0;
 
 export interface ChatComposerHandle {
+  focus: () => void;
   insertEmote: (code: string) => void;
+  insertText: (text: string) => void;
 }
 
 interface ChatComposerProps {
@@ -40,15 +42,51 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(
       closeSuggestions,
       clearPreview,
       insertEmote,
+      emoteChips,
+      setComposerText,
+      text,
     } = useChatComposer({
       availableEmotes,
       disabled,
       onSubmit,
     });
 
-    // Expose imperative handle for emote insertion
+    const EMPTY_TEXT_LENGTH = 0;
+    const CURSOR_MOVE_TIMEOUT_MS = 0;
+
+    const insertText = useCallback(
+      (textValue: string): void => {
+        if (disabled || textValue === '') {
+          return;
+        }
+        const currentText = text;
+        const needsSpace = currentText.length > EMPTY_TEXT_LENGTH && !currentText.endsWith(' ');
+        const prefix = needsSpace ? ' ' : '';
+        setComposerText(`${currentText}${prefix}${textValue}`, emoteChips);
+        // Move cursor to the end of the inserted text.
+        const newPosition = currentText.length + prefix.length + textValue.length;
+        setTimeout(() => {
+          composerRef.current?.focus();
+          const selection = globalThis.getSelection();
+          if (selection === null || composerRef.current === null) {
+            return;
+          }
+          const [textNode] = composerRef.current.childNodes;
+          if (textNode instanceof Text) {
+            selection.collapse(textNode, Math.min(newPosition, textNode.length));
+          }
+        }, CURSOR_MOVE_TIMEOUT_MS);
+      },
+      [disabled, emoteChips, setComposerText, text],
+    );
+
+    // Expose imperative handle for emote insertion, text insertion, and focus
     useImperativeHandle(ref, () => ({
+      focus: (): void => {
+        composerRef.current?.focus();
+      },
       insertEmote,
+      insertText,
     }));
 
     // Handle click outside to close suggestions

--- a/web/src/components/watch/chat.tsx
+++ b/web/src/components/watch/chat.tsx
@@ -1,7 +1,12 @@
-import { PanelRightClose } from 'lucide-react';
-import { useCallback, useRef, type ReactElement } from 'react';
+import { Copy, PanelRightClose, Reply, Clock } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 import type { EmoteItem } from '../../api-client';
-import { emoteUrl, formatUnreadMessage, readableSenderColor } from '../../hooks/watch/chat-utils';
+import {
+  emoteUrl,
+  formatUnreadMessage,
+  readableSenderColor,
+  type ChatMessage,
+} from '../../hooks/watch/chat-utils';
 import { useChat } from '../../hooks/watch/use-chat';
 import { ChatComposer, type ChatComposerHandle } from './chat-composer';
 import { EmotePicker } from './emote-picker';
@@ -9,6 +14,87 @@ import { EmotePicker } from './emote-picker';
 const CHAT_EMPTY_LENGTH = 0;
 const MESSAGE_PARTS_EMPTY_LENGTH = 0;
 const UNREAD_COUNT_ZERO = 0;
+const TIMESTAMP_STORAGE_KEY = 'twitch-relay-chat-timestamps';
+const MILLISECONDS_PER_SECOND = 1000;
+const PAD_WIDTH = 2;
+
+const padTwo = (value: number): string => String(value).padStart(PAD_WIDTH, '0');
+
+const formatTimestamp = (unix: number): string => {
+  const date = new Date(unix * MILLISECONDS_PER_SECOND);
+  return `${padTwo(date.getHours())}:${padTwo(date.getMinutes())}`;
+};
+
+const escapeRegExp = (value: string): string =>
+  value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\\$\u0026`);
+
+interface MentionMatch {
+  end: number;
+  start: number;
+}
+
+const findMentions = (text: string, login: string | undefined, displayName: string | undefined): MentionMatch[] => {
+  const EMPTY_LENGTH = 0;
+  if ((login === undefined || login === '') && (displayName === undefined || displayName === '')) {
+    return [];
+  }
+
+  const names: string[] = [];
+  if (login !== undefined && login !== '') {
+    names.push(escapeRegExp(login));
+  }
+  if (displayName !== undefined && displayName !== '' && displayName.toLowerCase() !== login?.toLowerCase()) {
+    names.push(escapeRegExp(displayName));
+  }
+
+  if (names.length === EMPTY_LENGTH) {
+    return [];
+  }
+
+  const pattern = new RegExp(`(^|[^\\w@])@?(?:${names.join('|')})\\b`, 'gi');
+  const matches: MentionMatch[] = [];
+  let match = pattern.exec(text);
+  while (match !== null) {
+    const [fullMatch, prefix] = match;
+    const prefixLength = prefix.length;
+    const start = match.index + prefixLength;
+    const end = start + fullMatch.length - prefixLength;
+    matches.push({ end, start });
+    match = pattern.exec(text);
+  }
+  return matches;
+};
+
+const renderHighlightedText = (
+  text: string,
+  messageId: string,
+  login: string | undefined,
+  displayName: string | undefined,
+): React.ReactNode[] => {
+  const EMPTY_LENGTH = 0;
+  const matches = findMentions(text, login, displayName);
+  if (matches.length === EMPTY_LENGTH) {
+    return [text];
+  }
+
+  const elements: React.ReactNode[] = [];
+  let lastIndex = 0;
+  for (const [index, match] of matches.entries()) {
+    if (match.start > lastIndex) {
+      elements.push(<span key={`${messageId}-text-${index}-pre`}>{text.slice(lastIndex, match.start)}</span>);
+    }
+    elements.push(
+      <span key={`${messageId}-mention-${index}`} className="chat-mention">
+        {text.slice(match.start, match.end)}
+      </span>,
+    );
+    lastIndex = match.end;
+  }
+  if (lastIndex < text.length) {
+    elements.push(<span key={`${messageId}-text-tail`}>{text.slice(lastIndex)}</span>);
+  }
+  return elements;
+};
 
 interface ChatProps {
   channelLogin: string;
@@ -17,7 +103,104 @@ interface ChatProps {
   onStatusChange: (status: { available: boolean; connected: boolean; message: string }) => void;
   isCollapsed: boolean;
   onToggleCollapse: () => void;
+  currentUserLogin?: string;
+  currentUserDisplayName?: string;
 }
+
+const ChatMessageActions = ({
+  message,
+  onCopy,
+  onReply,
+}: {
+  message: ChatMessage;
+  onCopy: (message: ChatMessage) => void;
+  onReply: (message: ChatMessage) => void;
+}): ReactElement => (
+  <span className="chat-message-actions" role="group" aria-label="Message actions">
+    <button
+      type="button"
+      className="chat-message-action-btn"
+      onClick={() => {
+        onCopy(message);
+      }}
+      aria-label={`Copy message from ${message.sender_display_name}`}
+      title="Copy message"
+    >
+      <Copy aria-hidden="true" size={14} />
+    </button>
+    <button
+      type="button"
+      className="chat-message-action-btn"
+      onClick={() => {
+        onReply(message);
+      }}
+      aria-label={`Reply to ${message.sender_display_name}`}
+      title="Reply"
+    >
+      <Reply aria-hidden="true" size={14} />
+    </button>
+  </span>
+);
+
+const ChatMessageItem = ({
+  currentUserDisplayName,
+  currentUserLogin,
+  message,
+  onCopy,
+  onReply,
+  showTimestamps,
+}: {
+  currentUserDisplayName?: string;
+  currentUserLogin?: string;
+  message: ChatMessage;
+  onCopy: (message: ChatMessage) => void;
+  onReply: (message: ChatMessage) => void;
+  showTimestamps: boolean;
+}): ReactElement => {
+  const memoizedContent = useMemo(
+    () =>
+      message.parts.length > MESSAGE_PARTS_EMPTY_LENGTH
+        ? message.parts.map((part, index) =>
+            part.kind === 'emote' ? (
+              <img
+                key={`${message.id}-${index}`}
+                className="emote"
+                src={part.image_url ?? emoteUrl(part.id ?? '')}
+                alt={part.code ?? ''}
+                title={part.code}
+                loading="lazy"
+                decoding="async"
+              />
+            ) : (
+              <span key={`${message.id}-${index}`}>
+                {renderHighlightedText(
+                  part.text ?? '',
+                  `${message.id}-${index}`,
+                  currentUserLogin,
+                  currentUserDisplayName,
+                )}
+              </span>
+            ),
+          )
+        : renderHighlightedText(message.text, message.id, currentUserLogin, currentUserDisplayName),
+    [currentUserDisplayName, currentUserLogin, message],
+  );
+
+  return (
+    <div className={`chat-message ${message.kind === 'notice' ? 'notice' : ''}`}>
+      {showTimestamps && (
+        <span className="chat-timestamp" aria-label="Message time">
+          {formatTimestamp(message.sent_at_unix)}
+        </span>
+      )}
+      <span className="sender" style={{ color: readableSenderColor(message.sender_color) }}>
+        {message.sender_display_name}
+      </span>
+      <span className="content">{memoizedContent}</span>
+      <ChatMessageActions message={message} onCopy={onCopy} onReply={onReply} />
+    </div>
+  );
+};
 
 export const Chat = ({
   channelLogin,
@@ -26,8 +209,11 @@ export const Chat = ({
   onStatusChange,
   isCollapsed,
   onToggleCollapse,
+  currentUserLogin,
+  currentUserDisplayName,
 }: ChatProps): ReactElement => {
-  const composerRef = useRef<ChatComposerHandle>(null);
+  const composerRef = useRef<ChatComposerHandle | null>(null);
+  const [showTimestamps, setShowTimestamps] = useState(false);
   const {
     chatMessagesRef,
     chatMessages,
@@ -46,8 +232,44 @@ export const Chat = ({
     onStatusChange,
   });
 
+  useEffect(() => {
+    const saved = globalThis.localStorage.getItem(TIMESTAMP_STORAGE_KEY);
+    setShowTimestamps(saved === 'true');
+  }, []);
+
+  const toggleTimestamps = useCallback((): void => {
+    setShowTimestamps((prev) => {
+      const next = !prev;
+      globalThis.localStorage.setItem(TIMESTAMP_STORAGE_KEY, String(next));
+      return next;
+    });
+  }, []);
+
   const handleEmoteSelect = useCallback((code: string): void => {
     composerRef.current?.insertEmote(code);
+  }, []);
+
+  const handleReply = useCallback(
+    (message: ChatMessage): void => {
+      const composer = composerRef.current;
+      if (composer === null) {
+        return;
+      }
+      const mention = `@${message.sender_display_name} `;
+      composer.insertText(mention);
+      composer.focus();
+    },
+    [],
+  );
+
+  const handleCopy = useCallback((message: ChatMessage): void => {
+    void (async (): Promise<void> => {
+      try {
+        await globalThis.navigator.clipboard.writeText(message.text);
+      } catch {
+        // Ignore clipboard errors.
+      }
+    })();
   }, []);
 
   // Collapsed state: minimal rail indicator, hook still running
@@ -59,60 +281,50 @@ export const Chat = ({
   return (
     <div className="chat-panel">
       <div className="chat-header">
-        <strong>Chat</strong>
-        <span className={chatConnected ? 'status-live' : undefined}>{chatStatus}</span>
-        <button
-          type="button"
-          className="chat-header-toggle"
-          onClick={onToggleCollapse}
-          aria-expanded="true"
-          aria-label="Collapse chat"
-        >
-          <PanelRightClose aria-hidden="true" />
-        </button>
+        <div className="chat-header-title">
+          <strong>Chat</strong>
+          <span className={chatConnected ? 'status-live' : undefined}>{chatStatus}</span>
+        </div>
+        <div className="chat-header-actions">
+          <button
+            type="button"
+            className={`chat-header-action-btn ${showTimestamps ? 'active' : ''}`}
+            onClick={toggleTimestamps}
+            aria-pressed={showTimestamps}
+            aria-label="Toggle timestamps"
+            title="Toggle timestamps"
+          >
+            <Clock aria-hidden="true" size={16} />
+          </button>
+          <button
+            type="button"
+            className="chat-header-action-btn chat-header-toggle"
+            onClick={onToggleCollapse}
+            aria-expanded="true"
+            aria-label="Collapse chat"
+            title="Collapse chat"
+          >
+            <PanelRightClose aria-hidden="true" size={16} />
+          </button>
+        </div>
       </div>
 
       {chatAvailable ? (
         <>
-          <div
-            ref={chatMessagesRef}
-            className="chat-messages ui-hide-scrollbar"
-            onScroll={handleScroll}
-          >
+          <div ref={chatMessagesRef} className="chat-messages ui-hide-scrollbar" onScroll={handleScroll}>
             {chatMessages.length === CHAT_EMPTY_LENGTH && (
               <p className="chat-empty">Waiting for messages...</p>
             )}
             {chatMessages.map((message) => (
-              <div
+              <ChatMessageItem
                 key={message.id}
-                className={`chat-message ${message.kind === 'notice' ? 'notice' : ''}`}
-              >
-                <span
-                  className="sender"
-                  style={{ color: readableSenderColor(message.sender_color) }}
-                >
-                  {message.sender_display_name}
-                </span>
-                <span className="content">
-                  {message.parts.length > MESSAGE_PARTS_EMPTY_LENGTH
-                    ? message.parts.map((part, index) =>
-                        part.kind === 'emote' ? (
-                          <img
-                            key={`${message.id}-${index}`}
-                            className="emote"
-                            src={part.image_url ?? emoteUrl(part.id ?? '')}
-                            alt={part.code ?? ''}
-                            title={part.code}
-                            loading="lazy"
-                            decoding="async"
-                          />
-                        ) : (
-                          <span key={`${message.id}-${index}`}>{part.text}</span>
-                        ),
-                      )
-                    : message.text}
-                </span>
-              </div>
+                currentUserDisplayName={currentUserDisplayName}
+                currentUserLogin={currentUserLogin}
+                message={message}
+                onCopy={handleCopy}
+                onReply={handleReply}
+                showTimestamps={showTimestamps}
+              />
             ))}
           </div>
           {unreadChatCount > UNREAD_COUNT_ZERO && (

--- a/web/src/components/watch/chat.tsx
+++ b/web/src/components/watch/chat.tsx
@@ -33,7 +33,11 @@ interface MentionMatch {
   start: number;
 }
 
-const findMentions = (text: string, login: string | undefined, displayName: string | undefined): MentionMatch[] => {
+const findMentions = (
+  text: string,
+  login: string | undefined,
+  displayName: string | undefined,
+): MentionMatch[] => {
   const EMPTY_LENGTH = 0;
   if ((login === undefined || login === '') && (displayName === undefined || displayName === '')) {
     return [];
@@ -43,7 +47,11 @@ const findMentions = (text: string, login: string | undefined, displayName: stri
   if (login !== undefined && login !== '') {
     names.push(escapeRegExp(login));
   }
-  if (displayName !== undefined && displayName !== '' && displayName.toLowerCase() !== login?.toLowerCase()) {
+  if (
+    displayName !== undefined &&
+    displayName !== '' &&
+    displayName.toLowerCase() !== login?.toLowerCase()
+  ) {
     names.push(escapeRegExp(displayName));
   }
 
@@ -81,7 +89,9 @@ const renderHighlightedText = (
   let lastIndex = 0;
   for (const [index, match] of matches.entries()) {
     if (match.start > lastIndex) {
-      elements.push(<span key={`${messageId}-text-${index}-pre`}>{text.slice(lastIndex, match.start)}</span>);
+      elements.push(
+        <span key={`${messageId}-text-${index}-pre`}>{text.slice(lastIndex, match.start)}</span>,
+      );
     }
     elements.push(
       <span key={`${messageId}-mention-${index}`} className="chat-mention">
@@ -249,18 +259,15 @@ export const Chat = ({
     composerRef.current?.insertEmote(code);
   }, []);
 
-  const handleReply = useCallback(
-    (message: ChatMessage): void => {
-      const composer = composerRef.current;
-      if (composer === null) {
-        return;
-      }
-      const mention = `@${message.sender_display_name} `;
-      composer.insertText(mention);
-      composer.focus();
-    },
-    [],
-  );
+  const handleReply = useCallback((message: ChatMessage): void => {
+    const composer = composerRef.current;
+    if (composer === null) {
+      return;
+    }
+    const mention = `@${message.sender_display_name} `;
+    composer.insertText(mention);
+    composer.focus();
+  }, []);
 
   const handleCopy = useCallback((message: ChatMessage): void => {
     void (async (): Promise<void> => {
@@ -311,7 +318,11 @@ export const Chat = ({
 
       {chatAvailable ? (
         <>
-          <div ref={chatMessagesRef} className="chat-messages ui-hide-scrollbar" onScroll={handleScroll}>
+          <div
+            ref={chatMessagesRef}
+            className="chat-messages ui-hide-scrollbar"
+            onScroll={handleScroll}
+          >
             {chatMessages.length === CHAT_EMPTY_LENGTH && (
               <p className="chat-empty">Waiting for messages...</p>
             )}

--- a/web/src/components/watch/index.ts
+++ b/web/src/components/watch/index.ts
@@ -2,3 +2,4 @@ export { Chat } from './chat';
 export { ChatComposer } from './chat-composer';
 export { EmotePicker } from './emote-picker';
 export { VideoPlayer } from './video-player';
+export { WatchPageMeta } from './watch-page-meta';

--- a/web/src/components/watch/recording-button.tsx
+++ b/web/src/components/watch/recording-button.tsx
@@ -57,11 +57,7 @@ export const RecordingButton = ({
   }, [isRecording, onStart, onStop, channelLogin]);
 
   const label = isRecording ? 'Stop' : 'Record';
-  const icon = isRecording ? (
-    <Square size={14} fill="currentColor" />
-  ) : (
-    <Radio size={14} />
-  );
+  const icon = isRecording ? <Square size={14} fill="currentColor" /> : <Radio size={14} />;
 
   return (
     <div className="recording-button-wrap">
@@ -78,9 +74,7 @@ export const RecordingButton = ({
         {label}
       </button>
       {isRecording && <span className="recording-pulse" aria-hidden="true" />}
-      {error !== undefined && error !== '' && (
-        <span className="recording-error">{error}</span>
-      )}
+      {error !== undefined && error !== '' && <span className="recording-error">{error}</span>}
     </div>
   );
 };

--- a/web/src/components/watch/recording-button.tsx
+++ b/web/src/components/watch/recording-button.tsx
@@ -1,0 +1,86 @@
+import { Loader2, Radio, Square } from 'lucide-react';
+import { useCallback, useState, type ReactElement } from 'react';
+import type { ActiveRecording } from '../../api-client/types';
+
+interface RecordingButtonProps {
+  channelLogin: string;
+  recording: ActiveRecording | undefined;
+  onStart: () => Promise<void>;
+  onStop: () => Promise<void>;
+}
+
+const EMPTY_MESSAGE_LENGTH = 0;
+
+const readMessage = (error: unknown, fallback: string): string => {
+  if (error instanceof Error && error.message.trim().length > EMPTY_MESSAGE_LENGTH) {
+    return error.message;
+  }
+  return fallback;
+};
+
+export const RecordingButton = ({
+  channelLogin,
+  recording,
+  onStart,
+  onStop,
+}: RecordingButtonProps): ReactElement => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+
+  const isRecording = recording !== undefined;
+  const mode = recording?.mode;
+  const recordingClass = ((): string => {
+    if (mode === 'auto') {
+      return 'active-auto';
+    }
+    if (mode === 'manual') {
+      return 'active-manual';
+    }
+    return '';
+  })();
+
+  const handleClick = useCallback((): void => {
+    setLoading(true);
+    setError(undefined);
+
+    const action = isRecording ? onStop : onStart;
+
+    void (async (): Promise<void> => {
+      try {
+        await action();
+      } catch (actionError) {
+        setError(readMessage(actionError, `Recording action failed for ${channelLogin}`));
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [isRecording, onStart, onStop, channelLogin]);
+
+  const label = isRecording ? 'Stop' : 'Record';
+  const icon = isRecording ? (
+    <Square size={14} fill="currentColor" />
+  ) : (
+    <Radio size={14} />
+  );
+
+  return (
+    <div className="recording-button-wrap">
+      <button
+        type="button"
+        className={`recording-button ${isRecording ? 'recording' : ''} ${recordingClass} ${loading ? 'loading' : ''}`}
+        onClick={handleClick}
+        disabled={loading}
+        aria-busy={loading}
+        title={isRecording ? `Stop ${mode ?? ''} recording`.trim() : 'Start recording'}
+        aria-label={isRecording ? `Stop ${mode ?? ''} recording`.trim() : 'Start recording'}
+      >
+        {loading ? <Loader2 size={14} className="spinning" /> : icon}
+        {label}
+      </button>
+      {isRecording && <span className="recording-pulse" aria-hidden="true" />}
+      {error !== undefined && error !== '' && (
+        <span className="recording-error">{error}</span>
+      )}
+    </div>
+  );
+};

--- a/web/src/components/watch/use-video-controls.ts
+++ b/web/src/components/watch/use-video-controls.ts
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useImperativeHandle, useState } from 'react';
+
+export interface VideoControlsHandle {
+  enterFullscreen: () => void;
+  toggleMute: () => void;
+}
+
+interface UseVideoControlsOptions {
+  playerRef: React.RefObject<HTMLVideoElement | null>;
+  playerHandleRef?: React.RefObject<VideoControlsHandle | null>;
+}
+
+interface UseVideoControlsReturn {
+  isFullscreen: boolean;
+  isPip: boolean;
+  toggleFullscreen: () => void;
+  togglePip: () => void;
+}
+
+const requestFullscreen = async (element: HTMLVideoElement): Promise<void> => {
+  try {
+    await element.requestFullscreen();
+  } catch {
+    // Ignore unsupported or rejected fullscreen requests.
+  }
+};
+
+const exitFullscreen = async (): Promise<void> => {
+  try {
+    if (document.fullscreenElement) {
+      await document.exitFullscreen();
+    }
+  } catch {
+    // Ignore unsupported or rejected fullscreen requests.
+  }
+};
+
+const requestPip = async (element: HTMLVideoElement): Promise<void> => {
+  try {
+    await element.requestPictureInPicture();
+  } catch {
+    // Ignore unsupported or rejected PiP requests.
+  }
+};
+
+const exitPip = async (): Promise<void> => {
+  try {
+    if (document.pictureInPictureElement) {
+      await document.exitPictureInPicture();
+    }
+  } catch {
+    // Ignore unsupported or rejected PiP requests.
+  }
+};
+
+export const useVideoControls = (options: UseVideoControlsOptions): UseVideoControlsReturn => {
+  const { playerRef, playerHandleRef } = options;
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [isPip, setIsPip] = useState(false);
+
+  const enterFullscreen = useCallback((): void => {
+    const playerEl = playerRef.current;
+    if (!playerEl) {
+      return;
+    }
+    void requestFullscreen(playerEl);
+  }, [playerRef]);
+
+  const toggleFullscreen = useCallback((): void => {
+    if (document.fullscreenElement) {
+      void exitFullscreen();
+    } else {
+      enterFullscreen();
+    }
+  }, [enterFullscreen]);
+
+  const enterPip = useCallback((): void => {
+    const playerEl = playerRef.current;
+    if (!playerEl) {
+      return;
+    }
+    void requestPip(playerEl);
+  }, [playerRef]);
+
+  const togglePip = useCallback((): void => {
+    if (document.pictureInPictureElement) {
+      void exitPip();
+    } else {
+      enterPip();
+    }
+  }, [enterPip]);
+
+  const toggleMute = useCallback((): void => {
+    const playerEl = playerRef.current;
+    if (!playerEl) {
+      return;
+    }
+    playerEl.muted = !playerEl.muted;
+  }, [playerRef]);
+
+  useEffect(() => {
+    const playerEl = playerRef.current;
+
+    const handleFullscreenChange = (): void => {
+      setIsFullscreen(document.fullscreenElement === playerEl);
+    };
+    const handlePipChange = (): void => {
+      setIsPip(document.pictureInPictureElement === playerEl);
+    };
+
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+    document.addEventListener('webkitfullscreenchange', handleFullscreenChange);
+    playerEl?.addEventListener('enterpictureinpicture', handlePipChange);
+    playerEl?.addEventListener('leavepictureinpicture', handlePipChange);
+
+    return (): void => {
+      document.removeEventListener('fullscreenchange', handleFullscreenChange);
+      document.removeEventListener('webkitfullscreenchange', handleFullscreenChange);
+      playerEl?.removeEventListener('enterpictureinpicture', handlePipChange);
+      playerEl?.removeEventListener('leavepictureinpicture', handlePipChange);
+    };
+  }, [playerRef]);
+
+  useImperativeHandle(
+    playerHandleRef,
+    () => ({
+      enterFullscreen,
+      toggleMute,
+    }),
+    [enterFullscreen, toggleMute],
+  );
+
+  return {
+    isFullscreen,
+    isPip,
+    toggleFullscreen,
+    togglePip,
+  };
+};

--- a/web/src/components/watch/video-player.tsx
+++ b/web/src/components/watch/video-player.tsx
@@ -64,7 +64,6 @@ export const VideoPlayer = ({
           </button>
         </div>
         <div className="overlay-right">
-
           {onToggleTheater && (
             <button
               type="button"

--- a/web/src/components/watch/video-player.tsx
+++ b/web/src/components/watch/video-player.tsx
@@ -1,13 +1,23 @@
-import { PanelRightOpen } from 'lucide-react';
+import {
+  Maximize,
+  Minimize,
+  PanelRightOpen,
+  PictureInPicture2,
+  RectangleHorizontal,
+} from 'lucide-react';
 import type { ReactElement } from 'react';
 import { useVideoPlayer } from '../../hooks/watch/use-video-player';
 import { AUTO_LEVEL, qualityLabel } from '../../hooks/watch/video-player-utils';
+import { useVideoControls } from './use-video-controls';
 
 interface VideoPlayerProps {
   manifestUrl: string;
   onError: (message: string) => void;
   chatCollapsed?: boolean;
   onToggleChat?: () => void;
+  theaterMode?: boolean;
+  onToggleTheater?: () => void;
+  playerHandleRef?: React.RefObject<{ enterFullscreen: () => void; toggleMute: () => void } | null>;
 }
 
 export const VideoPlayer = ({
@@ -15,6 +25,9 @@ export const VideoPlayer = ({
   onError,
   chatCollapsed,
   onToggleChat,
+  theaterMode = false,
+  onToggleTheater,
+  playerHandleRef,
 }: VideoPlayerProps): ReactElement => {
   const {
     playerRef,
@@ -27,6 +40,11 @@ export const VideoPlayer = ({
     selectQuality,
     goLive,
   } = useVideoPlayer({ manifestUrl, onError });
+
+  const { isFullscreen, isPip, toggleFullscreen, togglePip } = useVideoControls({
+    playerHandleRef,
+    playerRef,
+  });
 
   return (
     <div className="video-shell">
@@ -46,6 +64,34 @@ export const VideoPlayer = ({
           </button>
         </div>
         <div className="overlay-right">
+
+          {onToggleTheater && (
+            <button
+              type="button"
+              className={`overlay-btn theater-btn ${theaterMode ? 'active' : ''}`}
+              onClick={onToggleTheater}
+              aria-label={theaterMode ? 'Exit theater mode' : 'Enter theater mode'}
+              aria-pressed={theaterMode}
+            >
+              <RectangleHorizontal size={20} />
+            </button>
+          )}
+          <button
+            type="button"
+            className="overlay-btn pip-btn"
+            onClick={togglePip}
+            aria-label={isPip ? 'Exit picture-in-picture' : 'Enter picture-in-picture'}
+          >
+            <PictureInPicture2 size={20} />
+          </button>
+          <button
+            type="button"
+            className="overlay-btn fullscreen-btn"
+            onClick={toggleFullscreen}
+            aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+          >
+            {isFullscreen ? <Minimize size={20} /> : <Maximize size={20} />}
+          </button>
           <button type="button" className="overlay-btn quality-btn" onClick={toggleQualityMenu}>
             {selectedQualityLabel}
           </button>

--- a/web/src/components/watch/watch-content.tsx
+++ b/web/src/components/watch/watch-content.tsx
@@ -1,8 +1,8 @@
+import type { ReactElement } from 'react';
 import type { EmoteItem } from '../../api-client';
 import { Chat } from './chat';
-import { VideoPlayer } from './video-player';
 import type { VideoControlsHandle } from './use-video-controls';
-import type { ReactElement } from 'react';
+import { VideoPlayer } from './video-player';
 
 interface ChatStatus {
   available: boolean;
@@ -68,7 +68,9 @@ export const WatchContent = (props: WatchContentProps): ReactElement => {
   }
 
   return (
-    <div className={`watch-layout ${isChatCollapsed ? 'chat-collapsed' : ''} ${theaterMode ? 'theater' : ''}`}>
+    <div
+      className={`watch-layout ${isChatCollapsed ? 'chat-collapsed' : ''} ${theaterMode ? 'theater' : ''}`}
+    >
       <section className="watch-player-panel">
         <VideoPlayer
           chatCollapsed={isChatCollapsed}

--- a/web/src/components/watch/watch-content.tsx
+++ b/web/src/components/watch/watch-content.tsx
@@ -1,0 +1,111 @@
+import type { EmoteItem } from '../../api-client';
+import { Chat } from './chat';
+import { VideoPlayer } from './video-player';
+import type { VideoControlsHandle } from './use-video-controls';
+import type { ReactElement } from 'react';
+
+interface ChatStatus {
+  available: boolean;
+  connected: boolean;
+  message: string;
+}
+
+interface WatchContentProps {
+  availableEmotes: EmoteItem[];
+  channelLogin: string;
+  chatAvailable: boolean;
+  currentUserDisplayName?: string;
+  currentUserLogin?: string;
+  handleChatStatusChange: (status: ChatStatus) => void;
+  handleConnectTwitch: () => void;
+  handlePlaybackError: (msg: string) => void;
+  handleToggleCollapse: () => void;
+  isChatCollapsed: boolean;
+  manifestUrl: string;
+  onToggleTheater: () => void;
+  playbackError: string | undefined;
+  theaterMode: boolean;
+  videoPlayerRef: React.RefObject<VideoControlsHandle | null>;
+  watchError: string | undefined;
+  watchLoading: boolean;
+}
+
+export const WatchContent = (props: WatchContentProps): ReactElement => {
+  const {
+    availableEmotes,
+    channelLogin,
+    chatAvailable,
+    currentUserDisplayName,
+    currentUserLogin,
+    handleChatStatusChange,
+    handleConnectTwitch,
+    handlePlaybackError,
+    handleToggleCollapse,
+    isChatCollapsed,
+    manifestUrl,
+    onToggleTheater,
+    playbackError,
+    theaterMode,
+    videoPlayerRef,
+    watchError,
+    watchLoading,
+  } = props;
+
+  if (watchLoading) {
+    return (
+      <div className="watch-loading-state">
+        <p className="ui-muted">Loading watch session...</p>
+      </div>
+    );
+  }
+
+  if (watchError !== undefined && watchError !== '') {
+    return (
+      <div className="watch-loading-state">
+        <p className="ui-error">{watchError}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`watch-layout ${isChatCollapsed ? 'chat-collapsed' : ''} ${theaterMode ? 'theater' : ''}`}>
+      <section className="watch-player-panel">
+        <VideoPlayer
+          chatCollapsed={isChatCollapsed}
+          manifestUrl={manifestUrl}
+          onError={handlePlaybackError}
+          onToggleChat={handleToggleCollapse}
+          onToggleTheater={onToggleTheater}
+          playerHandleRef={videoPlayerRef}
+          theaterMode={theaterMode}
+        />
+
+        {playbackError !== undefined && playbackError !== '' && (
+          <p className="ui-error">{playbackError}</p>
+        )}
+      </section>
+
+      <aside className={`watch-chat-panel ${isChatCollapsed ? 'collapsed' : ''}`}>
+        {chatAvailable ? (
+          <Chat
+            availableEmotes={availableEmotes}
+            channelLogin={channelLogin}
+            chatAvailable={chatAvailable}
+            currentUserDisplayName={currentUserDisplayName}
+            currentUserLogin={currentUserLogin}
+            isCollapsed={isChatCollapsed}
+            onStatusChange={handleChatStatusChange}
+            onToggleCollapse={handleToggleCollapse}
+          />
+        ) : (
+          <div className="chat-offline">
+            <p className="ui-muted">Connect Twitch to read and send messages.</p>
+            <button type="button" className="ui-nav-chip" onClick={handleConnectTwitch}>
+              Connect Twitch
+            </button>
+          </div>
+        )}
+      </aside>
+    </div>
+  );
+};

--- a/web/src/components/watch/watch-page-meta.tsx
+++ b/web/src/components/watch/watch-page-meta.tsx
@@ -1,0 +1,73 @@
+import { Users } from 'lucide-react';
+import type { ReactElement } from 'react';
+
+const FALLBACK_INITIAL_LENGTH = 1;
+const FALLBACK_INITIAL_START = 0;
+const VIEWER_COUNT_LOCALE = 'en-US';
+
+interface WatchPageMetaProps {
+  channelLogin: string;
+  displayName?: string;
+  game?: string;
+  live: boolean;
+  profileUrl?: string;
+  title?: string;
+  viewerCount?: number;
+}
+
+const formatViewerCount = (count: number): string =>
+  new Intl.NumberFormat(VIEWER_COUNT_LOCALE).format(count);
+
+export const WatchPageMeta = ({
+  channelLogin,
+  displayName,
+  game,
+  live,
+  profileUrl,
+  title,
+  viewerCount,
+}: WatchPageMetaProps): ReactElement => {
+  const trimmedDisplayName = displayName?.trim();
+  const shownName = trimmedDisplayName !== undefined && trimmedDisplayName !== ''
+    ? trimmedDisplayName
+    : channelLogin;
+  const showLogin = trimmedDisplayName !== undefined && trimmedDisplayName !== ''
+    && trimmedDisplayName.toLowerCase() !== channelLogin.toLowerCase();
+
+  return (
+    <div className="watch-page-meta">
+      {profileUrl !== undefined && profileUrl !== '' ? (
+        <img alt={`${shownName} avatar`} className="ui-avatar watch-page-avatar" src={profileUrl} />
+      ) : (
+        <div className="ui-avatar ui-avatar-fallback watch-page-avatar">
+          {shownName.slice(FALLBACK_INITIAL_START, FALLBACK_INITIAL_LENGTH)}
+        </div>
+      )}
+
+      <div className="watch-page-meta-text">
+        <div className="watch-page-name-row">
+          <span className="watch-page-name">{shownName}</span>
+          {showLogin && <span className="watch-page-login">{channelLogin}</span>}
+          <span className={`watch-page-live-badge ${live ? 'live' : 'offline'}`}>
+            <span className="watch-page-live-dot" />
+            {live ? 'LIVE' : 'OFFLINE'}
+          </span>
+          {live && typeof viewerCount === 'number' && (
+            <span className="watch-page-viewers">
+              <Users size={14} />
+              {formatViewerCount(viewerCount)}
+            </span>
+          )}
+        </div>
+        <div className="watch-page-detail-row">
+          {title !== undefined && title !== '' && (
+            <span className="watch-page-title-text">{title}</span>
+          )}
+          {game !== undefined && game !== '' && (
+            <span className="watch-page-game">{game}</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/web/src/components/watch/watch-page-meta.tsx
+++ b/web/src/components/watch/watch-page-meta.tsx
@@ -28,11 +28,14 @@ export const WatchPageMeta = ({
   viewerCount,
 }: WatchPageMetaProps): ReactElement => {
   const trimmedDisplayName = displayName?.trim();
-  const shownName = trimmedDisplayName !== undefined && trimmedDisplayName !== ''
-    ? trimmedDisplayName
-    : channelLogin;
-  const showLogin = trimmedDisplayName !== undefined && trimmedDisplayName !== ''
-    && trimmedDisplayName.toLowerCase() !== channelLogin.toLowerCase();
+  const shownName =
+    trimmedDisplayName !== undefined && trimmedDisplayName !== ''
+      ? trimmedDisplayName
+      : channelLogin;
+  const showLogin =
+    trimmedDisplayName !== undefined &&
+    trimmedDisplayName !== '' &&
+    trimmedDisplayName.toLowerCase() !== channelLogin.toLowerCase();
 
   return (
     <div className="watch-page-meta">
@@ -63,9 +66,7 @@ export const WatchPageMeta = ({
           {title !== undefined && title !== '' && (
             <span className="watch-page-title-text">{title}</span>
           )}
-          {game !== undefined && game !== '' && (
-            <span className="watch-page-game">{game}</span>
-          )}
+          {game !== undefined && game !== '' && <span className="watch-page-game">{game}</span>}
         </div>
       </div>
     </div>

--- a/web/src/hooks/use-keyboard-shortcuts.ts
+++ b/web/src/hooks/use-keyboard-shortcuts.ts
@@ -74,9 +74,7 @@ export const useKeyboardShortcuts = (options: KeyboardShortcutsOptions): void =>
   }, [onFocusChat, onFullscreen, onMute, onTheater, theaterMode]);
 };
 
-export const useToggleCallback = (
-  setter: Dispatch<SetStateAction<boolean>>,
-): (() => void) =>
+export const useToggleCallback = (setter: Dispatch<SetStateAction<boolean>>): (() => void) =>
   useCallback((): void => {
     setter((prev: boolean) => !prev);
   }, [setter]);

--- a/web/src/hooks/use-keyboard-shortcuts.ts
+++ b/web/src/hooks/use-keyboard-shortcuts.ts
@@ -1,0 +1,82 @@
+import { type Dispatch, type SetStateAction, useCallback, useEffect } from 'react';
+
+interface KeyboardShortcutsOptions {
+  onFocusChat: () => void;
+  onFullscreen: () => void;
+  onMute: () => void;
+  onTheater: () => void;
+  theaterMode: boolean;
+}
+
+const isTypingTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  return (
+    target.isContentEditable ||
+    target.closest('.ui-chat-composer') !== null ||
+    target.tagName === 'INPUT' ||
+    target.tagName === 'TEXTAREA'
+  );
+};
+
+export const useKeyboardShortcuts = (options: KeyboardShortcutsOptions): void => {
+  const { onFocusChat, onFullscreen, onMute, onTheater, theaterMode } = options;
+
+  useEffect(() => {
+    const handleKeydown = (event: KeyboardEvent): void => {
+      if (isTypingTarget(event.target)) {
+        return;
+      }
+
+      switch (event.key) {
+        case 'f':
+        case 'F': {
+          event.preventDefault();
+          onFullscreen();
+          break;
+        }
+        case 't':
+        case 'T': {
+          event.preventDefault();
+          onTheater();
+          break;
+        }
+        case 'm':
+        case 'M': {
+          event.preventDefault();
+          onMute();
+          break;
+        }
+        case 'c':
+        case 'C': {
+          event.preventDefault();
+          onFocusChat();
+          break;
+        }
+        case 'Escape': {
+          if (theaterMode) {
+            event.preventDefault();
+            onTheater();
+          }
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeydown);
+    return (): void => {
+      document.removeEventListener('keydown', handleKeydown);
+    };
+  }, [onFocusChat, onFullscreen, onMute, onTheater, theaterMode]);
+};
+
+export const useToggleCallback = (
+  setter: Dispatch<SetStateAction<boolean>>,
+): (() => void) =>
+  useCallback((): void => {
+    setter((prev: boolean) => !prev);
+  }, [setter]);

--- a/web/src/hooks/use-watch-preferences.ts
+++ b/web/src/hooks/use-watch-preferences.ts
@@ -1,0 +1,40 @@
+import { type Dispatch, type SetStateAction, useEffect, useState } from 'react';
+
+const THEATER_STORAGE_KEY = 'twitch-relay-watch-theater';
+const CHAT_COLLAPSED_STORAGE_KEY = 'twitch-relay-watch-chat-collapsed';
+
+export const useWatchPreferences = (): {
+  isChatCollapsed: boolean;
+  setIsChatCollapsed: Dispatch<SetStateAction<boolean>>;
+  theaterMode: boolean;
+  setTheaterMode: Dispatch<SetStateAction<boolean>>;
+} => {
+  const [theaterMode, setTheaterMode] = useState(false);
+  const [isChatCollapsed, setIsChatCollapsed] = useState(false);
+
+  useEffect(() => {
+    const savedTheater = globalThis.localStorage.getItem(THEATER_STORAGE_KEY);
+    setTheaterMode(savedTheater === 'true');
+
+    const savedCollapsed = globalThis.localStorage.getItem(CHAT_COLLAPSED_STORAGE_KEY);
+    setIsChatCollapsed(savedCollapsed === 'true');
+  }, []);
+
+  useEffect(() => {
+    globalThis.localStorage.setItem(THEATER_STORAGE_KEY, String(theaterMode));
+  }, [theaterMode]);
+
+  useEffect(() => {
+    globalThis.localStorage.setItem(CHAT_COLLAPSED_STORAGE_KEY, String(isChatCollapsed));
+  }, [isChatCollapsed]);
+
+  useEffect(() => {
+    if (theaterMode) {
+      document.body.dataset.theater = 'true';
+    } else {
+      delete document.body.dataset.theater;
+    }
+  }, [theaterMode]);
+
+  return { isChatCollapsed, setIsChatCollapsed, setTheaterMode, theaterMode };
+};

--- a/web/src/hooks/watch/chat-utils.ts
+++ b/web/src/hooks/watch/chat-utils.ts
@@ -15,6 +15,7 @@ export interface ChatMessage {
   sender_color: string | null;
   text: string;
   parts: ChatPart[];
+  sent_at_unix: number;
 }
 
 type JsonRecord = Readonly<Record<string, unknown>>;
@@ -112,6 +113,19 @@ const extractMessageText = (payload: JsonRecord): string => {
   return EMPTY_STRING;
 };
 
+// Extract message timestamp from payload
+const extractSentAtUnix = (payload: JsonRecord): number => {
+  const MILLISECONDS_PER_SECOND = 1000;
+  const { sent_at_unix: sentAtUnix, now_unix_secs: nowUnixSecs } = payload;
+  if (typeof sentAtUnix === 'number' && Number.isFinite(sentAtUnix)) {
+    return sentAtUnix;
+  }
+  if (typeof nowUnixSecs === 'number' && Number.isFinite(nowUnixSecs)) {
+    return nowUnixSecs;
+  }
+  return Math.floor(Date.now() / MILLISECONDS_PER_SECOND);
+};
+
 // Check if part is text type
 const isTextPart = (partRecord: JsonRecord): boolean =>
   partRecord.kind === 'text' && typeof partRecord.text === 'string';
@@ -197,6 +211,7 @@ const buildChatMessage = (payload: JsonRecord): ChatMessage | null => {
   const senderColor = extractSenderColor(payload);
   const parts = extractChatParts(payload);
   const text = extractMessageText(payload);
+  const sentAtUnix = extractSentAtUnix(payload);
   const id = generateMessageId();
 
   return {
@@ -205,6 +220,7 @@ const buildChatMessage = (payload: JsonRecord): ChatMessage | null => {
     parts,
     sender_color: senderColor,
     sender_display_name: senderDisplayName,
+    sent_at_unix: sentAtUnix,
     text,
   };
 };

--- a/web/src/hooks/watch/use-video-player.ts
+++ b/web/src/hooks/watch/use-video-player.ts
@@ -152,7 +152,6 @@ export const useVideoPlayer = (options: UseVideoPlayerOptions): UseVideoPlayerRe
     updateGoLiveState();
   }, [hlsInstanceRef, updateGoLiveState]);
 
-
   useEffect(() => {
     let cleanupFn: (() => void) | null = null;
 

--- a/web/src/hooks/watch/use-video-player.ts
+++ b/web/src/hooks/watch/use-video-player.ts
@@ -152,7 +152,7 @@ export const useVideoPlayer = (options: UseVideoPlayerOptions): UseVideoPlayerRe
     updateGoLiveState();
   }, [hlsInstanceRef, updateGoLiveState]);
 
-  // Setup player when manifestUrl changes
+
   useEffect(() => {
     let cleanupFn: (() => void) | null = null;
 

--- a/web/src/lib/styles/app.css
+++ b/web/src/lib/styles/app.css
@@ -1562,6 +1562,141 @@ body[data-theme='youtube'] {
 
 /* === End of file === */
 
+.recording-button-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  position: relative;
+}
+
+.recording-button {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--border-soft);
+  border-radius: 0.6rem;
+  color: var(--danger);
+  padding: 0.4rem 0.7rem;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-height: 2rem;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.recording-button:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--danger) 10%, transparent);
+  border-color: color-mix(in srgb, var(--danger) 50%, var(--border));
+}
+
+.recording-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--danger) 35%, transparent);
+}
+
+.recording-button:disabled,
+.recording-button.loading {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.recording-button.recording {
+  color: white;
+}
+
+.recording-button.recording.active-manual {
+  background: color-mix(in srgb, var(--danger) 74%, #1e2030);
+  border-color: color-mix(in srgb, var(--danger) 75%, #fff);
+}
+
+.recording-button.recording.active-auto {
+  background: color-mix(in srgb, #f3b35f 74%, #1e2030);
+  border-color: color-mix(in srgb, #f3b35f 76%, #fff);
+}
+
+.recording-button.recording.active-auto:hover:not(:disabled) {
+  background: color-mix(in srgb, #f3b35f 82%, #1e2030);
+}
+
+.recording-button.recording.active-manual:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--danger) 82%, #1e2030);
+}
+
+.recording-pulse {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  animation: pulse 1.5s ease-in-out infinite;
+  color: var(--danger);
+}
+
+.recording-button.recording.active-auto ~ .recording-pulse {
+  color: var(--warn);
+}
+
+.recording-error {
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  right: 0;
+  white-space: nowrap;
+  font-size: 0.78rem;
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 10%, var(--bg));
+  border: 1px solid color-mix(in srgb, var(--danger) 30%, transparent);
+  border-radius: 0.4rem;
+  padding: 0.3rem 0.5rem;
+  z-index: 10;
+}
+
+@media (max-width: 700px) {
+  .stream-info-bar {
+    gap: 0.55rem;
+    padding: 0.55rem 0.65rem;
+  }
+
+  .stream-info-actions {
+    width: 100%;
+    justify-content: flex-end;
+    order: 3;
+  }
+
+  .stream-info-details {
+    width: 100%;
+    order: 3;
+  }
+
+  .recording-error {
+    position: static;
+    white-space: normal;
+    width: 100%;
+  }
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.5;
+    transform: scale(1.15);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 /* ============================================================================
    Watch Page Styles (ported from Svelte components)
    ============================================================================ */
@@ -1575,37 +1710,129 @@ body[data-theme='youtube'] {
 }
 
 .watch-page-header {
-  padding: 0.75rem 1rem;
+  padding: 0.55rem 0.75rem;
   border-bottom: 1px solid var(--border);
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
+  transition: opacity 150ms ease;
+  flex-wrap: wrap;
 }
 
 .watch-page-meta {
   display: flex;
-  align-items: baseline;
-  gap: 0.75rem;
+  align-items: center;
+  gap: 0.6rem;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.watch-page-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  flex: 0 0 32px;
+}
+
+.watch-page-meta-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.08rem;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.watch-page-name-row,
+.watch-page-detail-row {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
   min-width: 0;
 }
 
-.watch-page-meta strong {
-  font-size: 1rem;
-  font-weight: 700;
-  text-transform: lowercase;
-  color: var(--fg);
+.watch-page-detail-row {
+  color: var(--muted);
+  font-size: 0.78rem;
 }
 
-.watch-page-meta span {
-  font-size: 0.82rem;
+.watch-page-name {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.watch-page-login {
+  font-size: 0.75rem;
   color: var(--muted);
+  text-transform: lowercase;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.watch-page-live-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.watch-page-live-badge.live {
+  color: var(--success);
+}
+
+.watch-page-live-badge.offline {
+  color: var(--danger);
+}
+
+.watch-page-live-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.watch-page-live-badge.offline .watch-page-live-dot {
+  animation: none;
+}
+
+.watch-page-viewers {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.watch-page-title-text,
+.watch-page-game {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.watch-page-game::before {
+  content: '•';
+  margin-right: 0.45rem;
 }
 
 .watch-page-actions {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .watch-loading-state {
@@ -1660,6 +1887,84 @@ body[data-theme='youtube'] {
     width: 100%;
     min-width: 0;
     height: 38vh;
+  }
+}
+
+/* ============================================================================
+   Theater Mode
+   ============================================================================ */
+
+body[data-theater="true"] .watch-page {
+  padding: 0;
+  border: 0;
+  box-shadow: none;
+}
+
+body[data-theater="true"] .watch-page-header {
+  display: none;
+}
+
+body[data-theater="true"] .watch-layout {
+  position: fixed;
+  inset: 0;
+  height: 100dvh;
+  width: 100vw;
+  max-width: none;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: #000;
+}
+
+body[data-theater="true"] .watch-layout.chat-collapsed {
+  grid-template-columns: minmax(0, 1fr) 0px;
+}
+
+body[data-theater="true"] .watch-player-panel {
+  border: 0;
+  border-radius: 0;
+}
+
+body[data-theater="true"] .video-shell {
+  border: 0;
+  border-radius: 0;
+}
+
+body[data-theater="true"] .watch-chat-panel {
+  border-top: 0;
+  border-bottom: 0;
+  border-right: 0;
+  border-left: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  border-radius: 0;
+  background: var(--bg-soft);
+}
+
+.watch-layout.theater {
+  transition: grid-template-columns 170ms ease;
+}
+
+@media (max-width: 900px) {
+  body[data-theater="true"] .watch-layout {
+    position: static;
+    height: auto;
+    min-height: 100dvh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  body[data-theater="true"] .watch-chat-panel {
+    height: 38vh;
+    border-left: 0;
+    border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .watch-page-header,
+  body[data-theater="true"] .watch-layout {
+    transition: none !important;
   }
 }
 
@@ -1725,16 +2030,7 @@ body[data-theme='youtube'] {
   box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
-/* Overlay button spacing for chat expand */
-.overlay-btn.chat-expand-btn {
-  margin-right: 8px;
-  width: 30px;
-  padding: 0;
-  min-height: 30px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
+
 
 /* Reduced motion preferences */
 @media (prefers-reduced-motion: reduce) {
@@ -1809,13 +2105,17 @@ body[data-theme='youtube'] {
   border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
   color: var(--fg);
   cursor: pointer;
-  padding: 6px 12px;
+  padding: 6px 10px;
   border-radius: 4px;
   font-size: 12px;
   font-weight: 600;
   line-height: 1;
   min-height: 30px;
+  min-width: 30px;
   box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   transition:
     background 0.15s,
     border-color 0.15s;
@@ -1829,6 +2129,14 @@ body[data-theme='youtube'] {
 .overlay-btn:disabled {
   opacity: 0.65;
   cursor: not-allowed;
+}
+
+.overlay-btn.theater-btn,
+.overlay-btn.pip-btn,
+.overlay-btn.fullscreen-btn,
+.overlay-btn.chat-expand-btn {
+  width: 30px;
+  padding: 0;
 }
 
 .go-live-btn {
@@ -1910,9 +2218,66 @@ body[data-theme='youtube'] {
   gap: 0.55rem;
 }
 
+.chat-header-title {
+  display: flex;
+  align-items: baseline;
+  gap: 0.55rem;
+  min-width: 0;
+}
+
 .chat-header strong {
   color: var(--fg);
   font-size: 0.85rem;
+}
+
+.chat-header-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-shrink: 0;
+}
+
+.chat-header-action-btn {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0.3rem;
+  border-radius: 0.4rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  min-width: 28px;
+  transition:
+    color 0.15s ease,
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.chat-header-action-btn:hover {
+  color: var(--fg);
+  background: var(--surface-2);
+  border-color: var(--border);
+}
+
+.chat-header-action-btn.active {
+  color: var(--accent);
+  background: var(--accent-soft);
+  border-color: var(--accent-border);
+}
+
+.chat-header-action-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.chat-header-toggle {
+  border: 1px solid transparent;
+}
+
+.chat-header-toggle:hover {
+  border-color: var(--border);
 }
 
 .status-live {
@@ -1941,19 +2306,50 @@ body[data-theme='youtube'] {
 }
 
 .chat-message {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.35rem;
+  padding: 0.35rem 0.55rem;
+  border-radius: 0.4rem;
   line-height: 1.35;
   word-break: break-word;
   font-size: 0.9rem;
+  position: relative;
+  transition: background-color 0.15s ease;
+}
+
+.chat-message:nth-child(even) {
+  background: color-mix(in srgb, var(--bg) 50%, transparent);
+}
+
+.chat-message:hover {
+  background: color-mix(in srgb, var(--surface) 55%, transparent);
+}
+
+.chat-timestamp {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+  width: 2.4rem;
+  flex: 0 0 auto;
+  padding-top: 0.12rem;
+  opacity: 0.8;
 }
 
 .chat-message .sender {
   color: var(--accent);
   font-weight: 600;
   margin-right: 0.35rem;
+  flex: 0 0 auto;
 }
 
 .chat-message.notice .sender {
   color: var(--warn);
+}
+
+.chat-message .content {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .chat-message .content .emote {
@@ -1961,6 +2357,68 @@ body[data-theme='youtube'] {
   width: auto;
   vertical-align: middle;
   margin: 0 0.05em;
+}
+
+.chat-mention {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-radius: 0.25rem;
+  padding: 0.05rem 0.18rem;
+  font-weight: 500;
+}
+
+.chat-message-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  position: absolute;
+  right: 0.35rem;
+  top: 0.25rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+  background: color-mix(in srgb, var(--bg-soft) 92%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 0.4rem;
+  padding: 0.1rem;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
+  z-index: 5;
+}
+
+@media (hover: hover) {
+  .chat-message:hover .chat-message-actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+.chat-message-action-btn {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 0.3rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 22px;
+  min-width: 22px;
+  transition:
+    color 0.15s ease,
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.chat-message-action-btn:hover {
+  color: var(--fg);
+  background: var(--surface-2);
+  border-color: var(--border);
+}
+
+.chat-message-action-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--focus-ring);
 }
 
 .unread-pill {

--- a/web/src/lib/styles/app.css
+++ b/web/src/lib/styles/app.css
@@ -1910,7 +1910,7 @@ body[data-theater="true"] .watch-layout {
   height: 100dvh;
   width: 100vw;
   max-width: none;
-  grid-template-columns: minmax(0, 1fr) 320px;
+  grid-template-columns: minmax(0, 1fr) clamp(280px, 19vw, 380px);
   gap: 0;
   padding: 0;
   border: 0;

--- a/web/src/pages/watch-page.tsx
+++ b/web/src/pages/watch-page.tsx
@@ -1,4 +1,3 @@
-import { ExternalLink } from 'lucide-react';
 import { type ReactElement, useCallback, useEffect, useRef, useState } from 'react';
 import {
   getChatEmotes,
@@ -380,8 +379,6 @@ export const WatchPage = (): ReactElement => {
     globalThis.location.href = connectTwitchUrl;
   }, [connectTwitchUrl]);
 
-  const watchOnTwitchUrl = `https://www.twitch.tv/${encodeURIComponent(channelLogin)}`;
-
   return (
     <section className="watch-page" data-theater={theaterMode ? 'true' : 'false'}>
       <header className="watch-page-header">
@@ -403,10 +400,6 @@ export const WatchPage = (): ReactElement => {
               onStop={handleStopRecording}
             />
           )}
-          <a className="ui-nav-chip" href={watchOnTwitchUrl} rel="noopener noreferrer" target="_blank">
-            Watch on Twitch
-            <ExternalLink size={14} />
-          </a>
           <button type="button" className="ui-nav-chip" onClick={handleBackToChannels}>
             Back to channels
           </button>

--- a/web/src/pages/watch-page.tsx
+++ b/web/src/pages/watch-page.tsx
@@ -12,14 +12,14 @@ import {
   type EmoteItem,
   type WatchSessionResponse,
 } from '../api-client';
+import type { ChatComposerHandle } from '../components/watch/chat-composer';
 import { RecordingButton } from '../components/watch/recording-button';
+import type { VideoControlsHandle } from '../components/watch/use-video-controls';
 import { WatchContent } from '../components/watch/watch-content';
 import { WatchPageMeta } from '../components/watch/watch-page-meta';
 import { useKeyboardShortcuts, useToggleCallback } from '../hooks/use-keyboard-shortcuts';
-import { useWatchPreferences } from '../hooks/use-watch-preferences';
 import { useRouter } from '../hooks/use-router';
-import type { ChatComposerHandle } from '../components/watch/chat-composer';
-import type { VideoControlsHandle } from '../components/watch/use-video-controls';
+import { useWatchPreferences } from '../hooks/use-watch-preferences';
 
 const EMPTY_MESSAGE_LENGTH = 0;
 const ERROR_MISSING_TICKET = 'Missing watch ticket.';
@@ -108,7 +108,6 @@ const useWatchMetadata = (ticket: string): WatchMetadata => {
       setWatchLoading(false);
       return '';
     }
-
 
     setWatchLoading(true);
     setWatchError(undefined);
@@ -226,7 +225,9 @@ const useWatchMetadata = (ticket: string): WatchMetadata => {
   };
 };
 
-const useChatSetup = (channelLogin: string): {
+const useChatSetup = (
+  channelLogin: string,
+): {
   availableEmotes: EmoteItem[];
   chatAvailable: boolean;
   handleChatStatusChange: (status: ChatStatus) => void;
@@ -337,7 +338,8 @@ export const WatchPage = (): ReactElement => {
   const { availableEmotes, chatAvailable, handleChatStatusChange, twitchStatusChecked } =
     useChatSetup(channelLogin);
 
-  const { isChatCollapsed, setIsChatCollapsed, setTheaterMode, theaterMode } = useWatchPreferences();
+  const { isChatCollapsed, setIsChatCollapsed, setTheaterMode, theaterMode } =
+    useWatchPreferences();
   const currentTwitchUser = useCurrentTwitchUser();
   const [playbackError, setPlaybackError] = useState<string | undefined>();
   const composerRef = useRef<ChatComposerHandle | null>(null);

--- a/web/src/pages/watch-page.tsx
+++ b/web/src/pages/watch-page.tsx
@@ -1,19 +1,32 @@
-import { type ReactElement, useCallback, useEffect, useState } from 'react';
+import { ExternalLink } from 'lucide-react';
+import { type ReactElement, useCallback, useEffect, useRef, useState } from 'react';
 import {
   getChatEmotes,
+  getLiveStatus,
+  getRecordings,
   getTwitchConnectUrl,
   getTwitchStatus,
   getWatchSession,
+  startRecording,
+  stopRecording,
+  type ActiveRecording,
   type EmoteItem,
+  type WatchSessionResponse,
 } from '../api-client';
-import { Chat } from '../components/watch/chat';
-import { VideoPlayer } from '../components/watch/video-player';
+import { RecordingButton } from '../components/watch/recording-button';
+import { WatchContent } from '../components/watch/watch-content';
+import { WatchPageMeta } from '../components/watch/watch-page-meta';
+import { useKeyboardShortcuts, useToggleCallback } from '../hooks/use-keyboard-shortcuts';
+import { useWatchPreferences } from '../hooks/use-watch-preferences';
 import { useRouter } from '../hooks/use-router';
+import type { ChatComposerHandle } from '../components/watch/chat-composer';
+import type { VideoControlsHandle } from '../components/watch/use-video-controls';
 
 const EMPTY_MESSAGE_LENGTH = 0;
 const ERROR_MISSING_TICKET = 'Missing watch ticket.';
 const ERROR_SESSION_FAILED = 'Failed to initialize watch session.';
 const RELAY_PARAM = '1';
+const LIVE_STATUS_POLL_MS = 30_000;
 
 interface ChatStatus {
   available: boolean;
@@ -21,128 +34,211 @@ interface ChatStatus {
   message: string;
 }
 
-interface WatchContentProps {
-  availableEmotes: EmoteItem[];
+interface WatchMetadata {
+  activeRecording: ActiveRecording | undefined;
   channelLogin: string;
-  chatAvailable: boolean;
-  handleChatStatusChange: (status: ChatStatus) => void;
-  handleConnectTwitch: () => void;
-  handlePlaybackError: (msg: string) => void;
-  handleToggleCollapse: () => void;
-  isChatCollapsed: boolean;
+  displayName?: string;
+  game?: string;
+  handleStartRecording: () => Promise<void>;
+  handleStopRecording: () => Promise<void>;
+  live: boolean;
   manifestUrl: string;
-  playbackError: string | undefined;
-  watchError: string | undefined;
+  profileUrl?: string;
+  title?: string;
+  viewerCount?: number;
+  watchError?: string;
   watchLoading: boolean;
 }
 
-const WatchContent = (props: WatchContentProps): ReactElement => {
-  const {
-    availableEmotes,
-    channelLogin,
-    chatAvailable,
-    handleChatStatusChange,
-    handleConnectTwitch,
-    handlePlaybackError,
-    handleToggleCollapse,
-    isChatCollapsed,
-    manifestUrl,
-    playbackError,
-    watchError,
-    watchLoading,
-  } = props;
-
-  if (watchLoading) {
-    return (
-      <div className="watch-loading-state">
-        <p className="ui-muted">Loading watch session...</p>
-      </div>
-    );
+const readMessage = (err: unknown, fallback: string): string => {
+  if (err instanceof Error && err.message.trim().length > EMPTY_MESSAGE_LENGTH) {
+    return err.message;
   }
-
-  if (watchError !== undefined && watchError !== '') {
-    return (
-      <div className="watch-loading-state">
-        <p className="ui-error">{watchError}</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className={`watch-layout ${isChatCollapsed ? 'chat-collapsed' : ''}`}>
-      <section className="watch-player-panel">
-        <VideoPlayer
-          chatCollapsed={isChatCollapsed}
-          manifestUrl={manifestUrl}
-          onError={handlePlaybackError}
-          onToggleChat={handleToggleCollapse}
-        />
-
-        {playbackError !== undefined && playbackError !== '' && (
-          <p className="ui-error">{playbackError}</p>
-        )}
-      </section>
-
-      <aside className={`watch-chat-panel ${isChatCollapsed ? 'collapsed' : ''}`}>
-        {chatAvailable ? (
-          <Chat
-            availableEmotes={availableEmotes}
-            channelLogin={channelLogin}
-            chatAvailable={chatAvailable}
-            isCollapsed={isChatCollapsed}
-            onStatusChange={handleChatStatusChange}
-            onToggleCollapse={handleToggleCollapse}
-          />
-        ) : (
-          <div className="chat-offline">
-            <p className="ui-muted">Connect Twitch to read and send messages.</p>
-            <button type="button" className="ui-nav-chip" onClick={handleConnectTwitch}>
-              Connect Twitch
-            </button>
-          </div>
-        )}
-      </aside>
-    </div>
-  );
+  return fallback;
 };
 
-export const WatchPage = (): ReactElement => {
-  const { navigate, page } = useRouter();
-  const { ticket } = page.params;
+const isRelayForced = (): boolean => {
+  if (typeof globalThis === 'undefined') {
+    return false;
+  }
+  return new URLSearchParams(globalThis.location.search).get('relay') === RELAY_PARAM;
+};
 
+const applySessionToState = (
+  session: WatchSessionResponse,
+  setters: {
+    setChannelLogin: (value: string) => void;
+    setDisplayName: (value?: string) => void;
+    setProfileUrl: (value?: string) => void;
+    setTitle: (value?: string) => void;
+    setGame: (value?: string) => void;
+    setViewerCount: (value?: number) => void;
+    setLive: (value: boolean) => void;
+    setManifestUrl: (value: string) => void;
+  },
+): void => {
+  setters.setChannelLogin(session.channel);
+  setters.setDisplayName(session.display_name);
+  setters.setProfileUrl(session.profile_url);
+  setters.setTitle(session.title);
+  setters.setGame(session.game);
+  setters.setViewerCount(session.viewer_count);
+  setters.setLive(session.live);
+  setters.setManifestUrl(session.manifest_url);
+};
+
+const useWatchMetadata = (ticket: string): WatchMetadata => {
   const [channelLogin, setChannelLogin] = useState('');
-  const [appVersion, setAppVersion] = useState('');
+  const [displayName, setDisplayName] = useState<string | undefined>();
+  const [profileUrl, setProfileUrl] = useState<string | undefined>();
+  const [title, setTitle] = useState<string | undefined>();
+  const [game, setGame] = useState<string | undefined>();
+  const [viewerCount, setViewerCount] = useState<number | undefined>();
+  const [live, setLive] = useState(false);
   const [manifestUrl, setManifestUrl] = useState('');
   const [watchLoading, setWatchLoading] = useState(true);
   const [watchError, setWatchError] = useState<string | undefined>();
-  const [playbackError, setPlaybackError] = useState<string | undefined>();
+  const [activeRecording, setActiveRecording] = useState<ActiveRecording | undefined>();
+
+  const channelLoginRef = useRef(channelLogin);
+  channelLoginRef.current = channelLogin;
+
+  const initialize = useCallback(async (): Promise<string> => {
+    if (ticket === '') {
+      setWatchError(ERROR_MISSING_TICKET);
+      setWatchLoading(false);
+      return '';
+    }
+
+
+    setWatchLoading(true);
+    setWatchError(undefined);
+
+    try {
+      const session = await getWatchSession(ticket, isRelayForced());
+      applySessionToState(session, {
+        setChannelLogin,
+        setDisplayName,
+        setGame,
+        setLive,
+        setManifestUrl,
+        setProfileUrl,
+        setTitle,
+        setViewerCount,
+      });
+      setWatchLoading(false);
+      return session.channel;
+    } catch (error) {
+      setWatchError(readMessage(error, ERROR_SESSION_FAILED));
+      setWatchLoading(false);
+      return '';
+    }
+  }, [ticket]);
+
+  const refreshLiveStatus = useCallback(async (): Promise<void> => {
+    const currentChannel = channelLoginRef.current;
+    if (currentChannel === '') {
+      return;
+    }
+
+    try {
+      const status = await getLiveStatus();
+      const channelStatus = status.channels[currentChannel];
+      if (!('live' in channelStatus)) {
+        return;
+      }
+
+      setLive(channelStatus.live);
+      setTitle(channelStatus.title);
+      setGame(channelStatus.game);
+      setViewerCount(channelStatus.viewer_count);
+      setDisplayName(channelStatus.display_name);
+      setProfileUrl(channelStatus.profile_url);
+    } catch {
+      // Keep existing metadata on refresh failure.
+    }
+  }, []);
+
+  const findActiveRecording = useCallback(
+    (recordings: { active: readonly ActiveRecording[] }): ActiveRecording | undefined =>
+      recordings.active.find((recording) => recording.channel_login === channelLoginRef.current),
+    [],
+  );
+
+  const refreshRecordings = useCallback(async (): Promise<void> => {
+    const currentChannel = channelLoginRef.current;
+    if (currentChannel === '') {
+      return;
+    }
+
+    try {
+      const recordings = await getRecordings();
+      setActiveRecording(findActiveRecording(recordings));
+    } catch {
+      // Keep existing recording state on refresh failure.
+    }
+  }, [findActiveRecording]);
+
+  const handleStartRecording = useCallback(async (): Promise<void> => {
+    await startRecording(channelLoginRef.current, undefined, title);
+    await refreshRecordings();
+  }, [title, refreshRecordings]);
+
+  const handleStopRecording = useCallback(async (): Promise<void> => {
+    await stopRecording(channelLoginRef.current);
+    await refreshRecordings();
+  }, [refreshRecordings]);
+
+  useEffect(() => {
+    void initialize();
+  }, [ticket, initialize]);
+
+  useEffect((): (() => void) | undefined => {
+    if (channelLogin === '') {
+      return undefined;
+    }
+
+    void refreshRecordings();
+
+    const interval = setInterval(() => {
+      void refreshLiveStatus();
+      void refreshRecordings();
+    }, LIVE_STATUS_POLL_MS);
+
+    return (): void => {
+      clearInterval(interval);
+    };
+  }, [channelLogin, refreshLiveStatus, refreshRecordings]);
+
+  return {
+    activeRecording,
+    channelLogin,
+    displayName,
+    game,
+    handleStartRecording,
+    handleStopRecording,
+    live,
+    manifestUrl,
+    profileUrl,
+    title,
+    viewerCount,
+    watchError,
+    watchLoading,
+  };
+};
+
+const useChatSetup = (channelLogin: string): {
+  availableEmotes: EmoteItem[];
+  chatAvailable: boolean;
+  handleChatStatusChange: (status: ChatStatus) => void;
+  twitchStatusChecked: boolean;
+} => {
   const [chatAvailable, setChatAvailable] = useState(false);
   const [availableEmotes, setAvailableEmotes] = useState<EmoteItem[]>([]);
   const [twitchStatusChecked, setTwitchStatusChecked] = useState(false);
-  const [isChatCollapsed, setIsChatCollapsed] = useState(false);
-
-  const connectTwitchUrl = getTwitchConnectUrl();
-
-  const toggleChatCollapse = useCallback(() => {
-    setIsChatCollapsed((prev) => !prev);
-  }, []);
-
-  const readMessage = useCallback((err: unknown, fallback: string): string => {
-    if (err instanceof Error && err.message.trim().length > EMPTY_MESSAGE_LENGTH) {
-      return err.message;
-    }
-    return fallback;
-  }, []);
-
-  const isRelayForced = useCallback((): boolean => {
-    if (typeof globalThis === 'undefined') {
-      return false;
-    }
-    return new URLSearchParams(globalThis.location.search).get('relay') === RELAY_PARAM;
-  }, []);
 
   const loadEmotes = useCallback(async (channel: string): Promise<void> => {
-    if (!channel) {
+    if (channel === '') {
       return;
     }
     const emotes = await getChatEmotes(channel);
@@ -172,65 +268,145 @@ export const WatchPage = (): ReactElement => {
     [loadEmotes],
   );
 
-  const initializeWatchPage = useCallback(async (): Promise<void> => {
-    setWatchLoading(true);
-    setWatchError(undefined);
-    setPlaybackError(undefined);
-
-    const forceRelay = isRelayForced();
-    try {
-      const session = await getWatchSession(ticket, forceRelay);
-      setChannelLogin(session.channel);
-      setAppVersion(session.app_version);
-      setManifestUrl(session.manifest_url);
-
-      setWatchLoading(false);
-
-      // Setup chat
-      await setupChat(session.channel);
-    } catch (error) {
-      setWatchError(readMessage(error, ERROR_SESSION_FAILED));
-      setWatchLoading(false);
+  useEffect(() => {
+    if (channelLogin === '') {
+      return;
     }
-  }, [ticket, isRelayForced, readMessage, setupChat]);
+
+    void setupChat(channelLogin);
+  }, [channelLogin, setupChat]);
 
   const handleChatStatusChange = useCallback((status: ChatStatus): void => {
     setChatAvailable(status.available);
   }, []);
 
+  return {
+    availableEmotes,
+    chatAvailable,
+    handleChatStatusChange,
+    twitchStatusChecked,
+  };
+};
+
+interface TwitchUser {
+  connected: boolean;
+  display_name?: string;
+  login?: string;
+}
+
+const useCurrentTwitchUser = (): TwitchUser => {
+  const [user, setUser] = useState<TwitchUser>({ connected: false });
+
+  useEffect(() => {
+    void (async (): Promise<void> => {
+      try {
+        const status = await getTwitchStatus();
+        setUser({
+          connected: status.connected,
+          display_name: status.display_name,
+          login: status.login,
+        });
+      } catch {
+        setUser({ connected: false });
+      }
+    })();
+  }, []);
+
+  return user;
+};
+
+export const WatchPage = (): ReactElement => {
+  const { navigate, page } = useRouter();
+  const { ticket } = page.params;
+
+  const {
+    activeRecording,
+    channelLogin,
+    displayName,
+    game,
+    handleStartRecording,
+    handleStopRecording,
+    live,
+    manifestUrl,
+    profileUrl,
+    title,
+    viewerCount,
+    watchError,
+    watchLoading,
+  } = useWatchMetadata(ticket);
+
+  const { availableEmotes, chatAvailable, handleChatStatusChange, twitchStatusChecked } =
+    useChatSetup(channelLogin);
+
+  const { isChatCollapsed, setIsChatCollapsed, setTheaterMode, theaterMode } = useWatchPreferences();
+  const currentTwitchUser = useCurrentTwitchUser();
+  const [playbackError, setPlaybackError] = useState<string | undefined>();
+  const composerRef = useRef<ChatComposerHandle | null>(null);
+  const videoPlayerRef = useRef<VideoControlsHandle | null>(null);
+
+  const toggleChatCollapse = useToggleCallback(setIsChatCollapsed);
+  const toggleTheaterMode = useToggleCallback(setTheaterMode);
+
   const handlePlaybackError = useCallback((msg: string): void => {
     setPlaybackError(msg);
   }, []);
+
+  const handleFocusChat = useCallback((): void => {
+    composerRef.current?.focus();
+  }, []);
+
+  const handleToggleFullscreen = useCallback((): void => {
+    videoPlayerRef.current?.enterFullscreen();
+  }, []);
+
+  const handleToggleMute = useCallback((): void => {
+    videoPlayerRef.current?.toggleMute();
+  }, []);
+
+  useKeyboardShortcuts({
+    onFocusChat: handleFocusChat,
+    onFullscreen: handleToggleFullscreen,
+    onMute: handleToggleMute,
+    onTheater: toggleTheaterMode,
+    theaterMode,
+  });
 
   const handleBackToChannels = useCallback((): void => {
     navigate('/twitch');
   }, [navigate]);
 
+  const connectTwitchUrl = getTwitchConnectUrl();
   const handleConnectTwitch = useCallback((): void => {
     globalThis.location.href = connectTwitchUrl;
   }, [connectTwitchUrl]);
 
-  useEffect(() => {
-    if (ticket === '') {
-      setWatchError(ERROR_MISSING_TICKET);
-      setWatchLoading(false);
-      return;
-    }
-
-    void initializeWatchPage();
-  }, [ticket, initializeWatchPage]);
+  const watchOnTwitchUrl = `https://www.twitch.tv/${encodeURIComponent(channelLogin)}`;
 
   return (
-    <section className="watch-page">
+    <section className="watch-page" data-theater={theaterMode ? 'true' : 'false'}>
       <header className="watch-page-header">
-        <div className="watch-page-meta">
-          <strong>{channelLogin || 'stream'}</strong>
-          <span>
-            via Twitch Relay
-            {appVersion ? ` · v${appVersion}` : ''}
-          </span>
-        </div>
+        <WatchPageMeta
+          channelLogin={channelLogin}
+          displayName={displayName}
+          game={game}
+          live={live}
+          profileUrl={profileUrl}
+          title={title}
+          viewerCount={viewerCount}
+        />
         <div className="watch-page-actions">
+          {channelLogin !== '' && (
+            <RecordingButton
+              channelLogin={channelLogin}
+              recording={activeRecording}
+              onStart={handleStartRecording}
+              onStop={handleStopRecording}
+            />
+          )}
+          <a className="ui-nav-chip" href={watchOnTwitchUrl} rel="noopener noreferrer" target="_blank">
+            Watch on Twitch
+            <ExternalLink size={14} />
+          </a>
           <button type="button" className="ui-nav-chip" onClick={handleBackToChannels}>
             Back to channels
           </button>
@@ -246,13 +422,18 @@ export const WatchPage = (): ReactElement => {
         availableEmotes={availableEmotes}
         channelLogin={channelLogin}
         chatAvailable={chatAvailable}
+        currentUserDisplayName={currentTwitchUser.display_name}
+        currentUserLogin={currentTwitchUser.login}
         handleChatStatusChange={handleChatStatusChange}
         handleConnectTwitch={handleConnectTwitch}
         handlePlaybackError={handlePlaybackError}
         handleToggleCollapse={toggleChatCollapse}
         isChatCollapsed={isChatCollapsed}
         manifestUrl={manifestUrl}
+        onToggleTheater={toggleTheaterMode}
         playbackError={playbackError}
+        theaterMode={theaterMode}
+        videoPlayerRef={videoPlayerRef}
         watchError={watchError}
         watchLoading={watchLoading}
       />


### PR DESCRIPTION
- Added new \`GET /api/watch-session/{ticket}\` endpoint to fetch watch session bootstrap data.
- Updated the \`watch_session_handler\` function to include additional session details such as \`display_name\`, \`profile_url\`, \`title\`, \`game\`, \`viewer_count\`, \`live\`, \`resolver\`, and \`delivery_mode\`.
- Modified \`stream_proxy/session.rs\` to provide accessors for \`resolver_mode\` and \`delivery_mode\`.
- Updated API client types and parsing logic to accommodate the new response fields.
- Enhanced \`ChatComposer\` component with methods for text insertion and focus, improving user interaction.
- Refactored CSS styles in \`app.css\`, reducing lines by 19.
- Created new components like \`RecordingButton\`, \`useVideoControls\`, \`WatchContent\`, and \`WatchPageMeta\`.
- Introduced hooks such as \`useKeyboardShortcuts\` and \`useWatchPreferences\`.
- Updated \`watch-page.tsx\` to utilize the new components and hooks.