### PR TITLE
feat(chat): add chat recovery, reconnect backoff and status events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "twitch-relay"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twitch-relay"
-version = "0.6.8"
+version = "0.6.9"
 edition = "2024"
 description = "A relay service for Twitch streams"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "twitch-relay"
 version = "0.6.9"
 edition = "2024"
+license = "AGPL-3.0-or-later"
 description = "A relay service for Twitch streams"
 repository = "https://github.com/wandabastyle/twitch-relay"
 keywords = ["twitch", "streaming", "relay"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "twitch-relay"
 version = "0.6.9"
 edition = "2024"
 description = "A relay service for Twitch streams"
-license = "MIT"
 repository = "https://github.com/wandabastyle/twitch-relay"
 keywords = ["twitch", "streaming", "relay"]
 categories = ["multimedia", "web"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,235 @@
+GNU AFFERO GENERAL PUBLIC LICENSE
+Version 3, 19 November 2007
+
+Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+                            Preamble
+
+The GNU Affero General Public License is a free, copyleft license for software and other kinds of works, specifically designed to ensure cooperation with the community in the case of network server software.
+
+The licenses for most software and other practical works are designed to take away your freedom to share and change the works.  By contrast, our General Public Licenses are intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users.
+
+When we speak of free software, we are referring to freedom, not price.  Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things.
+
+Developers that use our General Public Licenses protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License which gives you legal permission to copy, distribute and/or modify the software.
+
+A secondary benefit of defending all users' freedom is that improvements made in alternate versions of the program, if they receive widespread use, become available for other developers to incorporate.  Many developers of free software are heartened and encouraged by the resulting cooperation.  However, in the case of software used on network servers, this result may fail to come about. The GNU General Public License permits making a modified version and letting the public access it on a server without ever releasing its source code to the public.
+
+The GNU Affero General Public License is designed specifically to ensure that, in such cases, the modified source code becomes available to the community.  It requires the operator of a network server to provide the source code of the modified version running there to the users of that server.  Therefore, public use of a modified version, on a publicly accessible server, gives the public access to the source code of the modified version.
+
+An older license, called the Affero General Public License and published by Affero, was designed to accomplish similar goals.  This is a different license, not a version of the Affero GPL, but Affero has released a new version of the Affero GPL which permits relicensing under this license.
+
+The precise terms and conditions for copying, distribution and modification follow.
+
+                       TERMS AND CONDITIONS
+
+0. Definitions.
+
+"This License" refers to version 3 of the GNU Affero General Public License.
+
+"Copyright" also means copyright-like laws that apply to other kinds of works, such as semiconductor masks.
+
+"The Program" refers to any copyrightable work licensed under this License.  Each licensee is addressed as "you".  "Licensees" and "recipients" may be individuals or organizations.
+
+To "modify" a work means to copy from or adapt all or part of the work in a fashion requiring copyright permission, other than the making of an exact copy.  The resulting work is called a "modified version" of the earlier work or a work "based on" the earlier work.
+
+A "covered work" means either the unmodified Program or a work based on the Program.
+
+To "propagate" a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy.  Propagation includes copying, distribution (with or without modification), making available to the public, and in some countries other activities as well.
+
+To "convey" a work means any kind of propagation that enables other parties to make or receive copies.  Mere interaction with a user through a computer network, with no transfer of a copy, is not conveying.
+
+An interactive user interface displays "Appropriate Legal Notices" to the extent that it includes a convenient and prominently visible feature that (1) displays an appropriate copyright notice, and (2) tells the user that there is no warranty for the work (except to the extent that warranties are provided), that licensees may convey the work under this License, and how to view a copy of this License.  If the interface presents a list of user commands or options, such as a menu, a prominent item in the list meets this criterion.
+
+1. Source Code.
+The "source code" for a work means the preferred form of the work for making modifications to it.  "Object code" means any non-source form of a work.
+
+A "Standard Interface" means an interface that either is an official standard defined by a recognized standards body, or, in the case of interfaces specified for a particular programming language, one that is widely used among developers working in that language.
+
+The "System Libraries" of an executable work include anything, other than the work as a whole, that (a) is included in the normal form of packaging a Major Component, but which is not part of that Major Component, and (b) serves only to enable use of the work with that Major Component, or to implement a Standard Interface for which an implementation is available to the public in source code form.  A "Major Component", in this context, means a major essential component (kernel, window system, and so on) of the specific operating system (if any) on which the executable work runs, or a compiler used to produce the work, or an object code interpreter used to run it.
+
+The "Corresponding Source" for a work in object code form means all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities.  However, it does not include the work's System Libraries, or general-purpose tools or generally available free programs which are used unmodified in performing those activities but which are not part of the work.  For example, Corresponding Source includes interface definition files associated with source files for the work, and the source code for shared libraries and dynamically linked subprograms that the work is specifically designed to require, such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+The Corresponding Source need not include anything that users can regenerate automatically from other parts of the Corresponding Source.
+
+The Corresponding Source for a work in source code form is that same work.
+
+2. Basic Permissions.
+All rights granted under this License are granted for the term of copyright on the Program, and are irrevocable provided the stated conditions are met.  This License explicitly affirms your unlimited permission to run the unmodified Program.  The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work.  This License acknowledges your rights of fair use or other equivalent, as provided by copyright law.
+
+You may make, run and propagate covered works that you do not convey, without conditions so long as your license otherwise remains in force.  You may convey covered works to others for the sole purpose of having them make modifications exclusively for you, or provide you with facilities for running those works, provided that you comply with the terms of this License in conveying all material for which you do not control copyright.  Those thus making or running the covered works for you must do so exclusively on your behalf, under your direction and control, on terms that prohibit them from making any copies of your copyrighted material outside their relationship with you.
+
+Conveying under any other circumstances is permitted solely under the conditions stated below.  Sublicensing is not allowed; section 10 makes it unnecessary.
+
+3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+No covered work shall be deemed part of an effective technological measure under any applicable law fulfilling obligations under article 11 of the WIPO copyright treaty adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention of such measures.
+
+When you convey a covered work, you waive any legal power to forbid circumvention of technological measures to the extent such circumvention is effected by exercising rights under this License with respect to the covered work, and you disclaim any intention to limit operation or modification of the work as a means of enforcing, against the work's users, your or third parties' legal rights to forbid circumvention of technological measures.
+
+4. Conveying Verbatim Copies.
+You may convey verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice; keep intact all notices stating that this License and any non-permissive terms added in accord with section 7 apply to the code; keep intact all notices of the absence of any warranty; and give all recipients a copy of this License along with the Program.
+
+You may charge any price or no price for each copy that you convey, and you may offer support or warranty protection for a fee.
+
+5. Conveying Modified Source Versions.
+You may convey a work based on the Program, or the modifications to produce it from the Program, in the form of source code under the terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is released under this License and any conditions added under section 7.  This requirement modifies the requirement in section 4 to "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this License to anyone who comes into possession of a copy.  This License will therefore apply, along with any applicable section 7 additional terms, to the whole of the work, and all its parts, regardless of how they are packaged.  This License gives no permission to license the work in any other way, but it does not invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display Appropriate Legal Notices; however, if the Program has interactive interfaces that do not display Appropriate Legal Notices, your work need not make them do so.
+
+A compilation of a covered work with other separate and independent works, which are not by their nature extensions of the covered work, and which are not combined with it such as to form a larger program, in or on a volume of a storage or distribution medium, is called an "aggregate" if the compilation and its resulting copyright are not used to limit the access or legal rights of the compilation's users beyond what the individual works permit.  Inclusion of a covered work in an aggregate does not cause this License to apply to the other parts of the aggregate.
+
+6. Conveying Non-Source Forms.
+You may convey a covered work in object code form under the terms of sections 4 and 5, provided that you also convey the machine-readable Corresponding Source under the terms of this License, in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by the Corresponding Source fixed on a durable physical medium customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by a written offer, valid for at least three years and valid for as long as you offer spare parts or customer support for that product model, to give anyone who possesses the object code either (1) a copy of the Corresponding Source for all the software in the product that is covered by this License, on a durable physical medium customarily used for software interchange, for a price no more than your reasonable cost of physically performing this conveying of source, or (2) access to copy the Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the written offer to provide the Corresponding Source.  This alternative is allowed only occasionally and noncommercially, and only if you received the object code with such an offer, in accord with subsection 6b.
+
+    d) Convey the object code by offering access from a designated place (gratis or for a charge), and offer equivalent access to the Corresponding Source in the same way through the same place at no further charge.  You need not require recipients to copy the Corresponding Source along with the object code.  If the place to copy the object code is a network server, the Corresponding Source may be on a different server (operated by you or a third party) that supports equivalent copying facilities, provided you maintain clear directions next to the object code saying where to find the Corresponding Source.  Regardless of what server hosts the Corresponding Source, you remain obligated to ensure that it is available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided you inform other peers where the object code and Corresponding Source of the work are being offered to the general public at no charge under subsection 6d.
+
+A separable portion of the object code, whose source code is excluded from the Corresponding Source as a System Library, need not be included in conveying the object code work.
+
+A "User Product" is either (1) a "consumer product", which means any tangible personal property which is normally used for personal, family, or household purposes, or (2) anything designed or sold for incorporation into a dwelling.  In determining whether a product is a consumer product, doubtful cases shall be resolved in favor of coverage.  For a particular product received by a particular user, "normally used" refers to a typical or common use of that class of product, regardless of the status of the particular user or of the way in which the particular user actually uses, or expects or is expected to use, the product.  A product is a consumer product regardless of whether the product has substantial commercial, industrial or non-consumer uses, unless such uses represent the only significant mode of use of the product.
+
+"Installation Information" for a User Product means any methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source.  The information must suffice to ensure that the continued functioning of the modified object code is in no case prevented or interfered with solely because modification has been made.
+
+If you convey an object code work under this section in, or with, or specifically for use in, a User Product, and the conveying occurs as part of a transaction in which the right of possession and use of the User Product is transferred to the recipient in perpetuity or for a fixed term (regardless of how the transaction is characterized), the Corresponding Source conveyed under this section must be accompanied by the Installation Information.  But this requirement does not apply if neither you nor any third party retains the ability to install modified object code on the User Product (for example, the work has been installed in ROM).
+
+The requirement to provide Installation Information does not include a requirement to continue to provide support service, warranty, or updates for a work that has been modified or installed by the recipient, or for the User Product in which it has been modified or installed.  Access to a network may be denied when the modification itself materially and adversely affects the operation of the network or violates the rules and protocols for communication across the network.
+
+Corresponding Source conveyed, and Installation Information provided, in accord with this section must be in a format that is publicly documented (and with an implementation available to the public in source code form), and must require no special password or key for unpacking, reading or copying.
+
+7. Additional Terms.
+"Additional permissions" are terms that supplement the terms of this License by making exceptions from one or more of its conditions. Additional permissions that are applicable to the entire Program shall be treated as though they were included in this License, to the extent that they are valid under applicable law.  If additional permissions apply only to part of the Program, that part may be used separately under those permissions, but the entire Program remains governed by this License without regard to the additional permissions.
+
+When you convey a copy of a covered work, you may at your option remove any additional permissions from that copy, or from any part of it.  (Additional permissions may be written to require their own removal in certain cases when you modify the work.)  You may place additional permissions on material, added by you to a covered work, for which you have or can give appropriate copyright permission.
+
+Notwithstanding any other provision of this License, for material you add to a covered work, you may (if authorized by the copyright holders of that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or author attributions in that material or in the Appropriate Legal Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or requiring that modified versions of such material be marked in reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that material by anyone who conveys the material (or modified versions of it) with contractual assumptions of liability to the recipient, for any liability that these contractual assumptions directly impose on those licensors and authors.
+
+All other non-permissive additional terms are considered "further restrictions" within the meaning of section 10.  If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term.  If a license document contains a further restriction but permits relicensing or conveying under this License, you may add to a covered work material governed by the terms of that license document, provided that the further restriction does not survive such relicensing or conveying.
+
+If you add terms to a covered work in accord with this section, you must place, in the relevant source files, a statement of the additional terms that apply to those files, or a notice indicating where to find the applicable terms.
+
+Additional terms, permissive or non-permissive, may be stated in the form of a separately written license, or stated as exceptions; the above requirements apply either way.
+
+8. Termination.
+
+You may not propagate or modify a covered work except as expressly provided under this License.  Any attempt otherwise to propagate or modify it is void, and will automatically terminate your rights under this License (including any patent licenses granted under the third paragraph of section 11).
+
+However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice.
+
+Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License.  If your rights have been terminated and not permanently reinstated, you do not qualify to receive new licenses for the same material under section 10.
+
+9. Acceptance Not Required for Having Copies.
+
+You are not required to accept this License in order to receive or run a copy of the Program.  Ancillary propagation of a covered work occurring solely as a consequence of using peer-to-peer transmission to receive a copy likewise does not require acceptance.  However, nothing other than this License grants you permission to propagate or modify any covered work.  These actions infringe copyright if you do not accept this License.  Therefore, by modifying or propagating a covered work, you indicate your acceptance of this License to do so.
+
+10. Automatic Licensing of Downstream Recipients.
+
+Each time you convey a covered work, the recipient automatically receives a license from the original licensors, to run, modify and propagate that work, subject to this License.  You are not responsible for enforcing compliance by third parties with this License.
+
+An "entity transaction" is a transaction transferring control of an organization, or substantially all assets of one, or subdividing an organization, or merging organizations.  If propagation of a covered work results from an entity transaction, each party to that transaction who receives a copy of the work also receives whatever licenses to the work the party's predecessor in interest had or could give under the previous paragraph, plus a right to possession of the Corresponding Source of the work from the predecessor in interest, if the predecessor has it or can get it with reasonable efforts.
+
+You may not impose any further restrictions on the exercise of the rights granted or affirmed under this License.  For example, you may not impose a license fee, royalty, or other charge for exercise of rights granted under this License, and you may not initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is infringed by making, using, selling, offering for sale, or importing the Program or any portion of it.
+
+11. Patents.
+
+A "contributor" is a copyright holder who authorizes use under this License of the Program or a work on which the Program is based.  The work thus licensed is called the contributor's "contributor version".
+
+A contributor's "essential patent claims" are all patent claims owned or controlled by the contributor, whether already acquired or hereafter acquired, that would be infringed by some manner, permitted by this License, of making, using, or selling its contributor version, but do not include claims that would be infringed only as a consequence of further modification of the contributor version.  For purposes of this definition, "control" includes the right to grant patent sublicenses in a manner consistent with the requirements of this License.
+
+Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the contributor's essential patent claims, to make, use, sell, offer for sale, import and otherwise run, modify and propagate the contents of its contributor version.
+
+In the following three paragraphs, a "patent license" is any express agreement or commitment, however denominated, not to enforce a patent (such as an express permission to practice a patent or covenant not to sue for patent infringement).  To "grant" such a patent license to a party means to make such an agreement or commitment not to enforce a patent against the party.
+
+If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source of the work is not available for anyone to copy, free of charge and under the terms of this License, through a publicly available network server or other readily accessible means, then you must either (1) cause the Corresponding Source to be so available, or (2) arrange to deprive yourself of the benefit of the patent license for this particular work, or (3) arrange, in a manner consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have actual knowledge that, but for the patent license, your conveying the covered work in a country, or your recipient's use of the covered work in a country, would infringe one or more identifiable patents in that country that you have reason to believe are valid.
+
+If, pursuant to or in connection with a single transaction or arrangement, you convey, or propagate by procuring conveyance of, a covered work, and grant a patent license to some of the parties receiving the covered work authorizing them to use, propagate, modify or convey a specific copy of the covered work, then the patent license you grant is automatically extended to all recipients of the covered work and works based on it.
+
+A patent license is "discriminatory" if it does not include within the scope of its coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of the rights that are specifically granted under this License.  You may not convey a covered work if you are a party to an arrangement with a third party that is in the business of distributing software, under which you make payment to the third party based on the extent of your activity of conveying the work, and under which the third party grants, to any of the parties who would receive the covered work from you, a discriminatory patent license (a) in connection with copies of the covered work conveyed by you (or copies made from those copies), or (b) primarily for and in connection with specific products or compilations that contain the covered work, unless you entered into that arrangement, or that patent license was granted, prior to 28 March 2007.
+
+Nothing in this License shall be construed as excluding or limiting any implied license or other defenses to infringement that may otherwise be available to you under applicable patent law.
+
+12. No Surrender of Others' Freedom.
+
+If conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License.  If you cannot convey a covered work so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you to collect a royalty for further conveying from those to whom you convey the Program, the only way you could satisfy both those terms and this License would be to refrain entirely from conveying the Program.
+
+13. Remote Network Interaction; Use with the GNU General Public License.
+
+Notwithstanding any other provision of this License, if you modify the Program, your modified version must prominently offer all users interacting with it remotely through a computer network (if your version supports such interaction) an opportunity to receive the Corresponding Source of your version by providing access to the Corresponding Source from a network server at no charge, through some standard or customary means of facilitating copying of software.  This Corresponding Source shall include the Corresponding Source for any work covered by version 3 of the GNU General Public License that is incorporated pursuant to the following paragraph.
+
+Notwithstanding any other provision of this License, you have permission to link or combine any covered work with a work licensed under version 3 of the GNU General Public License into a single combined work, and to convey the resulting work.  The terms of this License will continue to apply to the part which is the covered work, but the work with which it is combined will remain governed by version 3 of the GNU General Public License.
+
+14. Revised Versions of this License.
+
+The Free Software Foundation may publish revised and/or new versions of the GNU Affero General Public License from time to time.  Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program specifies that a certain numbered version of the GNU Affero General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation.  If the Program does not specify a version number of the GNU Affero General Public License, you may choose any version ever published by the Free Software Foundation.
+
+If the Program specifies that a proxy can decide which future versions of the GNU Affero General Public License can be used, that proxy's public statement of acceptance of a version permanently authorizes you to choose that version for the Program.
+
+Later license versions may give you additional or different permissions.  However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version.
+
+15. Disclaimer of Warranty.
+
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. Limitation of Liability.
+
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+17. Interpretation of Sections 15 and 16.
+
+If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program, unless a warranty or assumption of liability accompanies a copy of the Program in return for a fee.
+
+END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program.  It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+     <one line to give the program's name and a brief idea of what it does.>
+     Copyright (C) <year>  <name of author>
+
+     This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+
+     You should have received a copy of the GNU Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If your software can interact with users remotely through a computer network, you should also make sure that it provides a way for users to get its source.  For example, if your program is a web application, its interface could display a "Source" link that leads users to an archive of the code.  There are many ways you could offer source, and different solutions will be better for different programs; see section 13 for the specific requirements.
+
+You should also get your employer (if you work as a programmer) or school, if any, to sign a "copyright disclaimer" for the program, if necessary. For more information on this, and how to apply and follow the GNU AGPL, see <http://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -124,3 +124,7 @@ Optional YouTube/Invidious support:
 - If not configured, YouTube features will be disabled and only Twitch will be available.
 
 See `.env.example` for the complete list of configuration options.
+
+## License
+
+This project is licensed under [AGPL-3.0-or-later](LICENSE). Operators of modified network-hosted versions must offer corresponding source to remote users.

--- a/src/chat/emotes.rs
+++ b/src/chat/emotes.rs
@@ -3,6 +3,7 @@ use std::{
       HashMap,
       HashSet,
    },
+   future::Future,
    sync::{
       Arc,
       atomic::{
@@ -16,7 +17,13 @@ use serde::{
    Deserialize,
    Serialize,
 };
-use tokio::sync::RwLock;
+use tokio::{
+   sync::RwLock,
+   time::{
+      Duration,
+      timeout,
+   },
+};
 
 use crate::{
    chat::events::ChatPart,
@@ -32,6 +39,7 @@ const THIRD_PARTY_EMOTE_CACHE_TTL_SECS: u64 = 300;
 const OWNER_NAME_CACHE_TTL_SECS: u64 = 24 * 60 * 60;
 const OWNER_NAME_MISS_CACHE_TTL_SECS: u64 = 15 * 60;
 const OWNER_LOOKUP_429_FALLBACK_COOLDOWN_SECS: u64 = 60;
+const THIRD_PARTY_EMOTE_REQUEST_TIMEOUT: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Clone, Serialize)]
 pub struct EmotePickerResponse {
@@ -362,14 +370,20 @@ pub async fn third_party_emotes_for_channel(
 
    merge_third_party_emote_map(
       &mut out,
-      fetch_7tv_channel_emotes(&client, &normalized_channel).await,
+      within_third_party_timeout(fetch_7tv_channel_emotes(&client, &normalized_channel)).await,
    );
    merge_third_party_emote_map(
       &mut out,
-      fetch_bttv_channel_emotes(&client, &normalized_channel).await,
+      within_third_party_timeout(fetch_bttv_channel_emotes(&client, &normalized_channel)).await,
    );
-   merge_third_party_emote_map(&mut out, fetch_7tv_global_emotes(&client).await);
-   merge_third_party_emote_map(&mut out, fetch_bttv_global_emotes(&client).await);
+   merge_third_party_emote_map(
+      &mut out,
+      within_third_party_timeout(fetch_7tv_global_emotes(&client)).await,
+   );
+   merge_third_party_emote_map(
+      &mut out,
+      within_third_party_timeout(fetch_bttv_global_emotes(&client)).await,
+   );
 
    let expires_at_unix = now_unix_secs().saturating_add(THIRD_PARTY_EMOTE_CACHE_TTL_SECS);
    {
@@ -383,10 +397,30 @@ pub async fn third_party_emotes_for_channel(
    Ok(out)
 }
 
+async fn within_third_party_timeout<T>(
+   future: impl Future<Output = Result<T, String>>,
+) -> Result<T, String> {
+   timeout(THIRD_PARTY_EMOTE_REQUEST_TIMEOUT, future)
+      .await
+      .map_err(|_| "third-party emote request timed out".to_string())?
+}
+
+pub async fn cached_third_party_emotes_for_channel(
+   cache: &Arc<RwLock<HashMap<String, CachedThirdPartyEmotes>>>,
+   channel: &str,
+) -> HashMap<String, String> {
+   let now = now_unix_secs();
+   let normalized_channel = channel.trim().to_ascii_lowercase();
+   let cache = cache.read().await;
+   cache
+      .get(&normalized_channel)
+      .filter(|entry| entry.expires_at_unix > now)
+      .map_or_else(HashMap::new, |entry| entry.by_code.clone())
+}
+
 pub async fn local_echo_parts_for_channel(
    emote_cache: &Arc<RwLock<HashMap<String, CachedEmoteEntry>>>,
    third_party_emote_cache: &Arc<RwLock<HashMap<String, CachedThirdPartyEmotes>>>,
-   auth: &TwitchAuthService,
    channel: &str,
    message: &str,
 ) -> Vec<ChatPart> {
@@ -409,9 +443,8 @@ pub async fn local_echo_parts_for_channel(
       }
    }
 
-   let third_party_emotes = third_party_emotes_for_channel(auth, third_party_emote_cache, channel)
-      .await
-      .unwrap_or_default();
+   let third_party_emotes =
+      cached_third_party_emotes_for_channel(third_party_emote_cache, channel).await;
 
    parse_local_message_parts(message, &emotes_by_code, &third_party_emotes)
 }

--- a/src/chat/events.rs
+++ b/src/chat/events.rs
@@ -52,6 +52,12 @@ pub struct ChatChannelStatus {
    pub error:      Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub enum ChatStreamEvent {
+   Chat(ChatEvent),
+   Status(ChatChannelStatus),
+}
+
 #[derive(Debug, Deserialize)]
 pub struct ChatChannelRequest {
    pub channel_login: String,

--- a/src/chat/irc.rs
+++ b/src/chat/irc.rs
@@ -2,8 +2,12 @@ use std::{
    collections::{
       HashMap,
       HashSet,
+      VecDeque,
    },
-   sync::Arc,
+   sync::{
+      Arc,
+      atomic::Ordering,
+   },
    time::Duration,
 };
 
@@ -12,15 +16,20 @@ use futures_util::{
    StreamExt,
    future::pending,
 };
+use rand::Rng;
 use tokio::{
    sync::{
       RwLock,
+      Semaphore,
       broadcast,
       mpsc,
+      watch,
    },
+   task::JoinHandle,
    time::{
       Instant,
       sleep_until,
+      timeout,
    },
 };
 use tokio_tungstenite::{
@@ -31,34 +40,47 @@ use tokio_tungstenite::{
 use crate::{
    chat::{
       emotes::{
+         CachedEmoteEntry,
          CachedThirdPartyEmotes,
+         cached_third_party_emotes_for_channel,
          local_echo_parts_for_channel,
          third_party_emotes_for_channel,
       },
       events::{
+         ChatChannelStatus,
          ChatEvent,
          ChatEventKind,
          ChatPart,
+         ChatStreamEvent,
          fallback_sender_color,
          parse_chat_event,
       },
       service::{
          ChatCommand,
          ChatError,
+         ChatMetrics,
       },
    },
    twitch_auth::TwitchAuthService,
    util::time::now_unix_secs,
 };
 
-const LOCAL_ECHO_TTL_SECS: u64 = 8;
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(12);
+const AUTH_TIMEOUT: Duration = Duration::from_secs(10);
+const IDLE_TIMEOUT: Duration = Duration::from_mins(3);
 const PART_GRACE_PERIOD: Duration = Duration::from_secs(3);
-const IRC_RECONNECT_DELAY: Duration = Duration::from_secs(5);
+const RECONNECT_CAP: Duration = Duration::from_mins(1);
+const OUTBOUND_CAPACITY: usize = 256;
+const INBOUND_CAPACITY: usize = 512;
+const EMOTE_REFRESH_CAPACITY: usize = 4;
+const LOCAL_ECHO_TTL: Duration = Duration::from_secs(8);
+const MAX_LOCAL_ECHOES: usize = 256;
+const JOIN_RETRY_DELAY: Duration = Duration::from_millis(250);
+const MAX_PENDING_JOIN_RETRIES: usize = 256;
 
 #[derive(Debug)]
-pub enum ReaderEvent {
+enum ReaderEvent {
    Line(String),
-   Disconnected,
 }
 
 #[derive(Debug, Clone)]
@@ -67,136 +89,277 @@ struct ChatIdentity {
    display_name: String,
 }
 
-/// State for the chat manager loop.
+struct ConnectedSocket {
+   writer_tx:     mpsc::Sender<String>,
+   reader_rx:     mpsc::Receiver<ReaderEvent>,
+   disconnect_rx: watch::Receiver<Option<String>>,
+   identity:      ChatIdentity,
+}
+
+struct LocalEcho {
+   key:        String,
+   expires_at: Instant,
+}
+
 struct ChatManagerState {
-   subscribed_counts:  HashMap<String, usize>,
-   joined_channels:    HashSet<String>,
-   connected:          bool,
-   last_error:         Option<String>,
-   writer_tx:          Option<mpsc::UnboundedSender<String>>,
-   reader_rx:          Option<mpsc::UnboundedReceiver<ReaderEvent>>,
-   chat_identity:      Option<ChatIdentity>,
-   pending_local_echo: HashMap<String, u64>,
-   pending_parts:      HashMap<String, Instant>,
-   reconnect_after:    Option<Instant>,
+   subscribed_counts:    HashMap<String, usize>,
+   joined_channels:      HashSet<String>,
+   joining_channels:     HashSet<String>,
+   connected:            bool,
+   last_error:           Option<String>,
+   writer_tx:            Option<mpsc::Sender<String>>,
+   reader_rx:            Option<mpsc::Receiver<ReaderEvent>>,
+   disconnect_rx:        Option<watch::Receiver<Option<String>>>,
+   chat_identity:        Option<ChatIdentity>,
+   pending_parts:        HashMap<String, Instant>,
+   pending_joins:        HashMap<String, Instant>,
+   pending_local_echoes: VecDeque<LocalEcho>,
+   reconnect_after:      Option<Instant>,
+   failures:             u32,
 }
 
 impl ChatManagerState {
    fn new() -> Self {
       Self {
-         subscribed_counts:  HashMap::new(),
-         joined_channels:    HashSet::new(),
-         connected:          false,
-         last_error:         None,
-         writer_tx:          None,
-         reader_rx:          None,
-         chat_identity:      None,
-         pending_local_echo: HashMap::new(),
-         pending_parts:      HashMap::new(),
-         reconnect_after:    None,
+         subscribed_counts:    HashMap::new(),
+         joined_channels:      HashSet::new(),
+         joining_channels:     HashSet::new(),
+         connected:            false,
+         last_error:           None,
+         writer_tx:            None,
+         reader_rx:            None,
+         disconnect_rx:        None,
+         chat_identity:        None,
+         pending_parts:        HashMap::new(),
+         pending_joins:        HashMap::new(),
+         pending_local_echoes: VecDeque::new(),
+         reconnect_after:      None,
+         failures:             0,
       }
+   }
+
+   fn disconnect(&mut self, reason: String, metrics: &ChatMetrics) {
+      self.connected = false;
+      self.writer_tx = None;
+      self.reader_rx = None;
+      self.disconnect_rx = None;
+      self.chat_identity = None;
+      self.joined_channels.clear();
+      self.joining_channels.clear();
+      self.pending_joins.clear();
+      self.pending_local_echoes.clear();
+      tracing::warn!(error = %reason, failures = self.failures.saturating_add(1), "chat connection disconnected; scheduling reconnect");
+      self.last_error = Some(reason);
+      self.failures = self.failures.saturating_add(1);
+      self.reconnect_after = Some(Instant::now() + reconnect_delay(self.failures));
+      metrics.connected.store(false, Ordering::Relaxed);
+      metrics.disconnects.fetch_add(1, Ordering::Relaxed);
    }
 }
 
-async fn handle_subscribe_command(
-   channel: String,
-   response: tokio::sync::oneshot::Sender<Result<(), ChatError>>,
-   state: &mut ChatManagerState,
-   channels: &Arc<RwLock<HashMap<String, broadcast::Sender<ChatEvent>>>>,
+pub async fn run_chat_manager(
+   auth: TwitchAuthService,
+   mut command_rx: mpsc::Receiver<ChatCommand>,
+   channels: Arc<RwLock<HashMap<String, broadcast::Sender<ChatStreamEvent>>>>,
+   emote_cache: Arc<RwLock<HashMap<String, CachedEmoteEntry>>>,
+   third_party_cache: Arc<RwLock<HashMap<String, CachedThirdPartyEmotes>>>,
+   metrics: ChatMetrics,
 ) {
-   let canceled_part = state.pending_parts.remove(&channel).is_some();
-   let entry = state.subscribed_counts.entry(channel.clone()).or_insert(0);
-   *entry = entry.saturating_add(1);
-   tracing::info!(
-      channel = %channel,
-      count = *entry,
-      canceled_part,
-      connected = state.connected,
-      joined = state.joined_channels.contains(&channel),
-      "chat channel subscribed"
+   let mut state = ChatManagerState::new();
+   let mut attempt: Option<JoinHandle<Result<ConnectedSocket, ChatError>>> = None;
+   let mut attempt_started = None;
+   let (emote_refresh_tx, mut emote_refresh_rx) = mpsc::channel(EMOTE_REFRESH_CAPACITY);
+   let emote_refresh_slots = Arc::new(Semaphore::new(EMOTE_REFRESH_CAPACITY));
+
+   loop {
+      if state.subscribed_counts.is_empty()
+         && !state.connected
+         && let Some(handle) = attempt.take()
+      {
+         handle.abort();
+      }
+      if should_start_attempt(&state, attempt.is_some()) {
+         metrics.connection_attempts.fetch_add(1, Ordering::Relaxed);
+         if state.failures > 0 {
+            metrics.reconnects.fetch_add(1, Ordering::Relaxed);
+         }
+         let auth = auth.clone();
+         let attempt_metrics = metrics.clone();
+         attempt = Some(tokio::spawn(async move {
+            connect_chat(&auth, &attempt_metrics).await
+         }));
+         attempt_started = Some(Instant::now());
+      }
+
+      let deadline = next_timer_deadline(&state);
+      let reader = async {
+         match state.reader_rx.as_mut() {
+            Some(rx) => rx.recv().await,
+            None => pending().await,
+         }
+      };
+      let timer = async {
+         match deadline {
+            Some(value) => sleep_until(value).await,
+            None => pending().await,
+         }
+      };
+      let attempt_result = async {
+         match attempt.as_mut() {
+            Some(handle) => Some(handle.await),
+            None => pending().await,
+         }
+      };
+      let disconnect = wait_for_disconnect(state.disconnect_rx.as_mut());
+
+      tokio::select! {
+         command = command_rx.recv() => match command {
+            Some(command) => handle_command(command, &mut state, &channels, &emote_cache, &third_party_cache, &emote_refresh_tx).await,
+            None => break,
+         },
+         event = reader => match event {
+            Some(event) => handle_reader_event(event, &mut state, &channels, &third_party_cache, &emote_refresh_tx, &metrics).await,
+            None if state.connected => {
+               state.disconnect("chat reader task ended".to_string(), &metrics);
+               publish_all_statuses(&channels, &state).await;
+            },
+            None => {},
+         },
+         Some(()) = disconnect => {
+            let reason = state
+               .disconnect_rx
+               .as_mut()
+               .and_then(|rx| rx.borrow_and_update().clone())
+               .unwrap_or_else(|| "chat connection task ended".to_string());
+            state.disconnect(reason, &metrics);
+            publish_all_statuses(&channels, &state).await;
+         },
+         result = attempt_result => {
+            attempt = None;
+            if let Some(started) = attempt_started.take() {
+               metrics.last_attempt_ms.store(started.elapsed().as_millis().try_into().unwrap_or(u64::MAX), Ordering::Relaxed);
+            }
+            match result {
+               Some(Ok(Ok(socket))) => install_connection(socket, &mut state, &metrics, &channels).await,
+               Some(Ok(Err(error))) => { metrics.connection_failures.fetch_add(1, Ordering::Relaxed); state.disconnect(error.to_string(), &metrics); publish_all_statuses(&channels, &state).await; },
+               Some(Err(error)) => { metrics.connection_failures.fetch_add(1, Ordering::Relaxed); state.disconnect(format!("chat connection task failed: {error}"), &metrics); publish_all_statuses(&channels, &state).await; },
+               None => {},
+            }
+         },
+         Some(channel) = emote_refresh_rx.recv() => {
+            let auth = auth.clone();
+            let cache = third_party_cache.clone();
+            if let Ok(permit) = emote_refresh_slots.clone().try_acquire_owned() {
+               tokio::spawn(async move {
+                  let _permit = permit;
+                  if let Err(error) = third_party_emotes_for_channel(&auth, &cache, &channel).await {
+                     tracing::debug!(%channel, %error, "background third-party emote refresh failed");
+                  }
+               });
+            }
+         },
+          () = timer => process_due_control(&mut state, &channels).await,
+      }
+   }
+   if let Some(handle) = attempt {
+      handle.abort();
+   }
+   metrics.connected.store(false, Ordering::Relaxed);
+}
+
+fn should_start_attempt(state: &ChatManagerState, attempting: bool) -> bool {
+   !attempting
+      && !state.connected
+      && !state.subscribed_counts.is_empty()
+      && state.reconnect_after.is_none_or(|at| at <= Instant::now())
+}
+
+async fn wait_for_disconnect(rx: Option<&mut watch::Receiver<Option<String>>>) -> Option<()> {
+   match rx {
+      Some(rx) => rx.changed().await.ok(),
+      None => pending().await,
+   }
+}
+
+async fn install_connection(
+   socket: ConnectedSocket,
+   state: &mut ChatManagerState,
+   metrics: &ChatMetrics,
+   channels: &Arc<RwLock<HashMap<String, broadcast::Sender<ChatStreamEvent>>>>,
+) {
+   state.writer_tx = Some(socket.writer_tx);
+   state.reader_rx = Some(socket.reader_rx);
+   state.disconnect_rx = Some(socket.disconnect_rx);
+   state.chat_identity = Some(socket.identity.clone());
+   state.connected = true;
+   state.last_error = None;
+   state.reconnect_after = None;
+   state.failures = 0;
+   metrics.connected.store(true, Ordering::Relaxed);
+   tracing::info!(login = %socket.identity.login, "chat IRC welcome confirmed");
+   send_raw(
+      state,
+      "CAP REQ :twitch.tv/tags twitch.tv/commands twitch.tv/membership".to_string(),
    );
-   ensure_channel_sender(channels, &channel).await;
-
-   if state.connected
-      && !state.joined_channels.contains(&channel)
-      && let Some(writer) = state.writer_tx.as_ref()
-   {
-      tracing::info!(channel = %channel, count = *entry, "sending chat JOIN");
-      let _ = writer.send(format!("JOIN #{channel}"));
-      state.joined_channels.insert(channel.clone());
+   let targets: Vec<String> = state.subscribed_counts.keys().cloned().collect();
+   for channel in targets {
+      request_join(state, &channel);
    }
-
-   let _ = response.send(Ok(()));
+   publish_all_statuses(channels, state).await;
 }
 
-fn handle_unsubscribe_command(
-   channel: &str,
-   response: tokio::sync::oneshot::Sender<Result<(), ChatError>>,
-   state: &mut ChatManagerState,
-) {
-   if let Some(entry) = state.subscribed_counts.get_mut(channel) {
-      if *entry > 1 {
-         *entry -= 1;
-         tracing::debug!(channel = %channel, count = *entry, "chat channel unsubscribed");
-      } else {
-         state.subscribed_counts.remove(channel);
-         let deadline = Instant::now() + PART_GRACE_PERIOD;
-         state.pending_parts.insert(channel.to_string(), deadline);
-         tracing::debug!(
-            channel = %channel,
-            grace_ms = PART_GRACE_PERIOD.as_millis(),
-            "chat channel unsubscribe reached zero; scheduling PART"
-         );
-      }
-   }
-   let _ = response.send(Ok(()));
-}
-
-/// Handle a single chat command.
 async fn handle_command(
    command: ChatCommand,
    state: &mut ChatManagerState,
-   channels: &Arc<RwLock<HashMap<String, broadcast::Sender<ChatEvent>>>>,
-   emote_cache: &Arc<RwLock<HashMap<String, crate::chat::emotes::CachedEmoteEntry>>>,
-   third_party_emote_cache: &Arc<RwLock<HashMap<String, CachedThirdPartyEmotes>>>,
-   auth: &TwitchAuthService,
-) -> bool {
+   channels: &Arc<RwLock<HashMap<String, broadcast::Sender<ChatStreamEvent>>>>,
+   emote_cache: &Arc<RwLock<HashMap<String, CachedEmoteEntry>>>,
+   third_party_cache: &Arc<RwLock<HashMap<String, CachedThirdPartyEmotes>>>,
+   emote_refresh_tx: &mpsc::Sender<String>,
+) {
    match command {
       ChatCommand::Subscribe { channel, response } => {
-         handle_subscribe_command(channel, response, state, channels).await;
+         state.pending_parts.remove(&channel);
+         *state.subscribed_counts.entry(channel.clone()).or_insert(0) += 1;
+         ensure_channel_sender(channels, &channel).await;
+         request_join(state, &channel);
+         publish_status(channels, state, &channel).await;
+         let _ = response.send(Ok(()));
       },
       ChatCommand::Unsubscribe { channel, response } => {
-         handle_unsubscribe_command(&channel, response, state);
+         if let Some(count) = state.subscribed_counts.get_mut(&channel) {
+            if *count > 1 {
+               *count -= 1;
+            } else {
+               state.subscribed_counts.remove(&channel);
+               state.pending_joins.remove(&channel);
+               state
+                  .pending_parts
+                  .insert(channel.clone(), Instant::now() + PART_GRACE_PERIOD);
+            }
+         }
+         publish_status(channels, state, &channel).await;
+         let _ = response.send(Ok(()));
       },
       ChatCommand::SendMessage {
          channel,
          message,
          response,
       } => {
-         if !state.connected {
-            let error = state.last_error.clone().map_or_else(
-               || ChatError::ConnectionUnavailable("unknown".to_string()),
-               ChatError::ConnectionUnavailable,
-            );
-            let _ = response.send(Err(error));
-            return false;
+         if !state.connected || !state.joined_channels.contains(&channel) {
+            request_join(state, &channel);
+            let error = state
+               .last_error
+               .clone()
+               .unwrap_or_else(|| "channel is not joined yet".to_string());
+            let _ = response.send(Err(ChatError::ConnectionUnavailable(error)));
+            return;
          }
-
-         if !state.joined_channels.contains(&channel)
-            && let Some(writer) = state.writer_tx.as_ref()
-         {
-            tracing::info!(channel = %channel, "sending chat JOIN before message");
-            let _ = writer.send(format!("JOIN #{channel}"));
-            state.joined_channels.insert(channel.clone());
-         }
-
-         if let Some(writer) = state.writer_tx.as_ref() {
-            let _ = writer.send(format!("PRIVMSG #{channel} :{message}"));
-
-            if let Some(identity) = state.chat_identity.as_ref()
-               && let Some(sender) = get_channel_sender(channels, &channel).await
-            {
-               let echo_event = ChatEvent {
+         if send_raw(state, format!("PRIVMSG #{channel} :{message}")) {
+            if let (Some(identity), Some(sender)) = (
+               state.chat_identity.as_ref(),
+               get_channel_sender(channels, &channel).await,
+            ) {
+               let event = ChatEvent {
                   kind:                ChatEventKind::Message,
                   channel_login:       channel.clone(),
                   sender_login:        Some(identity.login.clone()),
@@ -205,122 +368,161 @@ async fn handle_command(
                   text:                message.clone(),
                   parts:               local_echo_parts_for_channel(
                      emote_cache,
-                     third_party_emote_cache,
-                     auth,
+                     third_party_cache,
                      &channel,
                      &message,
                   )
                   .await,
                   sent_at_unix:        now_unix_secs(),
                };
-               remember_local_echo(&mut state.pending_local_echo, &echo_event);
-               let _ = sender.send(echo_event);
+               remember_local_echo(state, &event);
+               let _ = sender.send(ChatStreamEvent::Chat(event));
+               let _ = emote_refresh_tx.try_send(channel);
             }
-
             let _ = response.send(Ok(()));
          } else {
             let _ = response.send(Err(ChatError::WriterUnavailable));
          }
       },
       ChatCommand::Status { channel, response } => {
-         let subscribed_count = state.subscribed_counts.get(&channel).copied().unwrap_or(0);
-         let subscribed = subscribed_count > 0;
-         tracing::debug!(
-            channel = %channel,
-            subscribed_count,
-            connected = state.connected,
-            joined = state.joined_channels.contains(&channel),
-            pending_part = state.pending_parts.contains_key(&channel),
-            "chat status reported"
-         );
          let _ = response.send(crate::chat::events::ChatChannelStatus {
-            subscribed,
-            connected: state.connected,
-            joined: state.joined_channels.contains(&channel),
-            error: state.last_error.clone(),
+            subscribed: state.subscribed_counts.contains_key(&channel),
+            connected:  state.connected,
+            joined:     state.joined_channels.contains(&channel),
+            error:      state.last_error.clone(),
          });
       },
    }
-   true
 }
 
-/// Handle a read event from the IRC connection.
-async fn handle_read_event(
+async fn handle_reader_event(
    event: ReaderEvent,
    state: &mut ChatManagerState,
-   channels: &Arc<RwLock<HashMap<String, broadcast::Sender<ChatEvent>>>>,
-   third_party_emote_cache: &Arc<RwLock<HashMap<String, CachedThirdPartyEmotes>>>,
-   auth: &TwitchAuthService,
+   channels: &Arc<RwLock<HashMap<String, broadcast::Sender<ChatStreamEvent>>>>,
+   third_party_cache: &Arc<RwLock<HashMap<String, CachedThirdPartyEmotes>>>,
+   emote_refresh_tx: &mpsc::Sender<String>,
+   metrics: &ChatMetrics,
 ) {
    match event {
       ReaderEvent::Line(line) => {
-         if let Some(writer) = state.writer_tx.as_ref()
-            && line.starts_with("PING ")
-         {
-            let payload = line.trim_start_matches("PING ").trim();
-            let _ = writer.send(format!("PONG {payload}"));
+         if let Some(pong) = pong_for_ping(&line) {
+            let _ = send_raw(state, pong);
             return;
          }
-
-         if let Some(mut event) = parse_chat_event(&line) {
-            enrich_chat_event_with_third_party_emotes(&mut event, third_party_emote_cache, auth)
-               .await;
-
-            if !is_duplicate_local_echo(&mut state.pending_local_echo, &event)
-               && let Some(sender) = get_channel_sender(channels, &event.channel_login).await
-            {
-               let _ = sender.send(event);
+         match parse_server_signal(
+            &line,
+            state
+               .chat_identity
+               .as_ref()
+               .map(|identity| identity.login.as_str()),
+         ) {
+            ServerSignal::Join(channel) => {
+               state.joining_channels.remove(&channel);
+               if state.subscribed_counts.contains_key(&channel) {
+                  state.joined_channels.insert(channel.clone());
+                  metrics.joins.fetch_add(1, Ordering::Relaxed);
+                  tracing::info!(%channel, "chat JOIN confirmed");
+                  publish_status(channels, state, &channel).await;
+               }
+            },
+            ServerSignal::Part(channel) => {
+               state.joined_channels.remove(&channel);
+               state.joining_channels.remove(&channel);
+               publish_status(channels, state, &channel).await;
+            },
+            ServerSignal::Reconnect => {
+               state.disconnect("Twitch requested reconnect".to_string(), metrics);
+               publish_all_statuses(channels, state).await;
+            },
+            ServerSignal::AuthenticationFailed(reason) => {
+               state.disconnect(reason, metrics);
+               publish_all_statuses(channels, state).await;
+            },
+            ServerSignal::Welcome | ServerSignal::None => {},
+         }
+         if let Some(mut chat_event) = parse_chat_event(&line) {
+            if is_duplicate_local_echo(state, &chat_event) {
+               return;
+            }
+            let cached =
+               cached_third_party_emotes_for_channel(third_party_cache, &chat_event.channel_login)
+                  .await;
+            if !cached.is_empty() {
+               chat_event.parts = apply_third_party_emotes(&chat_event.parts, &cached);
+            }
+            let _ = emote_refresh_tx.try_send(chat_event.channel_login.clone());
+            if let Some(sender) = get_channel_sender(channels, &chat_event.channel_login).await {
+               let _ = sender.send(ChatStreamEvent::Chat(chat_event));
             }
          }
-      },
-      ReaderEvent::Disconnected => {
-         state.connected = false;
-         state.writer_tx = None;
-         state.reader_rx = None;
-         state.chat_identity = None;
-         state.joined_channels.clear();
-         state.last_error = Some("chat connection lost; retrying".to_string());
-         state.reconnect_after = Some(Instant::now());
       },
    }
 }
 
-/// Attempt to connect to IRC if not connected.
-async fn maybe_connect(state: &mut ChatManagerState, auth: &TwitchAuthService) {
-   if !state.connected && !state.subscribed_counts.is_empty() {
-      if state
-         .reconnect_after
-         .is_some_and(|deadline| deadline > Instant::now())
-      {
-         return;
+fn request_join(state: &mut ChatManagerState, channel: &str) {
+   if state.connected
+      && !state.joined_channels.contains(channel)
+      && !state.joining_channels.contains(channel)
+   {
+      if send_raw(state, format!("JOIN #{channel}")) {
+         state.joining_channels.insert(channel.to_string());
+         state.pending_joins.remove(channel);
+      } else {
+         schedule_join_retry(state, channel);
       }
-      match connect_chat(auth).await {
-         Ok((tx, rx, identity)) => {
-            state.writer_tx = Some(tx);
-            state.reader_rx = Some(rx);
-            state.chat_identity = Some(identity.clone());
-            state.connected = true;
-            state.last_error = None;
-            state.reconnect_after = None;
+   }
+}
 
-            if let Some(writer) = state.writer_tx.as_ref() {
-               let _ = writer.send(
-                  "CAP REQ :twitch.tv/tags twitch.tv/commands twitch.tv/membership".to_string(),
-               );
-               for channel in state.subscribed_counts.keys() {
-                  tracing::debug!(channel = %channel, "sending chat JOIN after connect");
-                  let _ = writer.send(format!("JOIN #{channel}"));
-                  state.joined_channels.insert(channel.clone());
-               }
-            }
+fn schedule_join_retry(state: &mut ChatManagerState, channel: &str) {
+   if state.pending_joins.contains_key(channel) {
+      return;
+   }
+   if state.pending_joins.len() >= MAX_PENDING_JOIN_RETRIES {
+      tracing::warn!(channel, "chat JOIN retry queue is full");
+      return;
+   }
+   state
+      .pending_joins
+      .insert(channel.to_string(), Instant::now() + JOIN_RETRY_DELAY);
+}
 
-            tracing::info!(login = %identity.login, joined = state.joined_channels.len(), "chat IRC connected");
-         },
-         Err(e) => {
-            state.connected = false;
-            state.last_error = Some(e.to_string());
-            state.reconnect_after = Some(Instant::now() + IRC_RECONNECT_DELAY);
-         },
+fn send_raw(state: &ChatManagerState, line: String) -> bool {
+   state
+      .writer_tx
+      .as_ref()
+      .is_some_and(|tx| tx.try_send(line).is_ok())
+}
+
+async fn process_due_control(
+   state: &mut ChatManagerState,
+   channels: &Arc<RwLock<HashMap<String, broadcast::Sender<ChatStreamEvent>>>>,
+) {
+   let now = Instant::now();
+   let due: Vec<String> = state
+      .pending_parts
+      .iter()
+      .filter(|(_, at)| **at <= now)
+      .map(|(channel, _)| channel.clone())
+      .collect();
+   for channel in due {
+      state.pending_parts.remove(&channel);
+      if !state.subscribed_counts.contains_key(&channel) && state.joined_channels.remove(&channel) {
+         let _ = send_raw(state, format!("PART #{channel}"));
+         publish_status(channels, state, &channel).await;
+      }
+   }
+
+   let now = Instant::now();
+   let due_joins: Vec<String> = state
+      .pending_joins
+      .iter()
+      .filter(|(_, at)| **at <= now)
+      .map(|(channel, _)| channel.clone())
+      .collect();
+   for channel in due_joins {
+      state.pending_joins.remove(&channel);
+      if state.subscribed_counts.contains_key(&channel) {
+         request_join(state, &channel);
       }
    }
 }
@@ -331,400 +533,469 @@ fn next_timer_deadline(state: &ChatManagerState) -> Option<Instant> {
       .values()
       .copied()
       .chain(state.reconnect_after)
+      .chain(state.pending_joins.values().copied())
       .min()
 }
 
-fn process_due_parts(state: &mut ChatManagerState) {
-   let now = Instant::now();
-   let due_channels: Vec<String> = state
-      .pending_parts
-      .iter()
-      .filter(|(_, deadline)| **deadline <= now)
-      .map(|(channel, _)| channel.clone())
-      .collect();
-
-   for channel in due_channels {
-      state.pending_parts.remove(&channel);
-      if state.subscribed_counts.contains_key(&channel) {
-         tracing::debug!(channel = %channel, "skipping scheduled chat PART because channel was resubscribed");
-         continue;
-      }
-
-      if state.connected
-         && state.joined_channels.remove(&channel)
-         && let Some(writer) = state.writer_tx.as_ref()
-      {
-         tracing::debug!(channel = %channel, "sending chat PART");
-         let _ = writer.send(format!("PART #{channel}"));
-      }
-   }
-}
-
-pub async fn run_chat_manager(
-   auth: TwitchAuthService,
-   mut command_rx: mpsc::UnboundedReceiver<ChatCommand>,
-   channels: Arc<RwLock<HashMap<String, broadcast::Sender<ChatEvent>>>>,
-   emote_cache: Arc<RwLock<HashMap<String, crate::chat::emotes::CachedEmoteEntry>>>,
-   third_party_emote_cache: Arc<RwLock<HashMap<String, CachedThirdPartyEmotes>>>,
-) {
-   let mut state = ChatManagerState::new();
-
-   loop {
-      maybe_connect(&mut state, &auth).await;
-      process_due_parts(&mut state);
-
-      let next_deadline = next_timer_deadline(&state);
-
-      let read_event = async {
-         if let Some(rx) = state.reader_rx.as_mut() {
-            rx.recv().await
-         } else {
-            pending().await
-         }
-      };
-
-      let timer = async {
-         if let Some(deadline) = next_deadline {
-            sleep_until(deadline).await;
-         } else {
-            pending::<()>().await;
-         }
-      };
-
-      tokio::select! {
-          maybe_cmd = command_rx.recv() => {
-              let Some(command) = maybe_cmd else {
-                  break;
-              };
-
-              let _ = handle_command(
-                  command,
-                  &mut state,
-                  &channels,
-                  &emote_cache,
-                  &third_party_emote_cache,
-                  &auth,
-              ).await;
-          }
-          maybe_event = read_event => {
-              if let Some(event) = maybe_event {
-                  handle_read_event(
-                      event,
-                      &mut state,
-                      &channels,
-                      &third_party_emote_cache,
-                      &auth,
-                  ).await;
-              }
-          }
-          () = timer => {
-              process_due_parts(&mut state);
-          }
-      }
-   }
+fn reconnect_delay(failures: u32) -> Duration {
+   let exponent = failures.saturating_sub(1).min(6);
+   let base = 1_u64 << exponent;
+   let jitter = rand::rng().random_range(0..=base / 2);
+   Duration::from_secs((base + jitter).min(RECONNECT_CAP.as_secs()))
 }
 
 async fn connect_chat(
    auth: &TwitchAuthService,
-) -> Result<
-   (
-      mpsc::UnboundedSender<String>,
-      mpsc::UnboundedReceiver<ReaderEvent>,
-      ChatIdentity,
-   ),
-   ChatError,
-> {
-   let account = auth.ensure_chat_account().await.map_err(ChatError::Other)?;
-
-   let (ws_stream, _response) = connect_async("wss://irc-ws.chat.twitch.tv:443")
+   metrics: &ChatMetrics,
+) -> Result<ConnectedSocket, ChatError> {
+   let account = timeout(AUTH_TIMEOUT, auth.ensure_chat_account())
       .await
-      .map_err(|e| ChatError::WebSocketConnectFailed(e.to_string()))?;
-
-   let (mut ws_writer, mut ws_reader) = ws_stream.split();
-
-   ws_writer
+      .map_err(|_| ChatError::Other("chat OAuth preparation timed out".to_string()))?
+      .map_err(ChatError::Other)?;
+   let (stream, _) = timeout(
+      CONNECT_TIMEOUT,
+      connect_async("wss://irc-ws.chat.twitch.tv:443"),
+   )
+   .await
+   .map_err(|_| ChatError::WebSocketConnectFailed("connection timed out".to_string()))?
+   .map_err(|error| ChatError::WebSocketConnectFailed(error.to_string()))?;
+   let (mut writer, mut reader) = stream.split();
+   writer
       .send(Message::Text(
          format!("PASS oauth:{}", account.access_token).into(),
       ))
       .await
-      .map_err(|e| ChatError::PassFailed(e.to_string()))?;
-   ws_writer
+      .map_err(|error| ChatError::PassFailed(error.to_string()))?;
+   writer
       .send(Message::Text(format!("NICK {}", account.login).into()))
       .await
-      .map_err(|e| ChatError::NickFailed(e.to_string()))?;
-
-   let (writer_tx, mut writer_rx) = mpsc::unbounded_channel::<String>();
-   let (reader_tx, reader_rx) = mpsc::unbounded_channel::<ReaderEvent>();
-
+      .map_err(|error| ChatError::NickFailed(error.to_string()))?;
+   wait_for_welcome(&mut reader).await?;
+   let (writer_tx, mut writer_rx) = mpsc::channel::<String>(OUTBOUND_CAPACITY);
+   let (reader_tx, reader_rx) = mpsc::channel(INBOUND_CAPACITY);
+   let (disconnect_tx, disconnect_rx) = watch::channel(None);
+   let writer_disconnect = disconnect_tx.clone();
+   let reader_metrics = metrics.clone();
    tokio::spawn(async move {
-      while let Some(outbound) = writer_rx.recv().await {
-         if ws_writer
-            .send(Message::Text(outbound.into()))
-            .await
-            .is_err()
-         {
-            break;
+      while let Some(line) = writer_rx.recv().await {
+         if writer.send(Message::Text(line.into())).await.is_err() {
+            let _ = writer_disconnect.send(Some("chat writer task failed".to_string()));
+            return;
          }
       }
    });
-
    tokio::spawn(async move {
-      while let Some(result) = ws_reader.next().await {
-         match result {
-            Ok(Message::Text(text)) => {
-               for line in text.lines() {
-                  let _ = reader_tx.send(ReaderEvent::Line(line.to_string()));
-               }
+      loop {
+         let message = match timeout(IDLE_TIMEOUT, reader.next()).await {
+            Ok(Some(Ok(message))) => message,
+            Ok(Some(Err(error))) => {
+               let _ = disconnect_tx.send(Some(format!("chat reader error: {error}")));
+               return;
             },
-            Ok(Message::Close(_)) | Err(_) => break,
-            Ok(_) => {},
+            Ok(None) => {
+               let _ = disconnect_tx.send(Some("chat socket closed".to_string()));
+               return;
+            },
+            Err(_) => {
+               let _ = disconnect_tx.send(Some("chat socket idle timeout".to_string()));
+               return;
+            },
+         };
+         if let Message::Text(text) = &message {
+            for line in text.lines() {
+               if reader_tx
+                  .try_send(ReaderEvent::Line(line.to_string()))
+                  .is_err()
+               {
+                  reader_metrics
+                     .event_queue_full
+                     .fetch_add(1, Ordering::Relaxed);
+                  let _ = disconnect_tx.send(Some("chat inbound queue saturated".to_string()));
+                  return;
+               }
+            }
+         }
+         if matches!(message, Message::Close(_)) {
+            let _ = disconnect_tx.send(Some("chat socket closed".to_string()));
+            return;
          }
       }
-
-      let _ = reader_tx.send(ReaderEvent::Disconnected);
    });
+   Ok(ConnectedSocket {
+      writer_tx,
+      reader_rx,
+      disconnect_rx,
+      identity: ChatIdentity {
+         login:        account.login,
+         display_name: account.display_name,
+      },
+   })
+}
 
-   Ok((writer_tx, reader_rx, ChatIdentity {
-      login:        account.login,
-      display_name: account.display_name,
-   }))
+async fn wait_for_welcome(
+   reader: &mut (
+           impl futures_util::Stream<Item = Result<Message, tokio_tungstenite::tungstenite::Error>>
+           + Unpin
+        ),
+) -> Result<(), ChatError> {
+   timeout(AUTH_TIMEOUT, async {
+      while let Some(message) = reader.next().await {
+         let message = message.map_err(|error| {
+            ChatError::Other(format!("chat authentication read failed: {error}"))
+         })?;
+         if let Message::Text(text) = message {
+            for line in text.lines() {
+               match parse_server_signal(line, None) {
+                  ServerSignal::Welcome => return Ok(()),
+                  ServerSignal::AuthenticationFailed(reason) => {
+                     return Err(ChatError::Other(reason));
+                  },
+                  _ => {},
+               }
+            }
+         }
+      }
+      Err(ChatError::Other(
+         "chat socket closed during authentication".to_string(),
+      ))
+   })
+   .await
+   .map_err(|_| ChatError::Other("chat welcome timed out".to_string()))?
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ServerSignal {
+   Welcome,
+   AuthenticationFailed(String),
+   Join(String),
+   Part(String),
+   Reconnect,
+   None,
+}
+
+fn parse_server_signal(line: &str, self_login: Option<&str>) -> ServerSignal {
+   let upper = line.to_ascii_uppercase();
+   if upper.contains(" 001 ") {
+      return ServerSignal::Welcome;
+   }
+   if upper.contains(" RECONNECT") {
+      return ServerSignal::Reconnect;
+   }
+   if upper.contains("LOGIN AUTHENTICATION FAILED") || upper.contains("IMPROPERLY FORMATTED AUTH") {
+      return ServerSignal::AuthenticationFailed(line.to_string());
+   }
+   let Some(login) = self_login else {
+      return ServerSignal::None;
+   };
+   let prefix = format!(":{}!", login.to_ascii_lowercase());
+   if !line.to_ascii_lowercase().starts_with(&prefix) {
+      return ServerSignal::None;
+   }
+   let words: Vec<&str> = line.split_whitespace().collect();
+   match words.as_slice() {
+      [_, "JOIN", channel] => {
+         ServerSignal::Join(channel.trim_start_matches('#').to_ascii_lowercase())
+      },
+      [_, "PART", channel, ..] => {
+         ServerSignal::Part(channel.trim_start_matches('#').to_ascii_lowercase())
+      },
+      _ => ServerSignal::None,
+   }
+}
+
+fn pong_for_ping(line: &str) -> Option<String> {
+   line
+      .strip_prefix("PING ")
+      .map(|payload| format!("PONG {payload}"))
 }
 
 async fn ensure_channel_sender(
-   channels: &Arc<RwLock<HashMap<String, broadcast::Sender<ChatEvent>>>>,
+   channels: &Arc<RwLock<HashMap<String, broadcast::Sender<ChatStreamEvent>>>>,
    channel: &str,
 ) {
    let mut guard = channels.write().await;
-   guard.entry(channel.to_string()).or_insert_with(|| {
-      let (sender, _receiver) = broadcast::channel(256);
-      sender
+   guard
+      .entry(channel.to_string())
+      .or_insert_with(|| broadcast::channel(256).0);
+}
+async fn get_channel_sender(
+   channels: &Arc<RwLock<HashMap<String, broadcast::Sender<ChatStreamEvent>>>>,
+   channel: &str,
+) -> Option<broadcast::Sender<ChatStreamEvent>> {
+   channels.read().await.get(channel).cloned()
+}
+
+fn channel_status(state: &ChatManagerState, channel: &str) -> ChatChannelStatus {
+   ChatChannelStatus {
+      subscribed: state.subscribed_counts.contains_key(channel),
+      connected:  state.connected,
+      joined:     state.joined_channels.contains(channel),
+      error:      state.last_error.clone(),
+   }
+}
+
+async fn publish_status(
+   channels: &Arc<RwLock<HashMap<String, broadcast::Sender<ChatStreamEvent>>>>,
+   state: &ChatManagerState,
+   channel: &str,
+) {
+   if let Some(sender) = get_channel_sender(channels, channel).await {
+      let _ = sender.send(ChatStreamEvent::Status(channel_status(state, channel)));
+   }
+}
+
+async fn publish_all_statuses(
+   channels: &Arc<RwLock<HashMap<String, broadcast::Sender<ChatStreamEvent>>>>,
+   state: &ChatManagerState,
+) {
+   let targets: Vec<String> = {
+      let guard = channels.read().await;
+      guard.keys().cloned().collect()
+   };
+   for channel in targets {
+      publish_status(channels, state, &channel).await;
+   }
+}
+
+fn remember_local_echo(state: &mut ChatManagerState, event: &ChatEvent) {
+   prune_local_echoes(&mut state.pending_local_echoes);
+   let Some(key) = local_echo_key(event) else {
+      return;
+   };
+   if state.pending_local_echoes.len() == MAX_LOCAL_ECHOES {
+      state.pending_local_echoes.pop_front();
+   }
+   state.pending_local_echoes.push_back(LocalEcho {
+      key,
+      expires_at: Instant::now() + LOCAL_ECHO_TTL,
    });
 }
 
-async fn get_channel_sender(
-   channels: &Arc<RwLock<HashMap<String, broadcast::Sender<ChatEvent>>>>,
-   channel: &str,
-) -> Option<broadcast::Sender<ChatEvent>> {
-   let guard = channels.read().await;
-   guard.get(channel).cloned()
-}
-
-async fn enrich_chat_event_with_third_party_emotes(
-   event: &mut ChatEvent,
-   third_party_emote_cache: &Arc<RwLock<HashMap<String, CachedThirdPartyEmotes>>>,
-   auth: &TwitchAuthService,
-) {
-   if !matches!(event.kind, ChatEventKind::Message) {
-      return;
-   }
-
-   let emotes_by_code = match third_party_emotes_for_channel(
-      auth,
-      third_party_emote_cache,
-      &event.channel_login,
-   )
-   .await
-   {
-      Ok(emotes_by_code) => emotes_by_code,
-      Err(error) => {
-         tracing::debug!(error = %error, channel = %event.channel_login, "failed loading third-party emotes");
-         return;
-      },
+fn is_duplicate_local_echo(state: &mut ChatManagerState, event: &ChatEvent) -> bool {
+   prune_local_echoes(&mut state.pending_local_echoes);
+   let Some(identity) = state.chat_identity.as_ref() else {
+      return false;
    };
-
-   if emotes_by_code.is_empty() {
-      return;
+   let Some(sender) = event.sender_login.as_deref() else {
+      return false;
+   };
+   if !sender.eq_ignore_ascii_case(&identity.login) {
+      return false;
    }
-
-   event.parts = apply_third_party_emotes_to_parts(&event.parts, &emotes_by_code);
-}
-
-fn apply_third_party_emotes_to_parts(
-   parts: &[ChatPart],
-   emotes_by_code: &HashMap<String, String>,
-) -> Vec<ChatPart> {
-   let mut out = Vec::new();
-   for part in parts {
-      match part {
-         ChatPart::Text { text } => {
-            for segment in split_preserving_whitespace(text) {
-               if segment.trim().is_empty() {
-                  out.push(ChatPart::Text { text: segment });
-               } else if let Some(image_url) = emotes_by_code.get(&segment) {
-                  out.push(ChatPart::Emote {
-                     id:        segment.clone(),
-                     code:      segment,
-                     image_url: Some(image_url.clone()),
-                  });
-               } else {
-                  out.push(ChatPart::Text { text: segment });
-               }
-            }
-         },
-         ChatPart::Emote { .. } => out.push(part.clone()),
-      }
-   }
-
-   if out.is_empty() {
-      vec![ChatPart::Text {
-         text: String::new(),
-      }]
-   } else {
-      out
-   }
-}
-
-fn split_preserving_whitespace(input: &str) -> Vec<String> {
-   let mut out = Vec::new();
-   let mut current = String::new();
-   let mut current_whitespace: Option<bool> = None;
-
-   for ch in input.chars() {
-      let is_whitespace = ch.is_whitespace();
-      match current_whitespace {
-         None => {
-            current_whitespace = Some(is_whitespace);
-            current.push(ch);
-         },
-         Some(value) if value == is_whitespace => current.push(ch),
-         Some(_) => {
-            if !current.is_empty() {
-               out.push(current.clone());
-               current.clear();
-            }
-            current_whitespace = Some(is_whitespace);
-            current.push(ch);
-         },
-      }
-   }
-
-   if !current.is_empty() {
-      out.push(current);
-   }
-
-   out
-}
-
-fn remember_local_echo(pending_local_echo: &mut HashMap<String, u64>, event: &ChatEvent) {
-   prune_local_echo_cache(pending_local_echo);
-   if let Some(key) = local_echo_key(event) {
-      pending_local_echo.insert(key, now_unix_secs().saturating_add(LOCAL_ECHO_TTL_SECS));
-   }
-}
-
-fn is_duplicate_local_echo(
-   pending_local_echo: &mut HashMap<String, u64>,
-   event: &ChatEvent,
-) -> bool {
-   prune_local_echo_cache(pending_local_echo);
    let Some(key) = local_echo_key(event) else {
       return false;
    };
-
-   if let Some(expires_at) = pending_local_echo.get(&key)
-      && *expires_at > now_unix_secs()
-   {
-      pending_local_echo.remove(&key);
-      return true;
-   }
-
-   false
+   let Some(index) = state
+      .pending_local_echoes
+      .iter()
+      .position(|candidate| candidate.key == key)
+   else {
+      return false;
+   };
+   state.pending_local_echoes.remove(index);
+   true
 }
 
-fn prune_local_echo_cache(pending_local_echo: &mut HashMap<String, u64>) {
-   let now = now_unix_secs();
-   pending_local_echo.retain(|_, expires_at| *expires_at > now);
+fn prune_local_echoes(echoes: &mut VecDeque<LocalEcho>) {
+   let now = Instant::now();
+   while echoes.front().is_some_and(|echo| echo.expires_at <= now) {
+      echoes.pop_front();
+   }
 }
 
 fn local_echo_key(event: &ChatEvent) -> Option<String> {
    if !matches!(event.kind, ChatEventKind::Message) {
       return None;
    }
-
-   let sender = event.sender_login.as_ref()?.trim().to_ascii_lowercase();
-   if sender.is_empty() {
-      return None;
-   }
-
-   let channel = event.channel_login.trim().to_ascii_lowercase();
-   if channel.is_empty() {
-      return None;
-   }
-
+   let channel = event.channel_login.trim();
+   let sender = event.sender_login.as_deref()?.trim();
    let text = event.text.trim();
-   if text.is_empty() {
+   if channel.is_empty() || sender.is_empty() || text.is_empty() {
       return None;
    }
+   Some(format!(
+      "{}|{}|{text}",
+      channel.to_ascii_lowercase(),
+      sender.to_ascii_lowercase()
+   ))
+}
 
-   Some(format!("{channel}|{sender}|{text}"))
+fn apply_third_party_emotes(parts: &[ChatPart], emotes: &HashMap<String, String>) -> Vec<ChatPart> {
+   parts
+      .iter()
+      .flat_map(|part| {
+         match part {
+            ChatPart::Text { text } => {
+               split_preserving_whitespace(text)
+                  .into_iter()
+                  .map(|segment| {
+                     match emotes.get(&segment) {
+                        Some(url) => {
+                           ChatPart::Emote {
+                              id:        segment.clone(),
+                              code:      segment,
+                              image_url: Some(url.clone()),
+                           }
+                        },
+                        None => ChatPart::Text { text: segment },
+                     }
+                  })
+                  .collect::<Vec<_>>()
+            },
+            ChatPart::Emote { .. } => vec![part.clone()],
+         }
+      })
+      .collect()
+}
+fn split_preserving_whitespace(input: &str) -> Vec<String> {
+   let mut out = Vec::new();
+   let mut current = String::new();
+   let mut whitespace = None;
+   for character in input.chars() {
+      let value = character.is_whitespace();
+      if whitespace.is_some_and(|current_value| current_value != value) {
+         out.push(std::mem::take(&mut current));
+      }
+      whitespace = Some(value);
+      current.push(character);
+   }
+   if !current.is_empty() {
+      out.push(current);
+   }
+   out
 }
 
 #[cfg(test)]
 mod tests {
    use super::*;
 
+   fn local_message(channel: &str, sender: &str, text: &str) -> ChatEvent {
+      ChatEvent {
+         kind:                ChatEventKind::Message,
+         channel_login:       channel.to_string(),
+         sender_login:        Some(sender.to_string()),
+         sender_display_name: Some(sender.to_string()),
+         sender_color:        None,
+         text:                text.to_string(),
+         parts:               vec![ChatPart::Text {
+            text: text.to_string(),
+         }],
+         sent_at_unix:        0,
+      }
+   }
    #[test]
-   fn reconnect_deadline_is_used_as_timer_deadline() {
+   fn parser_recognizes_welcome_auth_join_and_reconnect() {
+      assert_eq!(
+         parse_server_signal(":tmi.twitch.tv 001 alice :Welcome", None),
+         ServerSignal::Welcome
+      );
+      assert!(matches!(
+         parse_server_signal(":tmi.twitch.tv NOTICE * :Login authentication failed", None),
+         ServerSignal::AuthenticationFailed(_)
+      ));
+      assert_eq!(
+         parse_server_signal(":alice!alice@alice.tmi.twitch.tv JOIN #rust", Some("alice")),
+         ServerSignal::Join("rust".to_string())
+      );
+      assert_eq!(
+         parse_server_signal(":tmi.twitch.tv RECONNECT", Some("alice")),
+         ServerSignal::Reconnect
+      );
+   }
+   #[test]
+   fn ping_generates_pong() {
+      assert_eq!(
+         pong_for_ping("PING :tmi.twitch.tv"),
+         Some("PONG :tmi.twitch.tv".to_string())
+      );
+   }
+   #[test]
+   fn reconnect_backoff_is_capped() {
+      assert!(reconnect_delay(100) <= RECONNECT_CAP);
+   }
+   #[test]
+   fn timer_includes_reconnect_deadline() {
       let mut state = ChatManagerState::new();
-      let reconnect_after = Instant::now() + Duration::from_secs(5);
-      state.reconnect_after = Some(reconnect_after);
-
-      assert_eq!(next_timer_deadline(&state), Some(reconnect_after));
+      let deadline = Instant::now() + Duration::from_secs(1);
+      state.reconnect_after = Some(deadline);
+      assert_eq!(next_timer_deadline(&state), Some(deadline));
    }
 
    #[test]
-   fn due_part_is_delayed_until_grace_deadline() {
-      let (writer_tx, mut writer_rx) = mpsc::unbounded_channel();
+   fn channel_status_tracks_confirmed_connection_and_join() {
       let mut state = ChatManagerState::new();
+      state.subscribed_counts.insert("rust".to_string(), 1);
       state.connected = true;
-      state.writer_tx = Some(writer_tx);
-      state.joined_channels.insert("example".to_string());
-      state.pending_parts.insert(
-         "example".to_string(),
-         Instant::now() + Duration::from_mins(1),
-      );
+      state.joined_channels.insert("rust".to_string());
 
-      process_due_parts(&mut state);
+      let status = channel_status(&state, "rust");
 
-      assert!(state.joined_channels.contains("example"));
-      assert!(writer_rx.try_recv().is_err());
+      assert!(status.subscribed && status.connected && status.joined);
    }
 
    #[test]
-   fn due_part_sends_part_and_removes_joined_channel() {
-      let (writer_tx, mut writer_rx) = mpsc::unbounded_channel();
+   fn local_echo_marker_suppresses_only_the_matching_twitch_echo() {
       let mut state = ChatManagerState::new();
-      state.connected = true;
-      state.writer_tx = Some(writer_tx);
-      state.joined_channels.insert("example".to_string());
-      state.pending_parts.insert(
-         "example".to_string(),
-         Instant::now() - Duration::from_secs(1),
-      );
+      state.chat_identity = Some(ChatIdentity {
+         login:        "alice".to_string(),
+         display_name: "Alice".to_string(),
+      });
+      let local = local_message("rust", "alice", "hello");
+      remember_local_echo(&mut state, &local);
 
-      process_due_parts(&mut state);
-
-      assert!(!state.joined_channels.contains("example"));
-      assert_eq!(writer_rx.try_recv().expect("PART command"), "PART #example");
+      assert!(is_duplicate_local_echo(&mut state, &local));
+      assert!(!is_duplicate_local_echo(&mut state, &local));
+      assert!(!is_duplicate_local_echo(
+         &mut state,
+         &local_message("rust", "bob", "hello")
+      ));
    }
 
-   #[test]
-   fn due_part_is_skipped_after_resubscribe() {
-      let (writer_tx, mut writer_rx) = mpsc::unbounded_channel();
+   #[tokio::test]
+   async fn saturated_writer_retries_join_after_timer() {
+      let (writer_tx, mut writer_rx) = mpsc::channel(1);
       let mut state = ChatManagerState::new();
       state.connected = true;
       state.writer_tx = Some(writer_tx);
-      state.joined_channels.insert("example".to_string());
-      state.subscribed_counts.insert("example".to_string(), 1);
-      state.pending_parts.insert(
-         "example".to_string(),
-         Instant::now() - Duration::from_secs(1),
+      state.subscribed_counts.insert("rust".to_string(), 1);
+      let filled = send_raw(&state, "CAP REQ :test".to_string());
+      assert!(filled);
+
+      request_join(&mut state, "rust");
+      assert!(state.pending_joins.contains_key("rust"));
+      assert!(writer_rx.try_recv().is_ok());
+      state
+         .pending_joins
+         .insert("rust".to_string(), Instant::now());
+
+      let channels = Arc::new(RwLock::new(HashMap::new()));
+      process_due_control(&mut state, &channels).await;
+
+      assert_eq!(writer_rx.try_recv().ok().as_deref(), Some("JOIN #rust"));
+   }
+
+   #[tokio::test]
+   async fn saturation_notification_reaches_manager_when_event_queue_is_full() {
+      let (event_tx, mut event_rx) = mpsc::channel(1);
+      let (disconnect_tx, mut disconnect_rx) = watch::channel(None);
+      assert!(
+         event_tx
+            .try_send(ReaderEvent::Line("full".to_string()))
+            .is_ok()
+      );
+      assert!(
+         event_tx
+            .try_send(ReaderEvent::Line("overflow".to_string()))
+            .is_err()
       );
 
-      process_due_parts(&mut state);
+      let _ = disconnect_tx.send(Some("chat inbound queue saturated".to_string()));
+      assert!(disconnect_rx.changed().await.is_ok());
 
-      assert!(state.joined_channels.contains("example"));
-      assert!(writer_rx.try_recv().is_err());
-      assert!(!state.pending_parts.contains_key("example"));
+      assert_eq!(
+         disconnect_rx.borrow_and_update().clone(),
+         Some("chat inbound queue saturated".to_string())
+      );
+      assert!(event_rx.try_recv().is_ok());
    }
 }

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -4,6 +4,7 @@ pub use self::service::{
    ChatState,
    emotes,
    events,
+   metrics,
    send,
    status,
    subscribe,

--- a/src/chat/service.rs
+++ b/src/chat/service.rs
@@ -5,6 +5,7 @@ use std::{
       Arc,
       atomic::AtomicU64,
    },
+   time::Duration,
 };
 
 use axum::{
@@ -29,11 +30,15 @@ use futures_util::stream::{
    self,
    StreamExt,
 };
-use tokio::sync::{
-   RwLock,
-   broadcast,
-   mpsc,
-   oneshot,
+use serde::Serialize;
+use tokio::{
+   sync::{
+      RwLock,
+      broadcast,
+      mpsc,
+      oneshot,
+   },
+   time::timeout,
 };
 use tokio_stream::wrappers::BroadcastStream;
 
@@ -49,10 +54,10 @@ use crate::{
       events::{
          ChatChannelRequest,
          ChatChannelStatus,
-         ChatEvent,
          ChatSendRequest,
          ChatStatusQuery,
          ChatStatusResponse,
+         ChatStreamEvent,
          EmotesQuery,
       },
       irc::run_chat_manager,
@@ -66,6 +71,8 @@ use crate::{
 pub enum ChatError {
    #[error("chat runtime is not available")]
    RuntimeUnavailable,
+   #[error("chat command queue is full")]
+   CommandQueueFull,
    #[error("chat runtime did not return status")]
    StatusTimeout,
    #[error("channel not found")]
@@ -109,16 +116,130 @@ impl From<String> for ChatError {
 #[derive(Debug, Clone)]
 pub struct ChatService {
    auth:                             TwitchAuthService,
-   command_tx:                       mpsc::UnboundedSender<ChatCommand>,
-   channels:                         Arc<RwLock<HashMap<String, broadcast::Sender<ChatEvent>>>>,
+   command_tx:                       mpsc::Sender<ChatCommand>,
+   channels: Arc<RwLock<HashMap<String, broadcast::Sender<ChatStreamEvent>>>>,
    emote_cache:                      Arc<RwLock<HashMap<String, CachedEmoteEntry>>>,
    owner_name_cache:                 Arc<RwLock<HashMap<String, CachedOwnerName>>>,
    owner_lookup_cooldown_until_unix: Arc<AtomicU64>,
+   metrics:                          ChatMetrics,
 }
 
 #[derive(Debug, Clone)]
 pub struct ChatState {
    pub service: ChatService,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChatMetrics {
+   pub(crate) connected:           Arc<std::sync::atomic::AtomicBool>,
+   pub(crate) connection_attempts: Arc<AtomicU64>,
+   pub(crate) connection_failures: Arc<AtomicU64>,
+   pub(crate) reconnects:          Arc<AtomicU64>,
+   pub(crate) joins:               Arc<AtomicU64>,
+   pub(crate) disconnects:         Arc<AtomicU64>,
+   pub(crate) command_queue_full:  Arc<AtomicU64>,
+   pub(crate) event_queue_full:    Arc<AtomicU64>,
+   pub(crate) last_attempt_ms:     Arc<AtomicU64>,
+   pub(crate) sse_broadcast_lag:   Arc<AtomicU64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ChatMetricsSnapshot {
+   connected:           bool,
+   connection_attempts: u64,
+   connection_failures: u64,
+   reconnects:          u64,
+   joins:               u64,
+   disconnects:         u64,
+   command_queue_full:  u64,
+   event_queue_full:    u64,
+   last_attempt_ms:     u64,
+   sse_broadcast_lag:   u64,
+}
+
+impl ChatMetrics {
+   fn new() -> Self {
+      Self {
+         connected:           Arc::new(std::sync::atomic::AtomicBool::new(false)),
+         connection_attempts: Arc::new(AtomicU64::new(0)),
+         connection_failures: Arc::new(AtomicU64::new(0)),
+         reconnects:          Arc::new(AtomicU64::new(0)),
+         joins:               Arc::new(AtomicU64::new(0)),
+         disconnects:         Arc::new(AtomicU64::new(0)),
+         command_queue_full:  Arc::new(AtomicU64::new(0)),
+         event_queue_full:    Arc::new(AtomicU64::new(0)),
+         last_attempt_ms:     Arc::new(AtomicU64::new(0)),
+         sse_broadcast_lag:   Arc::new(AtomicU64::new(0)),
+      }
+   }
+
+   pub fn snapshot(&self) -> ChatMetricsSnapshot {
+      use std::sync::atomic::Ordering;
+      ChatMetricsSnapshot {
+         connected:           self.connected.load(Ordering::Relaxed),
+         connection_attempts: self.connection_attempts.load(Ordering::Relaxed),
+         connection_failures: self.connection_failures.load(Ordering::Relaxed),
+         reconnects:          self.reconnects.load(Ordering::Relaxed),
+         joins:               self.joins.load(Ordering::Relaxed),
+         disconnects:         self.disconnects.load(Ordering::Relaxed),
+         command_queue_full:  self.command_queue_full.load(Ordering::Relaxed),
+         event_queue_full:    self.event_queue_full.load(Ordering::Relaxed),
+         last_attempt_ms:     self.last_attempt_ms.load(Ordering::Relaxed),
+         sse_broadcast_lag:   self.sse_broadcast_lag.load(Ordering::Relaxed),
+      }
+   }
+
+   fn prometheus(&self) -> String {
+      let snapshot = self.snapshot();
+      format!(
+         concat!(
+            "# HELP twitch_relay_chat_connected Whether the IRC connection completed Twitch \
+             welcome.\n",
+            "# TYPE twitch_relay_chat_connected gauge\n",
+            "twitch_relay_chat_connected {}\n",
+            "# HELP twitch_relay_chat_connection_attempts_total IRC connection attempts.\n",
+            "# TYPE twitch_relay_chat_connection_attempts_total counter\n",
+            "twitch_relay_chat_connection_attempts_total {}\n",
+            "# HELP twitch_relay_chat_connection_failures_total Failed IRC connection attempts.\n",
+            "# TYPE twitch_relay_chat_connection_failures_total counter\n",
+            "twitch_relay_chat_connection_failures_total {}\n",
+            "# HELP twitch_relay_chat_reconnects_total IRC reconnect attempts.\n",
+            "# TYPE twitch_relay_chat_reconnects_total counter\n",
+            "twitch_relay_chat_reconnects_total {}\n",
+            "# HELP twitch_relay_chat_joins_total Confirmed Twitch channel joins.\n",
+            "# TYPE twitch_relay_chat_joins_total counter\n",
+            "twitch_relay_chat_joins_total {}\n",
+            "# HELP twitch_relay_chat_disconnects_total IRC disconnects.\n",
+            "# TYPE twitch_relay_chat_disconnects_total counter\n",
+            "twitch_relay_chat_disconnects_total {}\n",
+            "# HELP twitch_relay_chat_command_queue_full_total Rejected commands due to a full \
+             queue.\n",
+            "# TYPE twitch_relay_chat_command_queue_full_total counter\n",
+            "twitch_relay_chat_command_queue_full_total {}\n",
+            "# HELP twitch_relay_chat_event_queue_full_total Saturated inbound IRC event queues.\n",
+            "# TYPE twitch_relay_chat_event_queue_full_total counter\n",
+            "twitch_relay_chat_event_queue_full_total {}\n",
+            "# HELP twitch_relay_chat_sse_broadcast_lag_total SSE events skipped by lagging \
+             clients.\n",
+            "# TYPE twitch_relay_chat_sse_broadcast_lag_total counter\n",
+            "twitch_relay_chat_sse_broadcast_lag_total {}\n",
+            "# HELP twitch_relay_chat_last_connection_attempt_milliseconds Duration of the latest \
+             connection attempt.\n",
+            "# TYPE twitch_relay_chat_last_connection_attempt_milliseconds gauge\n",
+            "twitch_relay_chat_last_connection_attempt_milliseconds {}\n"
+         ),
+         u8::from(snapshot.connected),
+         snapshot.connection_attempts,
+         snapshot.connection_failures,
+         snapshot.reconnects,
+         snapshot.joins,
+         snapshot.disconnects,
+         snapshot.command_queue_full,
+         snapshot.event_queue_full,
+         snapshot.sse_broadcast_lag,
+         snapshot.last_attempt_ms,
+      )
+   }
 }
 
 #[derive(Debug)]
@@ -144,12 +265,13 @@ pub enum ChatCommand {
 
 impl ChatService {
    pub fn new(auth: TwitchAuthService) -> Self {
-      let (command_tx, command_rx) = mpsc::unbounded_channel();
+      let (command_tx, command_rx) = mpsc::channel(128);
       let channels = Arc::new(RwLock::new(HashMap::new()));
       let emote_cache = Arc::new(RwLock::new(HashMap::new()));
       let third_party_emote_cache = Arc::new(RwLock::new(HashMap::new()));
       let owner_name_cache = Arc::new(RwLock::new(HashMap::new()));
       let owner_lookup_cooldown_until_unix = Arc::new(AtomicU64::new(0));
+      let metrics = ChatMetrics::new();
 
       tokio::spawn(run_chat_manager(
          auth.clone(),
@@ -157,6 +279,7 @@ impl ChatService {
          channels.clone(),
          emote_cache.clone(),
          third_party_emote_cache,
+         metrics.clone(),
       ));
 
       Self {
@@ -166,6 +289,7 @@ impl ChatService {
          emote_cache,
          owner_name_cache,
          owner_lookup_cooldown_until_unix,
+         metrics,
       }
    }
 
@@ -176,12 +300,15 @@ impl ChatService {
       tracing::info!(channel = %normalized, "chat subscribe requested");
       self
          .command_tx
-         .send(ChatCommand::Subscribe {
+         .try_send(ChatCommand::Subscribe {
             channel:  normalized.clone(),
             response: tx,
          })
-         .map_err(|_| ChatError::RuntimeUnavailable)?;
-      let result = rx.await.map_err(|_| ChatError::StatusTimeout)?;
+         .map_err(|error| self.command_send_error(&error))?;
+      let result = timeout(Duration::from_secs(5), rx)
+         .await
+         .map_err(|_| ChatError::StatusTimeout)?
+         .map_err(|_| ChatError::StatusTimeout)?;
       if result.is_ok() {
          tracing::info!(channel = %normalized, "chat subscribe completed");
       }
@@ -195,12 +322,15 @@ impl ChatService {
       tracing::info!(channel = %normalized, "chat unsubscribe requested");
       self
          .command_tx
-         .send(ChatCommand::Unsubscribe {
+         .try_send(ChatCommand::Unsubscribe {
             channel:  normalized.clone(),
             response: tx,
          })
-         .map_err(|_| ChatError::RuntimeUnavailable)?;
-      let result = rx.await.map_err(|_| ChatError::StatusTimeout)?;
+         .map_err(|error| self.command_send_error(&error))?;
+      let result = timeout(Duration::from_secs(5), rx)
+         .await
+         .map_err(|_| ChatError::StatusTimeout)?
+         .map_err(|_| ChatError::StatusTimeout)?;
       if result.is_ok() {
          tracing::info!(channel = %normalized, "chat unsubscribe completed");
       }
@@ -221,13 +351,16 @@ impl ChatService {
          normalize_channel_login(channel).map_err(|_| ChatError::InvalidChannelName)?;
       self
          .command_tx
-         .send(ChatCommand::SendMessage {
+         .try_send(ChatCommand::SendMessage {
             channel:  normalized.clone(),
             message:  trimmed.to_string(),
             response: tx,
          })
-         .map_err(|_| ChatError::RuntimeUnavailable)?;
-      rx.await.map_err(|_| ChatError::StatusTimeout)?
+         .map_err(|error| self.command_send_error(&error))?;
+      timeout(Duration::from_secs(5), rx)
+         .await
+         .map_err(|_| ChatError::StatusTimeout)?
+         .map_err(|_| ChatError::StatusTimeout)?
    }
 
    pub async fn status(&self, channel: &str) -> Result<ChatChannelStatus, ChatError> {
@@ -236,18 +369,21 @@ impl ChatService {
          normalize_channel_login(channel).map_err(|_| ChatError::InvalidChannelName)?;
       self
          .command_tx
-         .send(ChatCommand::Status {
+         .try_send(ChatCommand::Status {
             channel:  normalized.clone(),
             response: tx,
          })
-         .map_err(|_| ChatError::RuntimeUnavailable)?;
-      rx.await.map_err(|_| ChatError::StatusTimeout)
+         .map_err(|error| self.command_send_error(&error))?;
+      timeout(Duration::from_secs(2), rx)
+         .await
+         .map_err(|_| ChatError::StatusTimeout)?
+         .map_err(|_| ChatError::StatusTimeout)
    }
 
    pub async fn receiver_for_channel(
       &self,
       channel: &str,
-   ) -> Result<broadcast::Receiver<ChatEvent>, ChatError> {
+   ) -> Result<broadcast::Receiver<ChatStreamEvent>, ChatError> {
       let normalized =
          normalize_channel_login(channel).map_err(|_| ChatError::InvalidChannelName)?;
       let sender = {
@@ -348,6 +484,19 @@ impl ChatService {
 
       Ok(())
    }
+
+   fn command_send_error(&self, error: &mpsc::error::TrySendError<ChatCommand>) -> ChatError {
+      match error {
+         mpsc::error::TrySendError::Full(_) => {
+            self
+               .metrics
+               .command_queue_full
+               .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            ChatError::CommandQueueFull
+         },
+         mpsc::error::TrySendError::Closed(_) => ChatError::RuntimeUnavailable,
+      }
+   }
 }
 
 pub async fn subscribe(
@@ -411,6 +560,17 @@ pub async fn status(
    }
 }
 
+pub async fn metrics(State(state): State<ChatState>) -> Response {
+   (
+      [(
+         axum::http::header::CONTENT_TYPE,
+         "text/plain; version=0.0.4; charset=utf-8",
+      )],
+      state.service.metrics.prometheus(),
+   )
+      .into_response()
+}
+
 pub async fn emotes(State(state): State<ChatState>, Query(query): Query<EmotesQuery>) -> Response {
    match state.service.emotes_for_channel(&query.channel_login).await {
       Ok(items) => Json(EmotePickerResponse { emotes: items }).into_response(),
@@ -427,21 +587,47 @@ pub async fn events(State(state): State<ChatState>, Path(channel): Path<String>)
       Ok(receiver) => receiver,
       Err(e) => return error_response(StatusCode::BAD_REQUEST, &e.to_string(), None),
    };
+   let initial_status = match state.service.status(&channel).await {
+      Ok(status) => status,
+      Err(error) => return error_response(StatusCode::BAD_REQUEST, &error.to_string(), None),
+   };
 
    let log_guard = ChatSseConnectionLog::new(channel);
-   let stream = BroadcastStream::new(receiver).filter_map(move |result| {
+   let metrics = state.service.metrics.clone();
+   let updates = BroadcastStream::new(receiver).filter_map(move |result| {
       let channel = log_guard.channel();
+      let metrics = metrics.clone();
       async move {
          match result {
-            Ok(event) => {
-               tracing::trace!(channel = %channel, "chat EventSource event sent");
+            Ok(ChatStreamEvent::Chat(event)) => {
+               tracing::trace!(channel = %channel, "chat EventSource chat event sent");
                let sse_event = Event::default().event("chat").json_data(event).ok()?;
                Some(Ok::<Event, Infallible>(sse_event))
             },
-            Err(_) => None,
+            Ok(ChatStreamEvent::Status(status)) => {
+               tracing::debug!(channel = %channel, connected = status.connected, joined = status.joined, "chat EventSource status event sent");
+               let sse_event = Event::default().event("status").json_data(status).ok()?;
+               Some(Ok::<Event, Infallible>(sse_event))
+            },
+            Err(tokio_stream::wrappers::errors::BroadcastStreamRecvError::Lagged(skipped)) => {
+               metrics
+                  .sse_broadcast_lag
+                  .fetch_add(skipped, std::sync::atomic::Ordering::Relaxed);
+               tracing::warn!(channel = %channel, skipped, "chat EventSource receiver lagged");
+               None
+            },
          }
       }
    });
+   let initial = stream::once(async move {
+      Event::default()
+         .event("status")
+         .json_data(initial_status)
+         .map(Ok::<Event, Infallible>)
+         .ok()
+   })
+   .filter_map(|event| async move { event });
+   let stream = initial.chain(updates);
 
    Sse::new(stream)
       .keep_alive(KeepAlive::new().interval(std::time::Duration::from_secs(12)))
@@ -466,5 +652,25 @@ impl ChatSseConnectionLog {
 impl Drop for ChatSseConnectionLog {
    fn drop(&mut self) {
       tracing::info!(channel = %self.channel, "chat EventSource closed");
+   }
+}
+
+#[cfg(test)]
+mod tests {
+   use super::*;
+
+   #[test]
+   fn prometheus_output_has_stable_names_and_types() {
+      let metrics = ChatMetrics::new();
+      metrics
+         .connection_attempts
+         .store(3, std::sync::atomic::Ordering::Relaxed);
+      let output = metrics.prometheus();
+
+      assert!(output.contains("# TYPE twitch_relay_chat_connected gauge\n"));
+      assert!(output.contains("twitch_relay_chat_connected 0\n"));
+      assert!(output.contains("# TYPE twitch_relay_chat_connection_attempts_total counter\n"));
+      assert!(output.contains("twitch_relay_chat_connection_attempts_total 3\n"));
+      assert!(output.contains("# TYPE twitch_relay_chat_sse_broadcast_lag_total counter\n"));
    }
 }

--- a/src/routes/chat.rs
+++ b/src/routes/chat.rs
@@ -18,7 +18,10 @@ use crate::{
 
 /// Build chat routes.
 pub fn chat_routes(state: ChatState, auth_config: WebAuthConfig) -> Router {
-   Router::new()
+   let metrics = Router::new()
+      .route("/api/chat/metrics", get(crate::chat::metrics))
+      .with_state(state.clone());
+   let protected = Router::new()
       .route("/api/chat/status", get(crate::chat::status))
       .route("/api/chat/emotes", get(crate::chat::emotes))
       .route("/api/chat/subscribe", post(crate::chat::subscribe))
@@ -32,5 +35,7 @@ pub fn chat_routes(state: ChatState, auth_config: WebAuthConfig) -> Router {
       .layer(middleware::from_fn_with_state(
          auth_config,
          auth::require_session_middleware,
-      ))
+      ));
+
+   metrics.merge(protected)
 }

--- a/web/package.json
+++ b/web/package.json
@@ -1,8 +1,8 @@
 {
   "name": "web",
   "version": "0.6.9",
-  "license": "AGPL-3.0-or-later",
   "private": true,
+  "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {
     "dev": "vp dev",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "version": "0.6.9",
-  "license": "UNLICENSED",
+  "license": "AGPL-3.0-or-later",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,7 @@
 {
   "name": "web",
   "version": "0.6.9",
+  "license": "UNLICENSED",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/src/components/watch/chat-composer.tsx
+++ b/web/src/components/watch/chat-composer.tsx
@@ -21,7 +21,7 @@ export interface ChatComposerHandle {
 interface ChatComposerProps {
   availableEmotes: EmoteItem[];
   disabled?: boolean;
-  onSubmit: (text: string) => void;
+  onSubmit: (text: string) => Promise<void>;
 }
 
 export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(

--- a/web/src/components/watch/chat.tsx
+++ b/web/src/components/watch/chat.tsx
@@ -218,6 +218,7 @@ const ChatHeader = ({
   chatConnected,
   chatOnly,
   chatStatus,
+  onRetry,
   onToggleChatOnly,
   onToggleCollapse,
   showTimestamps,
@@ -226,6 +227,7 @@ const ChatHeader = ({
   chatConnected: boolean;
   chatOnly: boolean;
   chatStatus: string;
+  onRetry: () => void;
   onToggleChatOnly: () => void;
   onToggleCollapse: () => void;
   showTimestamps: boolean;
@@ -236,6 +238,11 @@ const ChatHeader = ({
       <strong>Chat</strong>
       <span className={chatConnected ? 'status-live' : undefined}>{chatStatus}</span>
     </div>
+    {!chatConnected && (
+      <button type="button" className="chat-retry-btn" onClick={onRetry}>
+        Retry
+      </button>
+    )}
     <div className="chat-header-actions">
       <button
         type="button"
@@ -302,6 +309,7 @@ export const Chat = ({
     handleScroll,
     jumpToLatest,
     sendMessage,
+    retryConnection,
   } = useChat({
     channelLogin,
     chatAvailable,
@@ -358,6 +366,7 @@ export const Chat = ({
         chatConnected={chatConnected}
         chatOnly={chatOnly}
         chatStatus={chatStatus}
+        onRetry={retryConnection}
         onToggleChatOnly={onToggleChatOnly}
         onToggleCollapse={onToggleCollapse}
         showTimestamps={showTimestamps}
@@ -397,10 +406,8 @@ export const Chat = ({
             <ChatComposer
               ref={composerRef}
               availableEmotes={localEmotes}
-              disabled={chatSending}
-              onSubmit={(text) => {
-                void sendMessage(text);
-              }}
+              disabled={chatSending || !chatConnected}
+              onSubmit={sendMessage}
             />
           </div>
         </>

--- a/web/src/hooks/watch/chat-composer-keyboard.ts
+++ b/web/src/hooks/watch/chat-composer-keyboard.ts
@@ -173,7 +173,7 @@ export interface KeyboardHandlerActions {
   setSuggestionIndex: (index: number | ((prev: number) => number)) => void;
   setSuggestionsOpen: (open: boolean) => void;
   setSuggestionItems: (items: EmoteItem[]) => void;
-  onSubmit: (text: string) => void;
+  onSubmit: (text: string) => Promise<void>;
 }
 
 export interface CreateKeyboardHandlersReturn {
@@ -208,9 +208,7 @@ export const createKeyboardHandlers = (
     if (trimmed === '' || disabled) {
       return;
     }
-    actions.onSubmit(trimmed);
-    actions.setComposerText('', []);
-    actions.closeSuggestions();
+    void actions.onSubmit(trimmed);
   };
 
   const selectCurrent = (): void => {

--- a/web/src/hooks/watch/chat-request.ts
+++ b/web/src/hooks/watch/chat-request.ts
@@ -1,0 +1,44 @@
+const CHAT_REQUEST_TIMEOUT_MS = 10_000;
+
+const responseError = async (response: Response, fallback: string): Promise<Error> => {
+  const responseText = await response.text();
+  const detail = responseText.trim();
+  return new Error(detail === '' ? `${fallback} (${response.status})` : detail);
+};
+
+export const fetchChat = async (
+  input: RequestInfo | URL,
+  init: RequestInit,
+  fallback: string,
+): Promise<Response> => {
+  const controller = new AbortController();
+  const timeout = globalThis.setTimeout(() => {
+    controller.abort();
+  }, CHAT_REQUEST_TIMEOUT_MS);
+  const abortRequest = (): void => {
+    controller.abort();
+  };
+  init.signal?.addEventListener('abort', abortRequest, { once: true });
+
+  try {
+    const response = await fetch(input, { ...init, signal: controller.signal });
+    if (!response.ok) {
+      throw await responseError(response, fallback);
+    }
+    return response;
+  } catch (error: unknown) {
+    if (controller.signal.aborted && init.signal?.aborted !== true) {
+      throw new Error(`${fallback}: request timed out`, { cause: error });
+    }
+    if (error instanceof TypeError) {
+      throw new TypeError(`${fallback}: network unavailable`, { cause: error });
+    }
+    throw error;
+  } finally {
+    globalThis.clearTimeout(timeout);
+    init.signal?.removeEventListener('abort', abortRequest);
+  }
+};
+
+export const chatErrorMessage = (error: unknown, fallback: string): string =>
+  error instanceof Error && error.message.trim() !== '' ? error.message : fallback;

--- a/web/src/hooks/watch/use-chat-composer.test.tsx
+++ b/web/src/hooks/watch/use-chat-composer.test.tsx
@@ -1,0 +1,53 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useChatComposer, type UseChatComposerReturn } from './use-chat-composer';
+
+describe('useChatComposer', () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    root?.unmount();
+    container?.remove();
+  });
+
+  it('retains composer content when sending fails', async () => {
+    const onSubmit = vi
+      .fn<(text: string) => Promise<void>>()
+      .mockRejectedValue(new Error('offline'));
+    const composerRef: { current: UseChatComposerReturn | undefined } = { current: undefined };
+
+    const TestComponent = (): null => {
+      composerRef.current = useChatComposer({ availableEmotes: [], onSubmit });
+      return null;
+    };
+
+    act(() => {
+      root?.render(<TestComponent />);
+    });
+    const initialComposer = composerRef.current;
+    if (initialComposer === undefined) {
+      throw new Error('Composer did not render');
+    }
+    act(() => {
+      initialComposer.setComposerText('please retry');
+    });
+    const composer = composerRef.current;
+    if (composer === undefined) {
+      throw new Error('Composer did not update');
+    }
+    await act(async () => {
+      await composer.submit();
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith('please retry');
+    expect(composerRef.current?.text).toBe('please retry');
+  });
+});

--- a/web/src/hooks/watch/use-chat-composer.ts
+++ b/web/src/hooks/watch/use-chat-composer.ts
@@ -42,7 +42,7 @@ export interface UseChatComposerReturn {
   handleKeydown: (event: React.KeyboardEvent) => void;
   handleSuggestionClick: (item: EmoteItem) => void;
   insertEmote: (code: string) => void;
-  submit: () => void;
+  submit: () => Promise<void>;
   closeSuggestions: () => void;
   clearPreview: () => void;
   createEmoteImageElement: (code: string, imageUrl: string) => HTMLSpanElement;
@@ -54,7 +54,7 @@ export interface UseChatComposerReturn {
 export interface UseChatComposerOptions {
   availableEmotes: EmoteItem[];
   disabled?: boolean;
-  onSubmit: (text: string) => void;
+  onSubmit: (text: string) => Promise<void>;
 }
 
 interface ComposerUiState {
@@ -170,7 +170,7 @@ export const useChatComposer = (options: UseChatComposerOptions): UseChatCompose
     });
   }, [text, availableEmotes, getCursorPosition, closeSuggestions, ui]);
 
-  const submit = useCallback((): void => {
+  const submit = useCallback(async (): Promise<void> => {
     const trimmed = text.trim();
     if (trimmed === '' || disabled) {
       return;
@@ -179,9 +179,13 @@ export const useChatComposer = (options: UseChatComposerOptions): UseChatCompose
     const newlineChar = '\n';
     const spaceChar = ' ';
     const flattened = trimmed.replaceAll(newlineChar, spaceChar);
-    onSubmit(flattened);
-    setComposerText('', []);
-    closeSuggestions();
+    try {
+      await onSubmit(flattened);
+      setComposerText('', []);
+      closeSuggestions();
+    } catch {
+      // The caller displays the retryable error while the composer retains its content.
+    }
   }, [text, disabled, onSubmit, setComposerText, closeSuggestions]);
 
   const keyboardHandlers = createKeyboardHandlers(
@@ -197,7 +201,7 @@ export const useChatComposer = (options: UseChatComposerOptions): UseChatCompose
     },
     {
       closeSuggestions,
-      onSubmit,
+      onSubmit: submit,
       setComposerText,
       setSuggestionIndex: ui.setSuggestionIndex,
       setSuggestionItems: ui.setSuggestionItems,

--- a/web/src/hooks/watch/use-chat-connection.ts
+++ b/web/src/hooks/watch/use-chat-connection.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 import { isObject } from '../../api-client/core';
+import { chatErrorMessage, fetchChat } from './chat-request';
 import { parseChatEvent, type ChatMessage } from './chat-utils';
 
 const UNREAD_COUNT_ZERO = 0;
@@ -47,29 +48,29 @@ const readChatStatus = async (
   signal: AbortSignal,
 ): Promise<ChatChannelStatus | null> => {
   const statusUrl = `/api/chat/status?channel_login=${encodeURIComponent(channelLogin)}`;
-  const response = await fetch(statusUrl, {
-    credentials: 'same-origin',
-    signal,
-  });
-  if (!response.ok) {
-    return null;
-  }
+  const response = await fetchChat(
+    statusUrl,
+    {
+      credentials: 'same-origin',
+      signal,
+    },
+    'Unable to check chat status',
+  );
   return parseChatStatusResponse(await response.json());
 };
 
-const subscribeChat = async (channelLogin: string, signal: AbortSignal): Promise<void> => {
+const subscribeChat = async (channelLogin: string): Promise<void> => {
   logChatLifecycle('Subscribing to chat channel', { channelLogin });
-  const response = await fetch('/api/chat/subscribe', {
-    body: JSON.stringify({ channel_login: channelLogin }),
-    credentials: 'same-origin',
-    headers: { 'content-type': 'application/json' },
-    method: 'POST',
-    signal,
-  });
-  if (!response.ok) {
-    const error = await response.text();
-    throw new Error(error || 'Failed to subscribe to chat');
-  }
+  await fetchChat(
+    '/api/chat/subscribe',
+    {
+      body: JSON.stringify({ channel_login: channelLogin }),
+      credentials: 'same-origin',
+      headers: { 'content-type': 'application/json' },
+      method: 'POST',
+    },
+    'Unable to subscribe to chat',
+  );
   logChatLifecycle('Chat subscribe accepted', { channelLogin });
 };
 
@@ -82,6 +83,49 @@ interface OpenChatEventsOptions {
   setChatConnected: (connected: boolean) => void;
   setChatStatus: (status: string) => void;
 }
+
+interface ChatSubscriptionRefs {
+  pending: React.RefObject<Map<string, Promise<void>>>;
+  subscribed: React.RefObject<Set<string>>;
+  unsubscribeRequested: React.RefObject<Set<string>>;
+  unsubscribeTimers: React.RefObject<Map<string, ReturnType<typeof setTimeout>>>;
+}
+
+const applyChatChannelStatus = (
+  status: ChatChannelStatus,
+  channelLogin: string,
+  setChatConnected: (connected: boolean) => void,
+  setChatStatus: (status: string) => void,
+): void => {
+  if (status.error !== undefined && status.error !== '') {
+    setChatConnected(false);
+    setChatStatus(`Chat unavailable: ${status.error}`);
+  } else if (status.joined === true) {
+    setChatConnected(true);
+    setChatStatus(`Connected to #${channelLogin}`);
+  } else {
+    setChatConnected(false);
+    if (status.connected === true && status.subscribed === true) {
+      setChatStatus(`IRC connected; joining #${channelLogin}...`);
+    } else if (status.subscribed === true) {
+      setChatStatus(`Connecting to #${channelLogin}...`);
+    } else {
+      setChatStatus(`Chat reconnecting for #${channelLogin}...`);
+    }
+  }
+};
+
+const parseChatStatusEvent = (data: unknown): ChatChannelStatus | null => {
+  if (typeof data !== 'string') {
+    return null;
+  }
+  try {
+    const payload: unknown = JSON.parse(data);
+    return isChatChannelStatus(payload) ? payload : parseChatStatusResponse(payload);
+  } catch {
+    return null;
+  }
+};
 
 const openChatEventsForConnection = (options: OpenChatEventsOptions): void => {
   const {
@@ -114,8 +158,7 @@ const openChatEventsForConnection = (options: OpenChatEventsOptions): void => {
       return;
     }
     logChatLifecycle('Chat EventSource opened', { channelLogin, generation });
-    setChatConnected(true);
-    setChatStatus(`SSE connected to #${channelLogin}; waiting for IRC messages`);
+    setChatStatus(`Chat transport connected; waiting for IRC #${channelLogin}...`);
   });
 
   eventSource.addEventListener('error', () => {
@@ -127,6 +170,18 @@ const openChatEventsForConnection = (options: OpenChatEventsOptions): void => {
     setChatStatus('Chat SSE reconnecting...');
   });
 
+  const handleStatusEvent = (event: Event): void => {
+    if (!isCurrentEventSource() || !(event instanceof MessageEvent)) {
+      return;
+    }
+    const status = parseChatStatusEvent(event.data);
+    if (status) {
+      applyChatChannelStatus(status, channelLogin, setChatConnected, setChatStatus);
+    }
+  };
+
+  eventSource.addEventListener('status', handleStatusEvent);
+  eventSource.addEventListener('connection', handleStatusEvent);
   eventSource.addEventListener('chat', (event: Event) => {
     if (!isCurrentEventSource() || !(event instanceof MessageEvent)) {
       return;
@@ -136,33 +191,100 @@ const openChatEventsForConnection = (options: OpenChatEventsOptions): void => {
     const message = parseChatEvent(messageText);
     if (message) {
       appendMessage(message);
+      // A chat payload proves IRC has joined even on older backends.
       setChatConnected(true);
       setChatStatus(`Connected to #${channelLogin}`);
     }
   });
 };
 
+const unsubscribeChat = (channelLogin: string, subscriptions: ChatSubscriptionRefs): void => {
+  logChatLifecycle('Unsubscribing from chat channel after grace period', { channelLogin });
+  void fetchChat(
+    `/api/chat/subscribe/${encodeURIComponent(channelLogin)}`,
+    {
+      body: JSON.stringify({}),
+      credentials: 'same-origin',
+      keepalive: true,
+      method: 'DELETE',
+    },
+    'Unable to unsubscribe from chat',
+  )
+    .catch((error: unknown) => {
+      logChatLifecycle('Chat unsubscribe failed', { channelLogin, error });
+    })
+    .finally(() => {
+      subscriptions.subscribed.current.delete(channelLogin);
+      subscriptions.unsubscribeRequested.current.delete(channelLogin);
+    });
+};
+
 const scheduleChatUnsubscribe = (
   channelLogin: string,
-  unsubscribeTimersRef: React.RefObject<Map<string, ReturnType<typeof setTimeout>>>,
+  subscriptions: ChatSubscriptionRefs,
 ): void => {
-  const existingTimer = unsubscribeTimersRef.current.get(channelLogin);
+  const existingTimer = subscriptions.unsubscribeTimers.current.get(channelLogin);
   if (existingTimer) {
     clearTimeout(existingTimer);
   }
 
   const timer = setTimeout(() => {
-    unsubscribeTimersRef.current.delete(channelLogin);
-    logChatLifecycle('Unsubscribing from chat channel after grace period', { channelLogin });
-    void fetch(`/api/chat/subscribe/${encodeURIComponent(channelLogin)}`, {
-      body: JSON.stringify({}),
-      credentials: 'same-origin',
-      keepalive: true,
-      method: 'DELETE',
-    });
+    subscriptions.unsubscribeTimers.current.delete(channelLogin);
+    const pendingSubscription = subscriptions.pending.current.get(channelLogin);
+    if (pendingSubscription) {
+      const finishUnsubscribe = (): void => {
+        if (subscriptions.unsubscribeRequested.current.has(channelLogin)) {
+          unsubscribeChat(channelLogin, subscriptions);
+        }
+      };
+      void pendingSubscription.then(finishUnsubscribe, finishUnsubscribe);
+      return;
+    }
+    if (!subscriptions.unsubscribeRequested.current.has(channelLogin)) {
+      return;
+    }
+    unsubscribeChat(channelLogin, subscriptions);
   }, UNSUBSCRIBE_GRACE_MS);
 
-  unsubscribeTimersRef.current.set(channelLogin, timer);
+  subscriptions.unsubscribeTimers.current.set(channelLogin, timer);
+};
+
+const cancelChatUnsubscribe = (channelLogin: string, subscriptions: ChatSubscriptionRefs): void => {
+  const pendingTimer = subscriptions.unsubscribeTimers.current.get(channelLogin);
+  if (pendingTimer) {
+    clearTimeout(pendingTimer);
+    subscriptions.unsubscribeTimers.current.delete(channelLogin);
+    logChatLifecycle('Canceled pending chat unsubscribe', { channelLogin });
+  }
+  subscriptions.unsubscribeRequested.current.delete(channelLogin);
+};
+
+const ensureChatSubscription = async (
+  channelLogin: string,
+  subscriptions: ChatSubscriptionRefs,
+): Promise<void> => {
+  const pendingSubscription = subscriptions.pending.current.get(channelLogin);
+  if (pendingSubscription) {
+    await pendingSubscription;
+    return;
+  }
+  if (subscriptions.subscribed.current.has(channelLogin)) {
+    return;
+  }
+
+  subscriptions.subscribed.current.add(channelLogin);
+  const subscription = subscribeChat(channelLogin);
+  subscriptions.pending.current.set(channelLogin, subscription);
+  void subscription
+    .catch(() => {
+      if (!subscriptions.unsubscribeRequested.current.has(channelLogin)) {
+        subscriptions.subscribed.current.delete(channelLogin);
+      }
+    })
+    .finally(() => {
+      subscriptions.pending.current.delete(channelLogin);
+    });
+  await subscription;
 };
 
 export interface UseChatConnectionReturn {
@@ -178,6 +300,7 @@ export interface UseChatConnectionReturn {
   appendMessage: (message: ChatMessage) => void;
   setupConnection: (channelLogin: string, chatAvailable: boolean) => Promise<void>;
   cleanupConnection: (channelLogin: string) => void;
+  resetChannelState: () => void;
   setChatStatus: (status: string) => void;
   setChatConnected: (connected: boolean) => void;
 }
@@ -187,7 +310,16 @@ export const useChatConnection = (): UseChatConnectionReturn => {
   const chatEventsRef = useRef<EventSource | null>(null);
   const connectionGenerationRef = useRef(INITIAL_CONNECTION_GENERATION);
   const subscribeAbortRef = useRef<AbortController | null>(null);
+  const pendingSubscriptionsRef = useRef<Map<string, Promise<void>>>(new Map());
+  const subscribedChannelsRef = useRef<Set<string>>(new Set());
+  const unsubscribeRequestedChannelsRef = useRef<Set<string>>(new Set());
   const unsubscribeTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const subscriptions: ChatSubscriptionRefs = {
+    pending: pendingSubscriptionsRef,
+    subscribed: subscribedChannelsRef,
+    unsubscribeRequested: unsubscribeRequestedChannelsRef,
+    unsubscribeTimers: unsubscribeTimersRef,
+  };
 
   const [chatConnected, setChatConnected] = useState(false);
   const [chatStatus, setChatStatus] = useState('Checking Twitch chat...');
@@ -244,12 +376,7 @@ export const useChatConnection = (): UseChatConnectionReturn => {
       if (!chatAvailable) {
         return;
       }
-      const pendingTimer = unsubscribeTimersRef.current.get(channelLogin);
-      if (pendingTimer) {
-        clearTimeout(pendingTimer);
-        unsubscribeTimersRef.current.delete(channelLogin);
-        logChatLifecycle('Canceled pending chat unsubscribe', { channelLogin });
-      }
+      cancelChatUnsubscribe(channelLogin, subscriptions);
 
       const generation = connectionGenerationRef.current + NEXT_CONNECTION_GENERATION_INCREMENT;
       connectionGenerationRef.current = generation;
@@ -261,7 +388,7 @@ export const useChatConnection = (): UseChatConnectionReturn => {
       setChatConnected(false);
 
       try {
-        await subscribeChat(channelLogin, abortController.signal);
+        await ensureChatSubscription(channelLogin, subscriptions);
         if (connectionGenerationRef.current !== generation) {
           return;
         }
@@ -269,14 +396,10 @@ export const useChatConnection = (): UseChatConnectionReturn => {
         if (connectionGenerationRef.current !== generation) {
           return;
         }
-        if (status?.joined === true) {
-          setChatStatus(`IRC joined #${channelLogin}; opening chat SSE...`);
-        } else if (status?.connected === true && status.subscribed === true) {
-          setChatStatus(`IRC connected; joining #${channelLogin}...`);
-        } else if (typeof status?.error === 'string' && status.error.length > UNREAD_COUNT_ZERO) {
-          setChatStatus(`Chat unavailable: ${status.error}`);
+        if (status) {
+          applyChatChannelStatus(status, channelLogin, setChatConnected, setChatStatus);
         } else {
-          setChatStatus(`Opening chat SSE for #${channelLogin}...`);
+          setChatStatus(`Opening chat transport for #${channelLogin}...`);
         }
         openChatEventsForConnection({
           appendMessage,
@@ -293,7 +416,9 @@ export const useChatConnection = (): UseChatConnectionReturn => {
         }
         logChatLifecycle('Chat subscribe failed', { channelLogin, error });
         setChatConnected(false);
-        setChatStatus('Chat unavailable');
+        setChatStatus(
+          `Chat unavailable: ${chatErrorMessage(error, 'Unable to subscribe to chat')}`,
+        );
       }
     },
     [appendMessage],
@@ -312,11 +437,19 @@ export const useChatConnection = (): UseChatConnectionReturn => {
 
     setChatConnected(false);
 
-    if (!channelLogin) {
+    if (!channelLogin || !subscriptions.subscribed.current.has(channelLogin)) {
       return;
     }
 
-    scheduleChatUnsubscribe(channelLogin, unsubscribeTimersRef);
+    subscriptions.unsubscribeRequested.current.add(channelLogin);
+    scheduleChatUnsubscribe(channelLogin, subscriptions);
+  }, []);
+
+  const resetChannelState = useCallback((): void => {
+    setChatMessages([]);
+    setUnreadChatCount(UNREAD_COUNT_ZERO);
+    setChatConnected(false);
+    setChatStatus('Checking Twitch chat...');
   }, []);
 
   return {
@@ -330,6 +463,7 @@ export const useChatConnection = (): UseChatConnectionReturn => {
     clearUnreadCount,
     handleScroll,
     jumpToLatest,
+    resetChannelState,
     setChatConnected,
     setChatStatus,
     setupConnection,

--- a/web/src/hooks/watch/use-chat-recovery.test.tsx
+++ b/web/src/hooks/watch/use-chat-recovery.test.tsx
@@ -1,0 +1,167 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useChat, type ChatStatus } from './use-chat';
+
+const HTTP_NO_CONTENT = 204;
+const HTTP_OK = 200;
+const ZERO = 0;
+const ONE = 1;
+
+vi.mock('../../api-client', () => ({ getChatEmotes: vi.fn().mockResolvedValue([]) }));
+
+class FakeEventSource extends EventTarget {
+  public static instances: FakeEventSource[] = [];
+
+  public constructor() {
+    super();
+    FakeEventSource.instances.push(this);
+  }
+
+  public close(): void {
+    this.dispatchEvent(new Event('close'));
+  }
+}
+
+const fetchUrl = (input: string | URL | Request): string => {
+  if (typeof input === 'string') {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.href;
+  }
+  return input.url;
+};
+
+const flush = async (): Promise<void> => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+describe('useChat recovery', () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+    FakeEventSource.instances = [];
+    vi.stubGlobal('EventSource', FakeEventSource);
+  });
+
+  afterEach(() => {
+    root?.unmount();
+    container?.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('reports a failed subscription without opening an EventSource', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('subscription refused', { status: 400 }),
+    );
+    const onStatusChange = vi.fn<(status: ChatStatus) => void>();
+    const TestComponent = (): null => {
+      useChat({ channelLogin: 'dj_trico', chatAvailable: true, onStatusChange });
+      return null;
+    };
+
+    act(() => {
+      root?.render(<TestComponent />);
+    });
+    await flush();
+
+    expect(FakeEventSource.instances).toHaveLength(ZERO);
+    expect(onStatusChange).toHaveBeenLastCalledWith({
+      available: true,
+      connected: false,
+      message: 'Chat unavailable: subscription refused',
+    });
+  });
+
+  it('keeps chat disconnected when only the SSE transport opens', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      await Promise.resolve();
+      const url = fetchUrl(input);
+      if (url === '/api/chat/subscribe' && init?.method === 'POST') {
+        return new Response(null, { status: HTTP_NO_CONTENT });
+      }
+      if (url.startsWith('/api/chat/status')) {
+        return Response.json({ status: { connected: true, joined: false, subscribed: true } });
+      }
+      return new Response(null, { status: HTTP_OK });
+    });
+    const onStatusChange = vi.fn<(status: ChatStatus) => void>();
+    const TestComponent = (): null => {
+      useChat({ channelLogin: 'dj_trico', chatAvailable: true, onStatusChange });
+      return null;
+    };
+
+    act(() => {
+      root?.render(<TestComponent />);
+    });
+    await flush();
+    act(() => {
+      FakeEventSource.instances[ZERO]?.dispatchEvent(new Event('open'));
+    });
+    await flush();
+
+    expect(onStatusChange).toHaveBeenLastCalledWith({
+      available: true,
+      connected: false,
+      message: 'Chat transport connected; waiting for IRC #dj_trico...',
+    });
+  });
+
+  it('resets messages when the channel changes', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      await Promise.resolve();
+      if (fetchUrl(input) === '/api/chat/subscribe' && init?.method === 'POST') {
+        return new Response(null, { status: HTTP_NO_CONTENT });
+      }
+      return Response.json({ status: { connected: true, joined: true, subscribed: true } });
+    });
+    const onStatusChange = vi.fn<(status: ChatStatus) => void>();
+    let chatMessages: readonly { text: string }[] = [];
+    const TestComponent = ({ channelLogin }: { channelLogin: string }): null => {
+      const { chatMessages: messages } = useChat({
+        channelLogin,
+        chatAvailable: true,
+        onStatusChange,
+      });
+      chatMessages = messages;
+      return null;
+    };
+
+    act(() => {
+      root?.render(<TestComponent channelLogin="dj_trico" />);
+    });
+    await flush();
+    act(() => {
+      FakeEventSource.instances[ZERO]?.dispatchEvent(
+        new MessageEvent('chat', {
+          data: JSON.stringify({
+            kind: 'message',
+            parts: [{ kind: 'text', text: 'hello' }],
+            sender_display_name: 'seraakai',
+            sender_login: 'seraakai',
+            text: 'hello',
+          }),
+        }),
+      );
+    });
+    await flush();
+    expect(chatMessages).toHaveLength(ONE);
+
+    act(() => {
+      root?.render(<TestComponent channelLogin="another_channel" />);
+    });
+    await flush();
+
+    expect(chatMessages).toHaveLength(ZERO);
+  });
+});

--- a/web/src/hooks/watch/use-chat-subscribe-race.test.tsx
+++ b/web/src/hooks/watch/use-chat-subscribe-race.test.tsx
@@ -1,0 +1,137 @@
+import { act, useEffect } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useChatConnection } from './use-chat-connection';
+
+const CHANNEL_A = 'channel_a';
+const CHANNEL_B = 'channel_b';
+const HTTP_NO_CONTENT = 204;
+const ZERO_REQUESTS = 0;
+const ONE_REQUEST = 1;
+const UNSUBSCRIBE_GRACE_MS = 3000;
+
+class FakeEventSource extends EventTarget {
+  public constructor() {
+    super();
+  }
+
+  public close(): void {
+    this.dispatchEvent(new Event('close'));
+  }
+}
+
+const fetchUrl = (input: string | URL | Request): string => {
+  if (typeof input === 'string') {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.href;
+  }
+  return input.url;
+};
+
+const flushAsyncWork = async (): Promise<void> => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+describe('useChatConnection pending subscription cleanup', () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+    vi.useFakeTimers();
+    vi.stubGlobal('EventSource', FakeEventSource);
+  });
+
+  afterEach(() => {
+    root?.unmount();
+    container?.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('waits for a delayed subscribe before deleting it after an A to B to A revisit', async () => {
+    const subscribeAResponse = Promise.withResolvers<Response>();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      await Promise.resolve();
+      const url = fetchUrl(input);
+      if (url === '/api/chat/subscribe' && init?.method === 'POST') {
+        if (init.body === JSON.stringify({ channel_login: CHANNEL_A })) {
+          const response = await subscribeAResponse.promise;
+          return response;
+        }
+        return new Response(null, { status: HTTP_NO_CONTENT });
+      }
+      if (init?.method === 'DELETE') {
+        return new Response(null, { status: HTTP_NO_CONTENT });
+      }
+      return Response.json({ status: { joined: true } });
+    });
+
+    const TestComponent = ({ channelLogin }: { channelLogin: string }): null => {
+      const { cleanupConnection, setupConnection } = useChatConnection();
+      useEffect(() => {
+        void setupConnection(channelLogin, true);
+        return (): void => {
+          cleanupConnection(channelLogin);
+        };
+      }, [channelLogin, cleanupConnection, setupConnection]);
+      return null;
+    };
+
+    act(() => {
+      root?.render(<TestComponent channelLogin={CHANNEL_A} />);
+    });
+    await flushAsyncWork();
+    act(() => {
+      root?.render(<TestComponent channelLogin={CHANNEL_B} />);
+    });
+    await flushAsyncWork();
+    act(() => {
+      root?.render(<TestComponent channelLogin={CHANNEL_A} />);
+    });
+    await flushAsyncWork();
+    act(() => {
+      root?.unmount();
+      vi.advanceTimersByTime(UNSUBSCRIBE_GRACE_MS);
+    });
+    await flushAsyncWork();
+
+    const subscribeA = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.filter(
+        ([input, init]) =>
+          fetchUrl(input) === '/api/chat/subscribe' &&
+          init?.body === JSON.stringify({ channel_login: CHANNEL_A }),
+      );
+    const unsubscribeA = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.filter(
+        ([input, init]) =>
+          fetchUrl(input) === `/api/chat/subscribe/${CHANNEL_A}` && init?.method === 'DELETE',
+      );
+    expect(subscribeA).toHaveLength(ONE_REQUEST);
+    expect(unsubscribeA).toHaveLength(ZERO_REQUESTS);
+
+    act(() => {
+      subscribeAResponse.resolve(new Response(null, { status: HTTP_NO_CONTENT }));
+    });
+    await flushAsyncWork();
+
+    const finalUnsubscribeA = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.filter(
+        ([input, init]) =>
+          fetchUrl(input) === `/api/chat/subscribe/${CHANNEL_A}` && init?.method === 'DELETE',
+      );
+    expect(finalUnsubscribeA).toHaveLength(ONE_REQUEST);
+  });
+});

--- a/web/src/hooks/watch/use-chat-subscription.test.tsx
+++ b/web/src/hooks/watch/use-chat-subscription.test.tsx
@@ -1,0 +1,132 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useChat, type ChatStatus } from './use-chat';
+
+const CHANNEL_A = 'channel_a';
+const CHANNEL_B = 'channel_b';
+const HTTP_NO_CONTENT = 204;
+const ONE_REQUEST = 1;
+const TWO_REQUESTS = 2;
+const UNSUBSCRIBE_GRACE_MS = 3000;
+
+vi.mock('../../api-client', () => ({ getChatEmotes: vi.fn().mockResolvedValue([]) }));
+
+class FakeEventSource extends EventTarget {
+  public constructor() {
+    super();
+  }
+
+  public close(): void {
+    this.dispatchEvent(new Event('close'));
+  }
+}
+
+const fetchUrl = (input: string | URL | Request): string => {
+  if (typeof input === 'string') {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.href;
+  }
+  return input.url;
+};
+
+const flushAsyncWork = async (): Promise<void> => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+describe('useChat subscription ownership', () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+    vi.useFakeTimers();
+    vi.stubGlobal('EventSource', FakeEventSource);
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      await Promise.resolve();
+      if (fetchUrl(input) === '/api/chat/subscribe' && init?.method === 'POST') {
+        return new Response(null, { status: HTTP_NO_CONTENT });
+      }
+      if (init?.method === 'DELETE') {
+        return new Response(null, { status: HTTP_NO_CONTENT });
+      }
+      return Response.json({ status: { connected: true, joined: true, subscribed: true } });
+    });
+  });
+
+  afterEach(() => {
+    root?.unmount();
+    container?.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('keeps channel ownership across an A to B to A revisit', async () => {
+    const onStatusChange = vi.fn<(status: ChatStatus) => void>();
+    const TestComponent = ({ channelLogin }: { channelLogin: string }): null => {
+      useChat({ channelLogin, chatAvailable: true, onStatusChange });
+      return null;
+    };
+
+    act(() => {
+      root?.render(<TestComponent channelLogin={CHANNEL_A} />);
+    });
+    await flushAsyncWork();
+    act(() => {
+      root?.render(<TestComponent channelLogin={CHANNEL_B} />);
+    });
+    await flushAsyncWork();
+    act(() => {
+      root?.render(<TestComponent channelLogin={CHANNEL_A} />);
+    });
+    await flushAsyncWork();
+    act(() => {
+      root?.unmount();
+    });
+    act(() => {
+      vi.advanceTimersByTime(UNSUBSCRIBE_GRACE_MS);
+    });
+    await flushAsyncWork();
+
+    const subscribeA = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.filter(
+        ([input, init]) => fetchUrl(input) === '/api/chat/subscribe' && init?.method === 'POST',
+      )
+      .filter(([, init]) => init?.body === JSON.stringify({ channel_login: CHANNEL_A }));
+    const subscribeB = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.filter(
+        ([input, init]) => fetchUrl(input) === '/api/chat/subscribe' && init?.method === 'POST',
+      )
+      .filter(([, init]) => init?.body === JSON.stringify({ channel_login: CHANNEL_B }));
+    const unsubscribeA = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.filter(
+        ([input, init]) =>
+          fetchUrl(input) === `/api/chat/subscribe/${CHANNEL_A}` && init?.method === 'DELETE',
+      );
+    const unsubscribeB = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.filter(
+        ([input, init]) =>
+          fetchUrl(input) === `/api/chat/subscribe/${CHANNEL_B}` && init?.method === 'DELETE',
+      );
+
+    expect(subscribeA).toHaveLength(ONE_REQUEST);
+    expect(subscribeB).toHaveLength(ONE_REQUEST);
+    expect(unsubscribeA).toHaveLength(ONE_REQUEST);
+    expect(unsubscribeB).toHaveLength(ONE_REQUEST);
+    expect(subscribeA.length + subscribeB.length).toBe(TWO_REQUESTS);
+    expect(unsubscribeA.length + unsubscribeB.length).toBe(TWO_REQUESTS);
+  });
+});

--- a/web/src/hooks/watch/use-chat.test.tsx
+++ b/web/src/hooks/watch/use-chat.test.tsx
@@ -12,8 +12,11 @@ const EXPECTED_SINGLE_CALL = 1;
 const FIRST_EVENT_SOURCE_INDEX = 0;
 const EXPECTED_EVENT_URLS = ['/api/chat/events/dj_trico'];
 const CONNECTED_STATUS_MESSAGE = 'Connected to #dj_trico';
+const UNSUBSCRIBE_GRACE_MS = 3000;
 
-const getChatEmotesMock = vi.fn<() => Promise<unknown[]>>();
+const { getChatEmotesMock } = vi.hoisted(() => ({
+  getChatEmotesMock: vi.fn<() => Promise<unknown[]>>(),
+}));
 
 vi.mock('../../api-client', () => ({
   getChatEmotes: getChatEmotesMock,
@@ -80,6 +83,7 @@ describe('useChat', () => {
     vi.stubGlobal('EventSource', FakeEventSource);
     FakeEventSource.openedUrls = [];
     FakeEventSource.instances = [];
+    getChatEmotesMock.mockReset();
     getChatEmotesMock.mockResolvedValue([]);
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
       await Promise.resolve();
@@ -108,6 +112,7 @@ describe('useChat', () => {
     }
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it('updates status from waiting to connected after receiving chat', async () => {
@@ -176,5 +181,53 @@ describe('useChat', () => {
     expect(subscribeRequests).toHaveLength(EXPECTED_SINGLE_CALL);
     expect(FakeEventSource.openedUrls).toEqual(EXPECTED_EVENT_URLS);
     expect(getChatEmotesMock).toHaveBeenCalledTimes(EXPECTED_SINGLE_CALL);
+  });
+
+  it('uses one subscription when retrying before cleanup', async () => {
+    vi.useFakeTimers();
+    let retryConnection: (() => void) | null = null;
+    const onStatusChange = vi.fn<(status: ChatStatus) => void>();
+
+    const TestComponent = ({ chatAvailable }: { chatAvailable: boolean }): null => {
+      const { retryConnection: retry } = useChat({
+        channelLogin: 'dj_trico',
+        chatAvailable,
+        onStatusChange,
+      });
+      retryConnection = retry;
+      return null;
+    };
+
+    act(() => {
+      root?.render(<TestComponent chatAvailable />);
+    });
+    await flushAsyncWork();
+    act(() => {
+      retryConnection?.();
+    });
+    await flushAsyncWork();
+    act(() => {
+      root?.render(<TestComponent chatAvailable={false} />);
+    });
+    act(() => {
+      vi.advanceTimersByTime(UNSUBSCRIBE_GRACE_MS);
+    });
+    await flushAsyncWork();
+
+    const subscribeRequests = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.filter(
+        ([input, init]) =>
+          fetchInputUrl(input) === '/api/chat/subscribe' && init?.method === 'POST',
+      );
+    const unsubscribeRequests = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.filter(
+        ([input, init]) =>
+          fetchInputUrl(input) === '/api/chat/subscribe/dj_trico' && init?.method === 'DELETE',
+      );
+
+    expect(subscribeRequests).toHaveLength(EXPECTED_SINGLE_CALL);
+    expect(unsubscribeRequests).toHaveLength(EXPECTED_SINGLE_CALL);
   });
 });

--- a/web/src/hooks/watch/use-chat.ts
+++ b/web/src/hooks/watch/use-chat.ts
@@ -1,9 +1,11 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { getChatEmotes, type EmoteItem } from '../../api-client';
+import { chatErrorMessage, fetchChat } from './chat-request';
 import type { ChatMessage } from './chat-utils';
 import { useChatConnection } from './use-chat-connection';
 
 const UNREAD_COUNT_ZERO = 0;
+const EMPTY_EMOTES: EmoteItem[] = [];
 
 export interface ChatStatus {
   available: boolean;
@@ -21,6 +23,7 @@ export interface UseChatReturn {
   emotesLoaded: boolean;
   chatMessagesRef: React.RefObject<HTMLDivElement | null>;
   sendMessage: (text: string) => Promise<void>;
+  retryConnection: () => void;
   handleScroll: () => void;
   jumpToLatest: () => void;
 }
@@ -33,22 +36,22 @@ export interface UseChatOptions {
 }
 
 export const useChat = (options: UseChatOptions): UseChatReturn => {
-  const { channelLogin, chatAvailable, initialEmotes = [], onStatusChange } = options;
+  const { channelLogin, chatAvailable, initialEmotes = EMPTY_EMOTES, onStatusChange } = options;
 
   const connection = useChatConnection();
-  const { cleanupConnection, setupConnection, setChatStatus } = connection;
+  const { cleanupConnection, resetChannelState, setupConnection, setChatStatus } = connection;
 
   const [localEmotes, setLocalEmotes] = useState<EmoteItem[]>([]);
   const [emotesLoaded, setEmotesLoaded] = useState(false);
   const [chatSending, setChatSending] = useState(false);
+  const emotesLoadingRef = useRef(false);
 
-  // Initialize emotes from props
   useEffect(() => {
-    if (initialEmotes.length > UNREAD_COUNT_ZERO && !emotesLoaded) {
-      setLocalEmotes(initialEmotes);
-      setEmotesLoaded(true);
-    }
-  }, [initialEmotes, emotesLoaded]);
+    resetChannelState();
+    emotesLoadingRef.current = false;
+    setLocalEmotes(initialEmotes);
+    setEmotesLoaded(initialEmotes.length > UNREAD_COUNT_ZERO);
+  }, [channelLogin, resetChannelState]);
 
   // Notify status changes
   useEffect(() => {
@@ -60,13 +63,20 @@ export const useChat = (options: UseChatOptions): UseChatReturn => {
   }, [chatAvailable, connection.chatConnected, connection.chatStatus, onStatusChange]);
 
   const loadEmotes = useCallback(async (): Promise<void> => {
-    if (emotesLoaded || !channelLogin) {
+    if (emotesLoaded || emotesLoadingRef.current || !channelLogin) {
       return;
     }
 
-    const emotes = await getChatEmotes(channelLogin);
-    setLocalEmotes(emotes);
-    setEmotesLoaded(true);
+    emotesLoadingRef.current = true;
+    try {
+      const emotes = await getChatEmotes(channelLogin);
+      setLocalEmotes(emotes);
+      setEmotesLoaded(true);
+    } catch {
+      // Chat remains usable without picker emotes; a later channel setup can retry.
+    } finally {
+      emotesLoadingRef.current = false;
+    }
   }, [channelLogin, emotesLoaded]);
 
   const sendMessage = useCallback(
@@ -79,20 +89,19 @@ export const useChat = (options: UseChatOptions): UseChatReturn => {
       setChatSending(true);
 
       try {
-        const response = await fetch('/api/chat/send', {
-          body: JSON.stringify({ channel_login: channelLogin, message: trimmed }),
-          credentials: 'same-origin',
-          headers: { 'content-type': 'application/json' },
-          method: 'POST',
-        });
-
-        if (!response.ok) {
-          const error = await response.text();
-          throw new Error(error || 'Failed to send message');
-        }
+        await fetchChat(
+          '/api/chat/send',
+          {
+            body: JSON.stringify({ channel_login: channelLogin, message: trimmed }),
+            credentials: 'same-origin',
+            headers: { 'content-type': 'application/json' },
+            method: 'POST',
+          },
+          'Unable to send message',
+        );
         setChatStatus(`Connected to #${channelLogin}`);
       } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : 'Failed to send message';
+        const message = chatErrorMessage(error, 'Unable to send message');
         setChatStatus(message);
         throw error;
       } finally {
@@ -120,6 +129,12 @@ export const useChat = (options: UseChatOptions): UseChatReturn => {
     }
   }, [chatAvailable, loadEmotes]);
 
+  const retryConnection = useCallback((): void => {
+    if (chatAvailable) {
+      void setupConnection(channelLogin, chatAvailable);
+    }
+  }, [channelLogin, chatAvailable, setupConnection]);
+
   return {
     chatConnected: connection.chatConnected,
     chatMessages: connection.chatMessages,
@@ -130,6 +145,7 @@ export const useChat = (options: UseChatOptions): UseChatReturn => {
     handleScroll: connection.handleScroll,
     jumpToLatest: connection.jumpToLatest,
     localEmotes,
+    retryConnection,
     sendMessage,
     unreadChatCount: connection.unreadChatCount,
   };

--- a/web/src/lib/styles/app.css
+++ b/web/src/lib/styles/app.css
@@ -2311,6 +2311,27 @@ body[data-theater="true"] .watch-chat-panel {
   flex-shrink: 0;
 }
 
+.chat-retry-btn {
+  border: 1px solid var(--accent-border-soft);
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-radius: 0.4rem;
+  padding: 0.25rem 0.45rem;
+  font: inherit;
+  font-size: 0.72rem;
+  cursor: pointer;
+}
+
+.chat-retry-btn:hover {
+  border-color: var(--accent-border-hover);
+  background: var(--surface-2);
+}
+
+.chat-retry-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
 .chat-header-action-btn {
   background: transparent;
   border: 1px solid transparent;

--- a/web/src/pages/watch-page.tsx
+++ b/web/src/pages/watch-page.tsx
@@ -27,6 +27,8 @@ const ERROR_MISSING_TICKET = 'Missing watch ticket.';
 const ERROR_SESSION_FAILED = 'Failed to initialize watch session.';
 const RELAY_PARAM = '1';
 const LIVE_STATUS_POLL_MS = 30_000;
+const INITIAL_CHAT_SETUP_GENERATION = 0;
+const NEXT_CHAT_SETUP_GENERATION_INCREMENT = 1;
 
 interface ChatStatus {
   available: boolean;
@@ -242,22 +244,29 @@ const useChatSetup = (
   const [chatAvailable, setChatAvailable] = useState(false);
   const [availableEmotes, setAvailableEmotes] = useState<EmoteItem[]>([]);
   const [twitchStatusChecked, setTwitchStatusChecked] = useState(false);
+  const chatSetupGenerationRef = useRef(INITIAL_CHAT_SETUP_GENERATION);
 
-  const loadEmotes = useCallback(async (channel: string): Promise<void> => {
+  const loadEmotes = useCallback(async (channel: string): Promise<EmoteItem[]> => {
     if (channel === '') {
-      return;
+      return [];
     }
     const emotes = await getChatEmotes(channel);
-    setAvailableEmotes(emotes);
+    return emotes;
   }, []);
 
   const setupChat = useCallback(
     async (channel: string): Promise<void> => {
+      const generation = chatSetupGenerationRef.current + NEXT_CHAT_SETUP_GENERATION_INCREMENT;
+      chatSetupGenerationRef.current = generation;
       setChatAvailable(false);
+      setAvailableEmotes([]);
       setTwitchStatusChecked(false);
 
       try {
         const twitchStatus = await getTwitchStatus();
+        if (chatSetupGenerationRef.current !== generation) {
+          return;
+        }
         setTwitchStatusChecked(true);
         if (!twitchStatus.connected) {
           setChatAvailable(false);
@@ -265,8 +274,14 @@ const useChatSetup = (
         }
 
         setChatAvailable(true);
-        await loadEmotes(channel);
+        const emotes = await loadEmotes(channel);
+        if (chatSetupGenerationRef.current === generation) {
+          setAvailableEmotes(emotes);
+        }
       } catch {
+        if (chatSetupGenerationRef.current !== generation) {
+          return;
+        }
         setChatAvailable(false);
         setTwitchStatusChecked(true);
       }

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     exclude: ['node_modules', 'build'],
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.{ts,tsx}'],
   },
 });


### PR DESCRIPTION
- Refactor the IRC chat manager to use bounded channels, per-operation timeouts, and capped exponential-backoff reconnects, improving connection stability.
- Unify chat messages and channel status behind a single \`ChatStreamEvent\` envelope so the frontend can receive connection-state updates.
- Bound third-party emote fetches with a 3-second timeout and render local-echo emotes from a per-channel cache instead of fetching on every message.
- Update the watch-page chat components and hooks to integrate the new event stream, request hook, and connection-recovery flows.
- Add Vitest tests covering chat subscription races, connection recovery, and composer behavior.