### PR TITLE
feat(web): add chat-only mode functionality and testing

### DIFF
--- a/web/src/components/watch/chat.tsx
+++ b/web/src/components/watch/chat.tsx
@@ -1,4 +1,4 @@
-import { Copy, PanelRightClose, Reply, Clock } from 'lucide-react';
+import { Clock, Copy, PanelRightClose, PanelTopClose, PanelTopOpen, Reply } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 import type { EmoteItem } from '../../api-client';
 import {
@@ -109,10 +109,12 @@ const renderHighlightedText = (
 interface ChatProps {
   channelLogin: string;
   chatAvailable: boolean;
+  chatOnly: boolean;
   availableEmotes?: EmoteItem[];
   onStatusChange: (status: { available: boolean; connected: boolean; message: string }) => void;
   isCollapsed: boolean;
   onToggleCollapse: () => void;
+  onToggleChatOnly: () => void;
   currentUserLogin?: string;
   currentUserDisplayName?: string;
 }
@@ -212,13 +214,84 @@ const ChatMessageItem = ({
   );
 };
 
+const ChatHeader = ({
+  chatConnected,
+  chatOnly,
+  chatStatus,
+  onToggleChatOnly,
+  onToggleCollapse,
+  showTimestamps,
+  toggleTimestamps,
+}: {
+  chatConnected: boolean;
+  chatOnly: boolean;
+  chatStatus: string;
+  onToggleChatOnly: () => void;
+  onToggleCollapse: () => void;
+  showTimestamps: boolean;
+  toggleTimestamps: () => void;
+}): ReactElement => (
+  <div className="chat-header">
+    <div className="chat-header-title">
+      <strong>Chat</strong>
+      <span className={chatConnected ? 'status-live' : undefined}>{chatStatus}</span>
+    </div>
+    <div className="chat-header-actions">
+      <button
+        type="button"
+        className={`chat-header-action-btn ${showTimestamps ? 'active' : ''}`}
+        onClick={toggleTimestamps}
+        aria-pressed={showTimestamps}
+        aria-label="Toggle timestamps"
+        title="Toggle timestamps"
+      >
+        <Clock aria-hidden="true" size={16} />
+      </button>
+      <button
+        type="button"
+        className={`chat-header-action-btn chat-header-chat-only ${chatOnly ? 'active' : ''}`}
+        onClick={onToggleChatOnly}
+        aria-pressed={chatOnly}
+        aria-label={chatOnly ? 'Show video' : 'Show chat only'}
+        title={chatOnly ? 'Show video' : 'Show chat only'}
+      >
+        {chatOnly ? (
+          <>
+            <PanelTopOpen aria-hidden="true" size={16} />
+            <span>Show video</span>
+          </>
+        ) : (
+          <>
+            <PanelTopClose aria-hidden="true" size={16} />
+            <span>Chat only</span>
+          </>
+        )}
+      </button>
+      {!chatOnly && (
+        <button
+          type="button"
+          className="chat-header-action-btn chat-header-toggle"
+          onClick={onToggleCollapse}
+          aria-expanded="true"
+          aria-label="Collapse chat"
+          title="Collapse chat"
+        >
+          <PanelRightClose aria-hidden="true" size={16} />
+        </button>
+      )}
+    </div>
+  </div>
+);
+
 export const Chat = ({
   channelLogin,
   chatAvailable,
+  chatOnly,
   availableEmotes = [],
   onStatusChange,
   isCollapsed,
   onToggleCollapse,
+  onToggleChatOnly,
   currentUserLogin,
   currentUserDisplayName,
 }: ChatProps): ReactElement => {
@@ -287,34 +360,15 @@ export const Chat = ({
   // Expanded state: full chat UI
   return (
     <div className="chat-panel">
-      <div className="chat-header">
-        <div className="chat-header-title">
-          <strong>Chat</strong>
-          <span className={chatConnected ? 'status-live' : undefined}>{chatStatus}</span>
-        </div>
-        <div className="chat-header-actions">
-          <button
-            type="button"
-            className={`chat-header-action-btn ${showTimestamps ? 'active' : ''}`}
-            onClick={toggleTimestamps}
-            aria-pressed={showTimestamps}
-            aria-label="Toggle timestamps"
-            title="Toggle timestamps"
-          >
-            <Clock aria-hidden="true" size={16} />
-          </button>
-          <button
-            type="button"
-            className="chat-header-action-btn chat-header-toggle"
-            onClick={onToggleCollapse}
-            aria-expanded="true"
-            aria-label="Collapse chat"
-            title="Collapse chat"
-          >
-            <PanelRightClose aria-hidden="true" size={16} />
-          </button>
-        </div>
-      </div>
+      <ChatHeader
+        chatConnected={chatConnected}
+        chatOnly={chatOnly}
+        chatStatus={chatStatus}
+        onToggleChatOnly={onToggleChatOnly}
+        onToggleCollapse={onToggleCollapse}
+        showTimestamps={showTimestamps}
+        toggleTimestamps={toggleTimestamps}
+      />
 
       {chatAvailable ? (
         <>

--- a/web/src/components/watch/chat.tsx
+++ b/web/src/components/watch/chat.tsx
@@ -249,22 +249,16 @@ const ChatHeader = ({
       </button>
       <button
         type="button"
-        className={`chat-header-action-btn chat-header-chat-only ${chatOnly ? 'active' : ''}`}
+        className={`chat-header-action-btn ${chatOnly ? 'active' : ''}`}
         onClick={onToggleChatOnly}
         aria-pressed={chatOnly}
         aria-label={chatOnly ? 'Show video' : 'Show chat only'}
         title={chatOnly ? 'Show video' : 'Show chat only'}
       >
         {chatOnly ? (
-          <>
-            <PanelTopOpen aria-hidden="true" size={16} />
-            <span>Show video</span>
-          </>
+          <PanelTopOpen aria-hidden="true" size={16} />
         ) : (
-          <>
-            <PanelTopClose aria-hidden="true" size={16} />
-            <span>Chat only</span>
-          </>
+          <PanelTopClose aria-hidden="true" size={16} />
         )}
       </button>
       {!chatOnly && (

--- a/web/src/components/watch/watch-content.tsx
+++ b/web/src/components/watch/watch-content.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react';
+import { useLayoutEffect, useRef, useState, type ReactElement } from 'react';
 import type { EmoteItem } from '../../api-client';
 import { Chat } from './chat';
 import type { VideoControlsHandle } from './use-video-controls';
@@ -32,6 +32,13 @@ interface WatchContentProps {
   watchLoading: boolean;
 }
 
+type ChatOnlyPlayerPhase = 'entering' | 'hidden' | 'leaving' | 'visible';
+
+const CHAT_ONLY_TRANSITION_MS = 180;
+
+const prefersReducedMotion = (): boolean =>
+  globalThis.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
 export const WatchContent = (props: WatchContentProps): ReactElement => {
   const {
     availableEmotes,
@@ -54,6 +61,33 @@ export const WatchContent = (props: WatchContentProps): ReactElement => {
     watchError,
     watchLoading,
   } = props;
+  const [playerPhase, setPlayerPhase] = useState<ChatOnlyPlayerPhase>(() =>
+    chatOnly ? 'hidden' : 'visible',
+  );
+  const previousChatOnly = useRef(chatOnly);
+
+  useLayoutEffect(() => {
+    const settledPhase = chatOnly ? 'hidden' : 'visible';
+    let timeout: ReturnType<typeof globalThis.setTimeout> | null = null;
+    const chatOnlyChanged = previousChatOnly.current !== chatOnly;
+    previousChatOnly.current = chatOnly;
+
+    if (!chatOnlyChanged || prefersReducedMotion()) {
+      setPlayerPhase(settledPhase);
+    } else {
+      const transitionPhase = chatOnly ? 'entering' : 'leaving';
+      setPlayerPhase(transitionPhase);
+      timeout = globalThis.setTimeout(() => {
+        setPlayerPhase((phase) => (phase === transitionPhase ? settledPhase : phase));
+      }, CHAT_ONLY_TRANSITION_MS);
+    }
+
+    return (): void => {
+      if (timeout !== null) {
+        globalThis.clearTimeout(timeout);
+      }
+    };
+  }, [chatOnly]);
 
   if (watchLoading) {
     return (
@@ -75,7 +109,11 @@ export const WatchContent = (props: WatchContentProps): ReactElement => {
     <div
       className={`watch-layout ${isChatCollapsed ? 'chat-collapsed' : ''} ${chatOnly ? 'chat-only' : ''} ${theaterMode ? 'theater' : ''}`}
     >
-      <section className="watch-player-panel">
+      <section
+        aria-hidden={playerPhase !== 'visible'}
+        className={`watch-player-panel player-${playerPhase}`}
+        inert={playerPhase !== 'visible'}
+      >
         <VideoPlayer
           chatCollapsed={isChatCollapsed}
           manifestUrl={manifestUrl}

--- a/web/src/components/watch/watch-content.tsx
+++ b/web/src/components/watch/watch-content.tsx
@@ -14,12 +14,14 @@ interface WatchContentProps {
   availableEmotes: EmoteItem[];
   channelLogin: string;
   chatAvailable: boolean;
+  chatOnly: boolean;
   currentUserDisplayName?: string;
   currentUserLogin?: string;
   handleChatStatusChange: (status: ChatStatus) => void;
   handleConnectTwitch: () => void;
   handlePlaybackError: (msg: string) => void;
   handleToggleCollapse: () => void;
+  handleToggleChatOnly: () => void;
   isChatCollapsed: boolean;
   manifestUrl: string;
   onToggleTheater: () => void;
@@ -35,12 +37,14 @@ export const WatchContent = (props: WatchContentProps): ReactElement => {
     availableEmotes,
     channelLogin,
     chatAvailable,
+    chatOnly,
     currentUserDisplayName,
     currentUserLogin,
     handleChatStatusChange,
     handleConnectTwitch,
     handlePlaybackError,
     handleToggleCollapse,
+    handleToggleChatOnly,
     isChatCollapsed,
     manifestUrl,
     onToggleTheater,
@@ -69,7 +73,7 @@ export const WatchContent = (props: WatchContentProps): ReactElement => {
 
   return (
     <div
-      className={`watch-layout ${isChatCollapsed ? 'chat-collapsed' : ''} ${theaterMode ? 'theater' : ''}`}
+      className={`watch-layout ${isChatCollapsed ? 'chat-collapsed' : ''} ${chatOnly ? 'chat-only' : ''} ${theaterMode ? 'theater' : ''}`}
     >
       <section className="watch-player-panel">
         <VideoPlayer
@@ -95,9 +99,11 @@ export const WatchContent = (props: WatchContentProps): ReactElement => {
             chatAvailable={chatAvailable}
             currentUserDisplayName={currentUserDisplayName}
             currentUserLogin={currentUserLogin}
+            chatOnly={chatOnly}
             isCollapsed={isChatCollapsed}
             onStatusChange={handleChatStatusChange}
             onToggleCollapse={handleToggleCollapse}
+            onToggleChatOnly={handleToggleChatOnly}
           />
         ) : (
           <div className="chat-offline">

--- a/web/src/hooks/use-chat-only-mode.test.ts
+++ b/web/src/hooks/use-chat-only-mode.test.ts
@@ -1,0 +1,100 @@
+import { act, createElement, Fragment, type ReactNode, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { useChatOnlyMode } from './use-chat-only-mode';
+
+const getRequiredElement = (container: HTMLElement | null, selector: string): HTMLElement => {
+  if (container === null) {
+    throw new Error('Test container is unavailable');
+  }
+
+  const element = container.querySelector<HTMLElement>(selector);
+  if (element === null) {
+    throw new Error(`Missing element: ${selector}`);
+  }
+  return element;
+};
+
+const TestComponent = ({ ticket }: { ticket: string }): ReactNode => {
+  const [isChatCollapsed, setIsChatCollapsed] = useState(false);
+  const { chatOnly, toggleChatCollapse, toggleChatOnly } = useChatOnlyMode(
+    ticket,
+    setIsChatCollapsed,
+  );
+
+  return createElement(
+    Fragment,
+    null,
+    createElement('output', { 'data-testid': 'chat-only' }, String(chatOnly)),
+    createElement('output', { 'data-testid': 'chat-collapsed' }, String(isChatCollapsed)),
+    createElement(
+      'button',
+      { 'data-testid': 'toggle-chat-only', onClick: toggleChatOnly, type: 'button' },
+      'Toggle chat only',
+    ),
+    createElement(
+      'button',
+      { 'data-testid': 'toggle-chat-collapse', onClick: toggleChatCollapse, type: 'button' },
+      'Toggle chat collapse',
+    ),
+  );
+};
+
+describe('useChatOnlyMode', () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    root?.unmount();
+    container?.remove();
+  });
+
+  it('clears chat-only mode before toggling ordinary chat collapse', () => {
+    act(() => {
+      root?.render(createElement(TestComponent, { ticket: 'first-ticket' }));
+    });
+
+    const chatOnlyButton = getRequiredElement(container, '[data-testid="toggle-chat-only"]');
+    const chatCollapseButton = getRequiredElement(
+      container,
+      '[data-testid="toggle-chat-collapse"]',
+    );
+
+    act(() => {
+      chatOnlyButton.click();
+    });
+    expect(getRequiredElement(container, '[data-testid="chat-only"]').textContent).toBe('true');
+    expect(getRequiredElement(container, '[data-testid="chat-collapsed"]').textContent).toBe(
+      'false',
+    );
+
+    act(() => {
+      chatCollapseButton.click();
+    });
+    expect(getRequiredElement(container, '[data-testid="chat-only"]').textContent).toBe('false');
+    expect(getRequiredElement(container, '[data-testid="chat-collapsed"]').textContent).toBe(
+      'true',
+    );
+  });
+
+  it('resets chat-only mode when the watch ticket changes', () => {
+    act(() => {
+      root?.render(createElement(TestComponent, { ticket: 'first-ticket' }));
+    });
+
+    act(() => {
+      getRequiredElement(container, '[data-testid="toggle-chat-only"]').click();
+    });
+
+    act(() => {
+      root?.render(createElement(TestComponent, { ticket: 'second-ticket' }));
+    });
+    expect(getRequiredElement(container, '[data-testid="chat-only"]').textContent).toBe('false');
+  });
+});

--- a/web/src/hooks/use-chat-only-mode.ts
+++ b/web/src/hooks/use-chat-only-mode.ts
@@ -1,0 +1,30 @@
+import { type Dispatch, type SetStateAction, useCallback, useEffect, useState } from 'react';
+
+interface ChatOnlyMode {
+  chatOnly: boolean;
+  toggleChatCollapse: () => void;
+  toggleChatOnly: () => void;
+}
+
+export const useChatOnlyMode = (
+  ticket: string,
+  setIsChatCollapsed: Dispatch<SetStateAction<boolean>>,
+): ChatOnlyMode => {
+  const [chatOnly, setChatOnly] = useState(false);
+
+  const toggleChatOnly = useCallback((): void => {
+    setIsChatCollapsed(false);
+    setChatOnly((previous) => !previous);
+  }, [setIsChatCollapsed]);
+
+  const toggleChatCollapse = useCallback((): void => {
+    setChatOnly(false);
+    setIsChatCollapsed((previous) => !previous);
+  }, [setIsChatCollapsed]);
+
+  useEffect(() => {
+    setChatOnly(false);
+  }, [ticket]);
+
+  return { chatOnly, toggleChatCollapse, toggleChatOnly };
+};

--- a/web/src/lib/styles/app.css
+++ b/web/src/lib/styles/app.css
@@ -1843,15 +1843,18 @@ body[data-theme='youtube'] {
 }
 
 .watch-layout {
+  --watch-chat-width: clamp(280px, 19vw, 380px);
+  --watch-layout-gap: clamp(8px, 1.2vw, 16px);
+  --watch-layout-padding: clamp(8px, 1.2vw, 16px);
   flex: 1;
   min-height: 0;
   display: grid;
   position: relative;
-  grid-template-columns: minmax(0, 1fr) clamp(280px, 19vw, 380px);
+  grid-template-columns: minmax(0, 1fr) var(--watch-chat-width);
   align-items: stretch;
   justify-content: stretch;
-  gap: clamp(8px, 1.2vw, 16px);
-  padding: clamp(8px, 1.2vw, 16px);
+  gap: var(--watch-layout-gap);
+  padding: var(--watch-layout-padding);
 }
 
 .watch-player-panel {
@@ -1878,13 +1881,41 @@ body[data-theme='youtube'] {
   grid-template-columns: minmax(0, 1fr);
 }
 
-.watch-layout.chat-only .watch-player-panel {
+.watch-player-panel.player-hidden {
   position: absolute;
   width: 1px;
   height: 1px;
   overflow: hidden;
   opacity: 0;
   pointer-events: none;
+  transform: translateX(-1.5rem) scale(0.985);
+}
+
+.watch-player-panel.player-entering,
+.watch-player-panel.player-leaving {
+  position: absolute;
+  z-index: 1;
+  top: var(--watch-layout-padding);
+  left: var(--watch-layout-padding);
+  width: calc(
+    100% - var(--watch-chat-width) - var(--watch-layout-gap) - var(--watch-layout-padding) -
+      var(--watch-layout-padding)
+  );
+  height: calc(100% - var(--watch-layout-padding) - var(--watch-layout-padding));
+  overflow: hidden;
+  pointer-events: none;
+  transition: opacity 180ms ease, transform 180ms ease;
+  will-change: opacity, transform;
+}
+
+.watch-player-panel.player-entering {
+  opacity: 0;
+  transform: translateX(-1.5rem) scale(0.985);
+}
+
+.watch-player-panel.player-leaving {
+  opacity: 1;
+  transform: translateX(0) scale(1);
 }
 
 .watch-layout.chat-only .watch-chat-panel {
@@ -1912,6 +1943,13 @@ body[data-theme='youtube'] {
     height: 100%;
     flex: 1;
   }
+
+  .watch-player-panel.player-entering,
+  .watch-player-panel.player-leaving {
+    width: calc(100% - var(--watch-layout-padding) - var(--watch-layout-padding));
+    height: auto;
+    aspect-ratio: 16 / 9;
+  }
 }
 
 /* ============================================================================
@@ -1929,12 +1967,14 @@ body[data-theater="true"] .watch-page-header {
 }
 
 body[data-theater="true"] .watch-layout {
+  --watch-layout-gap: 0px;
+  --watch-layout-padding: 0px;
   position: fixed;
   inset: 0;
   height: 100dvh;
   width: 100vw;
   max-width: none;
-  grid-template-columns: minmax(0, 1fr) clamp(280px, 19vw, 380px);
+  grid-template-columns: minmax(0, 1fr) var(--watch-chat-width);
   gap: 0;
   padding: 0;
   border: 0;
@@ -1995,7 +2035,9 @@ body[data-theater="true"] .watch-chat-panel {
 
 @media (prefers-reduced-motion: reduce) {
   .watch-page-header,
-  body[data-theater="true"] .watch-layout {
+  body[data-theater="true"] .watch-layout,
+  .watch-player-panel.player-entering,
+  .watch-player-panel.player-leaving {
     transition: none !important;
   }
 }

--- a/web/src/lib/styles/app.css
+++ b/web/src/lib/styles/app.css
@@ -1846,6 +1846,7 @@ body[data-theme='youtube'] {
   flex: 1;
   min-height: 0;
   display: grid;
+  position: relative;
   grid-template-columns: minmax(0, 1fr) clamp(280px, 19vw, 380px);
   align-items: stretch;
   justify-content: stretch;
@@ -1872,6 +1873,24 @@ body[data-theme='youtube'] {
   position: relative;
 }
 
+/* Keep the player mounted so playback state survives chat-only mode. */
+.watch-layout.chat-only {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.watch-layout.chat-only .watch-player-panel {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.watch-layout.chat-only .watch-chat-panel {
+  grid-column: 1;
+}
+
 @media (max-width: 900px) {
   .watch-page {
     height: auto;
@@ -1887,6 +1906,11 @@ body[data-theme='youtube'] {
     width: 100%;
     min-width: 0;
     height: 38vh;
+  }
+
+  .watch-layout.chat-only .watch-chat-panel {
+    height: 100%;
+    flex: 1;
   }
 }
 
@@ -1920,6 +1944,10 @@ body[data-theater="true"] .watch-layout {
 
 body[data-theater="true"] .watch-layout.chat-collapsed {
   grid-template-columns: minmax(0, 1fr) 0px;
+}
+
+body[data-theater="true"] .watch-layout.chat-only {
+  grid-template-columns: minmax(0, 1fr);
 }
 
 body[data-theater="true"] .watch-player-panel {
@@ -1958,6 +1986,10 @@ body[data-theater="true"] .watch-chat-panel {
     height: 38vh;
     border-left: 0;
     border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  }
+
+  body[data-theater="true"] .watch-layout.chat-only .watch-chat-panel {
+    height: 100%;
   }
 }
 
@@ -2023,6 +2055,17 @@ body[data-theater="true"] .watch-chat-panel {
 .chat-header-toggle:hover {
   color: var(--text);
   background: var(--surface-2);
+}
+
+.chat-header-chat-only {
+  gap: 0.3rem;
+  padding-inline: 0.45rem;
+}
+
+.chat-header-chat-only span {
+  font-size: 0.72rem;
+  font-weight: 600;
+  white-space: nowrap;
 }
 
 .chat-header-toggle:focus-visible {

--- a/web/src/lib/styles/app.css
+++ b/web/src/lib/styles/app.css
@@ -2057,17 +2057,6 @@ body[data-theater="true"] .watch-chat-panel {
   background: var(--surface-2);
 }
 
-.chat-header-chat-only {
-  gap: 0.3rem;
-  padding-inline: 0.45rem;
-}
-
-.chat-header-chat-only span {
-  font-size: 0.72rem;
-  font-weight: 600;
-  white-space: nowrap;
-}
-
 .chat-header-toggle:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px var(--focus-ring);

--- a/web/src/pages/watch-page.tsx
+++ b/web/src/pages/watch-page.tsx
@@ -17,6 +17,7 @@ import { RecordingButton } from '../components/watch/recording-button';
 import type { VideoControlsHandle } from '../components/watch/use-video-controls';
 import { WatchContent } from '../components/watch/watch-content';
 import { WatchPageMeta } from '../components/watch/watch-page-meta';
+import { useChatOnlyMode } from '../hooks/use-chat-only-mode';
 import { useKeyboardShortcuts, useToggleCallback } from '../hooks/use-keyboard-shortcuts';
 import { useRouter } from '../hooks/use-router';
 import { useWatchPreferences } from '../hooks/use-watch-preferences';
@@ -341,11 +342,14 @@ export const WatchPage = (): ReactElement => {
   const { isChatCollapsed, setIsChatCollapsed, setTheaterMode, theaterMode } =
     useWatchPreferences();
   const currentTwitchUser = useCurrentTwitchUser();
+  const { chatOnly, toggleChatCollapse, toggleChatOnly } = useChatOnlyMode(
+    ticket,
+    setIsChatCollapsed,
+  );
   const [playbackError, setPlaybackError] = useState<string | undefined>();
   const composerRef = useRef<ChatComposerHandle | null>(null);
   const videoPlayerRef = useRef<VideoControlsHandle | null>(null);
 
-  const toggleChatCollapse = useToggleCallback(setIsChatCollapsed);
   const toggleTheaterMode = useToggleCallback(setTheaterMode);
 
   const handlePlaybackError = useCallback((msg: string): void => {
@@ -417,12 +421,14 @@ export const WatchPage = (): ReactElement => {
         availableEmotes={availableEmotes}
         channelLogin={channelLogin}
         chatAvailable={chatAvailable}
+        chatOnly={chatOnly}
         currentUserDisplayName={currentTwitchUser.display_name}
         currentUserLogin={currentTwitchUser.login}
         handleChatStatusChange={handleChatStatusChange}
         handleConnectTwitch={handleConnectTwitch}
         handlePlaybackError={handlePlaybackError}
         handleToggleCollapse={toggleChatCollapse}
+        handleToggleChatOnly={toggleChatOnly}
         isChatCollapsed={isChatCollapsed}
         manifestUrl={manifestUrl}
         onToggleTheater={toggleTheaterMode}


### PR DESCRIPTION
- Added \`chatOnly\` prop and \`onToggleChatOnly\` callback to \`ChatProps\` interface in \`web/src/components/watch/chat.tsx\`.
- Introduced a new \`ChatHeader\` component with additional buttons for chat toggle and collapse, updating the layout accordingly.
- Updated \`WatchContent\` component to handle the new \`chatOnly\` state and add conditional rendering based on this state.
- Created a new hook \`use-chat-only-mode\` in \`web/src/hooks/use-chat-only-mode.ts\` to manage chat-only mode logic, including toggling chat visibility and collapsing.
- Added tests for the \`useChatOnlyMode\` hook in \`web/src/hooks/use-chat-only-mode.test.ts\` to ensure proper behavior on state changes and watch ticket updates.
- Updated CSS variables in \`web/src/lib/styles/app.css\` to adapt the layout for chat-only mode, ensuring responsive design.